### PR TITLE
feat: auto-reshuffle cemetery into deck when deck runs empty (#59)

### DIFF
--- a/server/gameState.js
+++ b/server/gameState.js
@@ -112,6 +112,28 @@ class GameState {
     }
   }
 
+  /**
+   * Draw the next card from the deck, automatically reshuffling the cemetery into
+   * the deck (with a fresh Fisher-Yates shuffle) when the deck runs empty.
+   * Returns null only when both the deck and the cemetery are truly empty.
+   */
+  pickCard() {
+    if (this.deck.length === 0) {
+      if (this.cemetery.length > 0) {
+        this.deck = [...this.cemetery];
+        this.cemetery = [];
+        for (let i = this.deck.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1));
+          [this.deck[i], this.deck[j]] = [this.deck[j], this.deck[i]];
+        }
+        console.log('Deck empty — reshuffled cemetery (' + this.deck.length + ' cards) into deck');
+      } else {
+        return null; // both deck and cemetery are empty
+      }
+    }
+    return this.deck.pop();
+  }
+
   priestConvert(attackerIdx, targetPlayerIdx, cardId) {
     const target = this.players[targetPlayerIdx];
     const attacker = this.players[attackerIdx];
@@ -235,7 +257,8 @@ class GameState {
       this.cemetery.push(cardId);
     }
     for (let i = 0; i < (drawFromDeck || 0); i++) {
-      if (this.deck.length > 0) this.cemetery.push(this.deck.pop());
+      const drawn = this.pickCard();
+      if (drawn !== null) this.cemetery.push(drawn);
     }
   }
 
@@ -282,10 +305,10 @@ class GameState {
       this.pickingDecks[deckIdx] = [];
       const otherIdx = 1 - deckIdx;
       // Add one face-DOWN card to the other deck (deck B grows by one hidden card)
-      if (this.deck.length > 0) this.pickingDecks[otherIdx].push({ id: this.deck.pop(), covered: true });
+      const c1 = this.pickCard(); if (c1 !== null) this.pickingDecks[otherIdx].push({ id: c1, covered: true });
       // Rebuild plundered deck: one face-up card (visible) + one face-down card on top
-      if (this.deck.length > 0) this.pickingDecks[deckIdx].push({ id: this.deck.pop(), covered: false });
-      if (this.deck.length > 0) this.pickingDecks[deckIdx].push({ id: this.deck.pop(), covered: true });
+      const c2 = this.pickCard(); if (c2 !== null) this.pickingDecks[deckIdx].push({ id: c2, covered: false });
+      const c3 = this.pickCard(); if (c3 !== null) this.pickingDecks[deckIdx].push({ id: c3, covered: true });
     } else {
       this.pushLog(`${this.pname(attackerIdx)} plunder on deck ${deckIdx + 1} failed`, false);
       if (kingUsed) attacker.isOut = true;
@@ -293,7 +316,7 @@ class GameState {
       // then add a new face-down card on top.
       const deck = this.pickingDecks[deckIdx];
       if (deck.length > 0) deck[deck.length - 1].covered = false;
-      if (this.deck.length > 0) this.pickingDecks[deckIdx].push({ id: this.deck.pop(), covered: true });
+      const c4 = this.pickCard(); if (c4 !== null) this.pickingDecks[deckIdx].push({ id: c4, covered: true });
     }
   }
 


### PR DESCRIPTION
Closes #59

## Problem

All server-side card draws were guarded with `if (this.deck.length > 0) ... this.deck.pop()`. When the deck was exhausted those draws simply silently skipped, leaving picking decks underfilled and some draws completely missed — with no recovery ever happening.

## Solution

Added a single `pickCard()` helper method to `GameState` (server-side only):

```js
pickCard() {
  if (this.deck.length === 0) {
    if (this.cemetery.length > 0) {
      this.deck = [...this.cemetery];
      this.cemetery = [];
      // Fisher-Yates shuffle
      for (let i = this.deck.length - 1; i > 0; i--) {
        const j = Math.floor(Math.random() * (i + 1));
        [this.deck[i], this.deck[j]] = [this.deck[j], this.deck[i]];
      }
    } else {
      return null; // both deck and cemetery are empty
    }
  }
  return this.deck.pop();
}
```

Replaced all 5 runtime `if (this.deck.length > 0) ... deck.pop()` sites with `pickCard()`:
- `addToCemetery` — turn-end draw-from-deck
- `plunderResolved` (success path) — refill other deck + rebuild plundered deck (3 draws)
- `plunderResolved` (fail path) — add face-down card on top of attacked deck

The two setup-time guards in `dealCards` and `initPickingDecks` are left unchanged — they run with a fresh 55-card deck and will never be empty.

## Java client

`CardDeck.getCard()` already handles this correctly via `refillCardDeck(cemeteryDeck)`. No Java changes needed.