### PR TITLE
fix: lock prey cards for remainder of turn after capture (#28)

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -1733,7 +1733,8 @@ public class GameScreen extends ScreenAdapter {
           handCard.removeAllListeners();
           // If battery tower denied this turn, lock only the specific cards used in the denied attack
           boolean isDeniedCard = gameState.getCurrentPlayer().getPlayerTurn().getBatteryDeniedAttackCardIds().contains(handCard.getCardId());
-          if (!isDeniedCard) {
+          boolean isPreyCard = gameState.getCurrentPlayer().getPlayerTurn().getPreyCardIds().contains(handCard.getCardId());
+          if (!isDeniedCard && !isPreyCard) {
             ownHandCardListener = new OwnHandCardListener(handCard, gameState.getCurrentPlayer(), gameState.getCardDeck(),
                 gameState.getCemeteryDeck(), gameState, socket, playerIndex);
             handCard.addListener(ownHandCardListener);
@@ -1748,12 +1749,13 @@ public class GameScreen extends ScreenAdapter {
     ArrayList<Hero> playerHeroes = currentPlayer.getHeroes();
     currentPlayer.sortHandCards();
     ArrayList<Integer> deniedCardIds = currentPlayer.getPlayerTurn().getBatteryDeniedAttackCardIds();
+    ArrayList<Integer> preyCardIds = currentPlayer.getPlayerTurn().getPreyCardIds();
 
     for (int j = 0; j < handCards.size(); j++) {
       Card handcard = handCards.get(j);
       handcard.setCovered(false);
       handcard.setActive(true);
-      if (deniedCardIds.contains(handcard.getCardId())) handcard.setColor(0.4f, 0.4f, 0.4f, 1f);
+      if (deniedCardIds.contains(handcard.getCardId()) || preyCardIds.contains(handcard.getCardId())) handcard.setColor(0.4f, 0.4f, 0.4f, 1f);
       else handcard.setColor(Color.WHITE);
       handcard.setRotation(0);
       handcard.setWidth(handcard.getDefWidth() * 2);
@@ -2243,6 +2245,14 @@ public class GameScreen extends ScreenAdapter {
             p.setSlotSabotaged(Integer.parseInt(key), sabotagedJson.getInt(key));
           }
         }
+
+        // Sync prey cards (captured this turn, locked until turn ends)
+        ArrayList<Integer> newPreyIds = new ArrayList<Integer>();
+        JSONArray preyJson = pj.optJSONArray("preyCards");
+        if (preyJson != null) {
+          for (int pr = 0; pr < preyJson.length(); pr++) newPreyIds.add(preyJson.getInt(pr));
+        }
+        p.getPlayerTurn().setPreyCardIds(newPreyIds);
       }
 
       // Sync local Saboteurs hero active count: count how many slots across all players are

--- a/core/src/com/mygdx/game/PlayerTurn.java
+++ b/core/src/com/mygdx/game/PlayerTurn.java
@@ -182,6 +182,12 @@ public class PlayerTurn {
   public ArrayList<Integer> getBatteryDeniedAttackCardIds() { return batteryDeniedAttackCardIds; }
   public void setBatteryDeniedAttackCardIds(ArrayList<Integer> ids) { this.batteryDeniedAttackCardIds = ids; }
 
+  // Card IDs of enemy cards captured this turn — locked/grayed until turn ends.
+  // Synced from server's preyCards array via stateUpdate.
+  private ArrayList<Integer> preyCardIds = new ArrayList<Integer>();
+  public ArrayList<Integer> getPreyCardIds() { return preyCardIds; }
+  public void setPreyCardIds(ArrayList<Integer> ids) { this.preyCardIds = ids; }
+
   // --- Reservists attack bonus ---
   // Incremented each time the player clicks the Reservists button in the attack or plunder overlay.
   // Reset to 0 after the attack/plunder resolves.

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -12,6 +12,7 @@ class GameState {
       defCards: {},
       topDefCards: {},
       kingCard: null,
+      preyCards: [],
     }));
     this.pickingDecks = [[], []]; // each entry: { id, covered }
     this.currentPlayerIndex = 0;
@@ -297,14 +298,15 @@ class GameState {
       if (defender.sabotaged && defender.sabotaged[positionId] !== undefined) {
         delete defender.sabotaged[positionId];
       }
+      if (!attacker.preyCards) attacker.preyCards = [];
       if (level === 0) {
         const defCardId = defender.defCards[positionId];
-        if (defCardId !== undefined) { attacker.hand.push(defCardId); delete defender.defCards[positionId]; }
+        if (defCardId !== undefined) { attacker.hand.push(defCardId); attacker.preyCards.push(defCardId); delete defender.defCards[positionId]; }
         const topCardId = defender.topDefCards[positionId];
-        if (topCardId !== undefined) { attacker.hand.push(topCardId); delete defender.topDefCards[positionId]; }
+        if (topCardId !== undefined) { attacker.hand.push(topCardId); attacker.preyCards.push(topCardId); delete defender.topDefCards[positionId]; }
       } else {
         const topCardId = defender.topDefCards[positionId];
-        if (topCardId !== undefined) { attacker.hand.push(topCardId); delete defender.topDefCards[positionId]; }
+        if (topCardId !== undefined) { attacker.hand.push(topCardId); attacker.preyCards.push(topCardId); delete defender.topDefCards[positionId]; }
       }
     } else {
       this.pushLog(`${this.pname(attackerIdx)} missed ${this.pname(defenderIdx)}'s shield [${positionId}]`, false);
@@ -323,6 +325,7 @@ class GameState {
 
   finishTurn(currentPlayerIndex) {
     this.lastMerchantReveal = null; // clear Merchant 2nd-try reveal on turn end
+    if (this.players[currentPlayerIndex]) this.players[currentPlayerIndex].preyCards = [];
     // Advance to the next non-eliminated player (server is authoritative)
     const n = this.players.length;
     let next = (currentPlayerIndex + 1) % n;
@@ -450,6 +453,7 @@ class GameState {
         kingCovered: p.kingCovered !== undefined ? p.kingCovered : true,
         isOut: p.isOut || false,
         sabotaged: Object.assign({}, p.sabotaged || {}),
+        preyCards: [...(p.preyCards || [])],
       })),
       pickingDecks: this.pickingDecks.map(d => d.map(c => ({ id: c.id, covered: c.covered }))),
       winnerIndex: this.checkWinner(),


### PR DESCRIPTION
Closes #28

## What changed

When a player successfully breaks an enemy defense card, the captured card(s) are now locked ("prey cards") for the rest of that turn.

### Server (`gameState.js`)
- Each player has a `preyCards: []` array initialized in the constructor
- `defAttackResolved()`: on success, captured card IDs are pushed to `attacker.preyCards` alongside `attacker.hand`
- `finishTurn()`: clears `preyCards` for the player finishing their turn
- `serialize()`: includes `preyCards` in the state snapshot

### Client (`PlayerTurn.java`)
- Added `preyCardIds: ArrayList<Integer>` with getter/setter, synced from server state

### Client (`GameScreen.java`)
- `applyStateUpdate()`: reads `preyCards` JSON array into `player.getPlayerTurn().setPreyCardIds(...)`
- `showHandStage()`: prey cards skip listener registration and are greyed out (`0.4f` alpha) — same pattern as battery-denied cards