### PR TITLE
fix: move "Sacrifice Joker" button onto the joker card

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -2402,7 +2402,7 @@ public class GameScreen extends ScreenAdapter {
       }
       if (jokerInHand != null) {
         final Card theJoker = jokerInHand;
-        TextButton heroBtn = new TextButton("Sacrifice Joker: Get Hero", MyGdxGame.skin);
+        TextButton heroBtn = new TextButton("Get Hero", MyGdxGame.skin);
         heroBtn.setSize(theJoker.getWidth(), heroBtn.getPrefHeight());
         heroBtn.setPosition(theJoker.getX(), theJoker.getY());
         heroBtn.addListener(new ClickListener() {

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -2403,7 +2403,8 @@ public class GameScreen extends ScreenAdapter {
       if (jokerInHand != null) {
         final Card theJoker = jokerInHand;
         TextButton heroBtn = new TextButton("Sacrifice Joker: Get Hero", MyGdxGame.skin);
-        heroBtn.setPosition(0, 0);
+        heroBtn.setSize(theJoker.getWidth(), heroBtn.getPrefHeight());
+        heroBtn.setPosition(theJoker.getX(), theJoker.getY());
         heroBtn.addListener(new ClickListener() {
           @Override
           public void clicked(InputEvent event, float x, float y) {


### PR DESCRIPTION
Fixes #43

## Problem
The "Sacrifice Joker: Get Hero" button was fixed at position `(0, 0)` in the hand stage — the lower-left corner — which overlaps with hero sprites and their indicator labels.

## Fix
Position the button directly on the joker card: sized to match the card's width and placed at the card's bottom edge. This ties the button visually to the card it acts on and moves it well clear of the hero area.