### PR TITLE
feat: rotate board so own player is always at bottom

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -639,7 +639,7 @@ public class GameScreen extends ScreenAdapter {
     // draw game status of players
     for (int i = 0; i < players.size(); i++) {
       // visual slot 0 = bottom (own player), 1 = left, 2 = top, 3 = right
-      int visualSlot = (i - playerIndex + players.size()) % players.size();
+      int visualSlot = (i - playerIndex + 4) % 4;
       System.out.println("Player " + players.get(i).getPlayerName() + " hand = " + players.get(i).getHandCards().size());
       System.out.println("Player " + players.get(i).getPlayerName() + " def = " + players.get(i).getDefCards().size());
 


### PR DESCRIPTION
Closes #52

## Change

In `showGameStage()`, added one line at the top of the player loop:

```java
int visualSlot = (i - playerIndex + players.size()) % players.size();
```

Then replaced raw `i` with `visualSlot` in all layout calls:
- `Dice.setMapPosition(visualSlot)`
- `Card.setMapPosition(visualSlot, ...)` — king, defense, top-defense
- Hand-deck `switch (visualSlot)`
- Player-label `switch (visualSlot)`
- Hero-icon `switch (visualSlot)`

No changes to game logic, listeners, or any other code.