### PR TITLE
fix: king swap requires Warlord or no defense cards

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -1492,13 +1492,8 @@ public class GameScreen extends ScreenAdapter {
             apt.getPendingAttackDefCards().clear();
             apt.getPendingAttackOwnDefCards().clear();
           }
-          apt.getPendingAttackCards().clear();
-          apt.resetReservistAttackBonus();
-          apt.resetPendingAttackMercenaryBonus();
-          apt.setAttackPending(false);
-          apt.setAttackTargetIsKing(false);
-          if (apt.isKingUsed()) apt.setKingUsedThisTurn(true);
-          // Coup swap: if the old king (now a hand card) was used in this attack, mark king as spent
+          // Coup swap: if the old king (now a hand card) was used in this attack, mark king as spent.
+          // Must check BEFORE clearing pendingAttackCards.
           int coupId2 = apt.getCoupSwapPendingCardId();
           if (coupId2 != -1) {
             for (Card c : apt.getPendingAttackCards()) {
@@ -1509,6 +1504,12 @@ public class GameScreen extends ScreenAdapter {
               }
             }
           }
+          apt.getPendingAttackCards().clear();
+          apt.resetReservistAttackBonus();
+          apt.resetPendingAttackMercenaryBonus();
+          apt.setAttackPending(false);
+          apt.setAttackTargetIsKing(false);
+          if (apt.isKingUsed()) apt.setKingUsedThisTurn(true);
           // Clear hand card attack boost visuals after attack resolves
           for (Card c : atkPlayer.getHandCards()) {
             c.setSelected(false);

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -778,12 +778,8 @@ public class GameScreen extends ScreenAdapter {
         continue;
       }
       kingCard.setMapPosition(visualSlot, 0, 0);
-      // make own covered cards visible
-      if (players.get(i) == currentPlayer) {
-        kingCard.setActive(true);
-      } else {
-        kingCard.setActive(false);
-      }
+      // king cards are always played face-down
+      kingCard.setActive(false);
 
       kingCard.removeAllListeners();
 
@@ -921,11 +917,8 @@ public class GameScreen extends ScreenAdapter {
         }
 
         defCard.setMapPosition(visualSlot, j, 0);
-        if (players.get(i) == currentPlayer) {
-          defCard.setActive(true);
-        } else {
-          defCard.setActive(false);
-        }
+        // defense cards are always played face-down
+        defCard.setActive(false);
         gameStage.addActor(defCard);
 
         if (players.get(i).isSlotSabotaged(j)) {
@@ -1019,11 +1012,8 @@ public class GameScreen extends ScreenAdapter {
             });
           }
           topDefCard.setMapPosition(visualSlot, j, 1);
-          if (players.get(i) == currentPlayer) {
-            topDefCard.setActive(true);
-          } else {
-            topDefCard.setActive(false);
-          }
+          // top defense cards are always played face-down
+          topDefCard.setActive(false);
           gameStage.addActor(topDefCard);
         }
       }

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -779,10 +779,11 @@ public class GameScreen extends ScreenAdapter {
       }
       // setMapPosition() resets isSelected=false; preserve it for the own king so that a
       // server stateUpdate arriving while the player has their king selected does not
-      // silently deselect it. Only restore when the king has not yet been used this turn.
+      // silently deselect it. Restored regardless of kingUsedThisTurn — the king may
+      // still need to be selected for a swap even after it has already attacked this turn.
+      // Attack listeners independently guard against a second king attack.
       boolean kingWasSelected = (players.get(i) == currentPlayer)
-          && kingCard.isSelected()
-          && !currentPlayer.getPlayerTurn().isKingUsedThisTurn();
+          && kingCard.isSelected();
       kingCard.setMapPosition(visualSlot, 0, 0);
       if (kingWasSelected) kingCard.setSelected(true);
       // Own king: active (grey tint, face visible to owner); enemy king: card back

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -777,7 +777,14 @@ public class GameScreen extends ScreenAdapter {
         Gdx.app.error("GameScreen", "kingCard is null for player " + i);
         continue;
       }
+      // setMapPosition() resets isSelected=false; preserve it for the own king so that a
+      // server stateUpdate arriving while the player has their king selected does not
+      // silently deselect it. Only restore when the king has not yet been used this turn.
+      boolean kingWasSelected = (players.get(i) == currentPlayer)
+          && kingCard.isSelected()
+          && !currentPlayer.getPlayerTurn().isKingUsedThisTurn();
       kingCard.setMapPosition(visualSlot, 0, 0);
+      if (kingWasSelected) kingCard.setSelected(true);
       // Own king: active (grey tint, face visible to owner); enemy king: card back
       if (players.get(i) == currentPlayer) {
         kingCard.setActive(true);

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -1136,6 +1136,17 @@ public class GameScreen extends ScreenAdapter {
           }
           pt.setPlunderPending(false);
           if (pt.isKingUsed()) pt.setKingUsedThisTurn(true);
+          // Coup swap: if the old king (now a hand card) was used in this attack, mark king as spent
+          int coupId = pt.getCoupSwapPendingCardId();
+          if (coupId != -1) {
+            for (Card c : pt.getPendingAttackCards()) {
+              if (c.getCardId() == coupId) {
+                pt.setKingUsedThisTurn(true);
+                pt.setCoupSwapPendingCardId(-1);
+                break;
+              }
+            }
+          }
           // Broadcast to server (server applies + broadcasts stateUpdate to all)
           try {
             JSONObject emitData = new JSONObject();
@@ -1475,6 +1486,17 @@ public class GameScreen extends ScreenAdapter {
           apt.setAttackPending(false);
           apt.setAttackTargetIsKing(false);
           if (apt.isKingUsed()) apt.setKingUsedThisTurn(true);
+          // Coup swap: if the old king (now a hand card) was used in this attack, mark king as spent
+          int coupId2 = apt.getCoupSwapPendingCardId();
+          if (coupId2 != -1) {
+            for (Card c : apt.getPendingAttackCards()) {
+              if (c.getCardId() == coupId2) {
+                apt.setKingUsedThisTurn(true);
+                apt.setCoupSwapPendingCardId(-1);
+                break;
+              }
+            }
+          }
           // Clear hand card attack boost visuals after attack resolves
           for (Card c : atkPlayer.getHandCards()) {
             c.setSelected(false);

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -778,8 +778,12 @@ public class GameScreen extends ScreenAdapter {
         continue;
       }
       kingCard.setMapPosition(visualSlot, 0, 0);
-      // king cards are always played face-down
-      kingCard.setActive(false);
+      // Own king: active (grey tint, face visible to owner); enemy king: card back
+      if (players.get(i) == currentPlayer) {
+        kingCard.setActive(true);
+      } else {
+        kingCard.setActive(false);
+      }
 
       kingCard.removeAllListeners();
 
@@ -917,8 +921,12 @@ public class GameScreen extends ScreenAdapter {
         }
 
         defCard.setMapPosition(visualSlot, j, 0);
-        // defense cards are always played face-down
-        defCard.setActive(false);
+        // Own def card: active (grey tint, face visible to owner); enemy def card: card back
+        if (players.get(i) == currentPlayer) {
+          defCard.setActive(true);
+        } else {
+          defCard.setActive(false);
+        }
         gameStage.addActor(defCard);
 
         if (players.get(i).isSlotSabotaged(j)) {
@@ -1012,8 +1020,12 @@ public class GameScreen extends ScreenAdapter {
             });
           }
           topDefCard.setMapPosition(visualSlot, j, 1);
-          // top defense cards are always played face-down
-          topDefCard.setActive(false);
+          // Own top def card: active (grey tint, face visible to owner); enemy: card back
+          if (players.get(i) == currentPlayer) {
+            topDefCard.setActive(true);
+          } else {
+            topDefCard.setActive(false);
+          }
           gameStage.addActor(topDefCard);
         }
       }

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -2806,6 +2806,26 @@ public class GameScreen extends ScreenAdapter {
           }
         }
 
+        // Restore coup-swap auto-select: keep old king selected in hand after a non-warlord swap
+        if (p == currentPlayer) {
+          int pendingId = currentPlayer.getPlayerTurn().getCoupSwapPendingCardId();
+          if (pendingId != -1) {
+            boolean found = false;
+            for (Card hc : p.getHandCards()) {
+              if (hc.getCardId() == pendingId) {
+                hc.setSelected(true);
+                p.setSelectedSymbol(hc.getSymbol());
+                found = true;
+                break;
+              }
+            }
+            if (!found) {
+              // Card no longer in hand (consumed or lost) — clear the pending flag
+              currentPlayer.getPlayerTurn().setCoupSwapPendingCardId(-1);
+            }
+          }
+        }
+
         // Save local def covered-state overrides (spy flips) before rebuilding
         // Key = slot, Value = card ID that was face-up (only restore if card ID unchanged)
         Map<Integer, Integer> savedDefCovered = new HashMap<Integer, Integer>();

--- a/core/src/com/mygdx/game/PlayerTurn.java
+++ b/core/src/com/mygdx/game/PlayerTurn.java
@@ -221,4 +221,12 @@ public class PlayerTurn {
   public int getPendingAttackDefStr() { return pendingAttackDefStr; }
   public void setPendingAttackDefStr(int v) { this.pendingAttackDefStr = v; }
 
+  // --- Coup-swap pending attack ---
+  // Card ID of the old king after a non-warlord (coup) king swap.
+  // The card stays auto-selected in hand so it can be directly used for an attack.
+  // Cleared when the player deselects the card or switches attack intent.
+  private int coupSwapPendingCardId = -1;
+  public int getCoupSwapPendingCardId() { return coupSwapPendingCardId; }
+  public void setCoupSwapPendingCardId(int id) { this.coupSwapPendingCardId = id; }
+
 }

--- a/core/src/com/mygdx/game/listeners/EnemyKingCardListener.java
+++ b/core/src/com/mygdx/game/listeners/EnemyKingCardListener.java
@@ -12,6 +12,7 @@ import com.mygdx.game.heroes.BatteryTower;
 import com.mygdx.game.heroes.Hero;
 import com.mygdx.game.heroes.Mercenaries;
 import com.mygdx.game.heroes.Reservists;
+import com.mygdx.game.heroes.Warlord;
 import com.mygdx.game.net.SocketClient;
 import com.mygdx.game.util.JSONArray;
 import com.mygdx.game.util.JSONException;
@@ -63,14 +64,30 @@ public class EnemyKingCardListener extends ClickListener {
     // Guard: king can only be attacked when defender has NO defense cards
     if (!defender.getDefCards().isEmpty() || !defender.getTopDefCards().isEmpty()) return;
 
-    boolean kingSelected = player.getKingCard() != null && player.getKingCard().isSelected();
-    if (!kingSelected && player.getSelectedHandCards().size() == 0) return;
-
-    // Attacker's king: one-use-per-turn, can only attack when attacker has no def cards
-    if (kingSelected) {
-      if (pt.isKingUsedThisTurn()) return;
-      if (!player.getDefCards().isEmpty() || !player.getTopDefCards().isEmpty()) return;
+    // Warlord: detect before the 'nothing selected' guard — selecting the Warlord hero
+    // and clicking an enemy king (when defender has no defense) forces the king card to attack.
+    // This bypasses the restriction that the attacker must have no defense cards of their own.
+    boolean warlordAttack = false;
+    Warlord warlord = null;
+    for (Hero wh : player.getHeroes()) {
+      if ("Warlord".equals(wh.getHeroName())) { warlord = (Warlord) wh; }
+      if ("Warlord".equals(wh.getHeroName()) && wh.isSelected()) { warlordAttack = true; }
     }
+
+    boolean kingSelected = player.getKingCard() != null && player.getKingCard().isSelected();
+    if (warlordAttack) {
+      // Force king as attacker; clear any hand card selections
+      kingSelected = true;
+      for (Card hc : player.getHandCards()) hc.setSelected(false);
+      if (warlord == null || !warlord.isAttackAvailable()) return;
+    } else {
+      if (!kingSelected && player.getSelectedHandCards().size() == 0) return;
+    }
+
+    // Attacker's king: one-use-per-turn
+    if (kingSelected && pt.isKingUsedThisTurn()) return;
+    // Without Warlord, king can only be used when attacker has no defense cards
+    if (kingSelected && !warlordAttack && (!player.getDefCards().isEmpty() || !player.getTopDefCards().isEmpty())) return;
 
     // Symbol constraint — king attacks use the king's own symbol (same as hand cards)
     Card attackCard = kingSelected ? player.getKingCard() : player.getSelectedHandCards().get(0);
@@ -138,6 +155,11 @@ public class EnemyKingCardListener extends ClickListener {
     }
 
     pt.setAttackPending(true);
+
+    // Consume Warlord charge after attack is committed
+    if (warlordAttack && warlord != null) {
+      warlord.useAttack();
+    }
 
     // Only trigger the Battery Tower intercept flow when the defender actually has one with charges.
     BatteryTower defBt = null;

--- a/core/src/com/mygdx/game/listeners/OwnHandCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnHandCardListener.java
@@ -167,10 +167,6 @@ public class OwnHandCardListener extends ClickListener {
       // select hand card
       if (handCard.isSelected()) {
         handCard.setSelected(false);
-        // Player explicitly deselected — cancel coup-swap auto-select
-        if (handCard.getCardId() == player.getPlayerTurn().getCoupSwapPendingCardId()) {
-          player.getPlayerTurn().setCoupSwapPendingCardId(-1);
-        }
       } else {
         if (handCard.getSymbol() == player.getSelectedSymbol()) {
           handCard.setSelected(true);

--- a/core/src/com/mygdx/game/listeners/OwnHandCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnHandCardListener.java
@@ -61,6 +61,12 @@ public class OwnHandCardListener extends ClickListener {
         player.setKingCard(newKing);
         player.getHandCards().remove(newKing);
         player.addHandCard(oldKing);
+        // Non-warlord coup: keep old king selected so it can immediately attack.
+        // coupSwapPendingCardId survives stateUpdate hand rebuilds, keeping the card auto-selected.
+        if (!hasWarlord) {
+          player.getPlayerTurn().setCoupSwapPendingCardId(oldKing.getCardId());
+          player.setSelectedSymbol(oldKing.getSymbol());
+        }
         // Deselect king
         player.getKingCard().setSelected(false);
         // Consume actions
@@ -161,6 +167,10 @@ public class OwnHandCardListener extends ClickListener {
       // select hand card
       if (handCard.isSelected()) {
         handCard.setSelected(false);
+        // Player explicitly deselected — cancel coup-swap auto-select
+        if (handCard.getCardId() == player.getPlayerTurn().getCoupSwapPendingCardId()) {
+          player.getPlayerTurn().setCoupSwapPendingCardId(-1);
+        }
       } else {
         if (handCard.getSymbol() == player.getSelectedSymbol()) {
           handCard.setSelected(true);
@@ -170,6 +180,8 @@ public class OwnHandCardListener extends ClickListener {
           }
           handCard.setSelected(true);
           player.setSelectedSymbol(handCard.getSymbol());
+          // Player switched to different symbol — cancel coup-swap auto-select
+          player.getPlayerTurn().setCoupSwapPendingCardId(-1);
         }
       }
 

--- a/core/src/com/mygdx/game/listeners/OwnHandCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnHandCardListener.java
@@ -49,9 +49,12 @@ public class OwnHandCardListener extends ClickListener {
   public void clicked(InputEvent event, float x, float y) {
 
     // Warlord king swap: if own king is selected, swap it with this hand card
-    // Costs 1 take + 1 put action
+    // Costs 1 take + 1 put action.
+    // Allowed only when: player has Warlord hero, OR player has no defense cards (coup).
     if (player.getKingCard() != null && player.getKingCard().isSelected()) {
-      if (player.getPlayerTurn().getTakeDefCard() > 0 && player.getPlayerTurn().getPutDefCard() > 0) {
+      boolean hasWarlord = player.hasHero("Warlord");
+      boolean hasDefCards = !player.getDefCards().isEmpty() || !player.getTopDefCards().isEmpty();
+      if ((hasWarlord || !hasDefCards) && player.getPlayerTurn().getTakeDefCard() > 0 && player.getPlayerTurn().getPutDefCard() > 0) {
         Card oldKing = player.getKingCard();
         Card newKing = handCard;
         // Swap locally

--- a/core/src/com/mygdx/game/listeners/OwnHandCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnHandCardListener.java
@@ -67,6 +67,8 @@ public class OwnHandCardListener extends ClickListener {
         if (!hasWarlord) {
           player.getPlayerTurn().setCoupSwapPendingCardId(oldKing.getCardId());
           player.setSelectedSymbol(oldKing.getSymbol());
+          // Fresh king on board: reset king-used flag so the new board king can attack this turn
+          player.getPlayerTurn().setKingUsedThisTurn(false);
         }
         // Deselect king
         player.getKingCard().setSelected(false);

--- a/core/src/com/mygdx/game/listeners/OwnHandCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnHandCardListener.java
@@ -57,7 +57,8 @@ public class OwnHandCardListener extends ClickListener {
       if ((hasWarlord || !hasDefCards) && player.getPlayerTurn().getTakeDefCard() > 0 && player.getPlayerTurn().getPutDefCard() > 0) {
         Card oldKing = player.getKingCard();
         Card newKing = handCard;
-        // Swap locally
+        // Swap locally — new king is always placed face-down
+        newKing.setCovered(true);
         player.setKingCard(newKing);
         player.getHandCards().remove(newKing);
         player.addHandCard(oldKing);

--- a/core/src/com/mygdx/game/listeners/OwnKingCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnKingCardListener.java
@@ -69,9 +69,6 @@ public class OwnKingCardListener extends ClickListener {
         }
         kingCard.setSelected(true);
       }
-      // Trigger an immediate rebuild so the selection highlight is visible right away
-      // and any stale coup-swap auto-select from a previous stateUpdate is cleared.
-      gameState.setUpdateState(true);
     }
     ;
 

--- a/core/src/com/mygdx/game/listeners/OwnKingCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnKingCardListener.java
@@ -37,6 +37,7 @@ public class OwnKingCardListener extends ClickListener {
   public void clicked(InputEvent event, float x, float y) {
 
     if (player.getSelectedHeroes().size() > 0) {
+      // Mercenaries in defense mode: clicking king adds a boost to it.
       for (int i = 0; i < player.getHeroes().size(); i++) {
         if (player.getHeroes().get(i).getHeroName() == "Mercenaries" && player.getHeroes().get(i).isSelected()) {
           Mercenaries mercenaries = (Mercenaries) player.getHeroes().get(i);
@@ -44,9 +45,17 @@ public class OwnKingCardListener extends ClickListener {
             mercenaries.operate();
             kingCard.addBoosted(1);
           }
+          return;
         }
       }
-    } else {
+      // Any other hero selected (e.g. Warlord after using its attack): deselect it
+      // and fall through to normal king selection below.
+      for (int i = 0; i < player.getHeroes().size(); i++) {
+        player.getHeroes().get(i).setSelected(false);
+      }
+    }
+
+    {
       // unselect all handcards
       for (int i = 0; i < handCards.size(); i++) {
         handCards.get(i).setSelected(false);

--- a/core/src/com/mygdx/game/listeners/OwnKingCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnKingCardListener.java
@@ -51,6 +51,8 @@ public class OwnKingCardListener extends ClickListener {
       for (int i = 0; i < handCards.size(); i++) {
         handCards.get(i).setSelected(false);
       }
+      // Selecting own king cancels any pending coup-swap auto-select
+      player.getPlayerTurn().setCoupSwapPendingCardId(-1);
 
       // select king card
       if (kingCard.isSelected()) {

--- a/core/src/com/mygdx/game/listeners/OwnKingCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnKingCardListener.java
@@ -69,6 +69,9 @@ public class OwnKingCardListener extends ClickListener {
         }
         kingCard.setSelected(true);
       }
+      // Trigger an immediate rebuild so the selection highlight is visible right away
+      // and any stale coup-swap auto-select from a previous stateUpdate is cleared.
+      gameState.setUpdateState(true);
     }
     ;
 

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -441,6 +441,7 @@ class GameState {
     p.hand.splice(handIdx, 1);
     p.hand.push(oldKingCardId);
     p.kingCard = newKingCardId;
+    p.kingCovered = true; // new king is always placed face-down
     this.pushLog(`${this.pname(playerIdx)} swapped king (Warlord)`, true, true);
   }
 


### PR DESCRIPTION
Fixes #57.

## Problem
A player could swap their king card with a hand card even without the **Warlord** hero, as long as they had enough action points. The swap should only be available when:
- The player owns the **Warlord** hero (the card's intended ability), OR
- The player has **no defense cards** (the "coup" — deliberately exposing the king)

## Change
In `OwnHandCardListener.clicked()`, added a guard before executing the king swap:

```java
boolean hasWarlord = player.hasHero("Warlord");
boolean hasDefCards = !player.getDefCards().isEmpty() || !player.getTopDefCards().isEmpty();
if ((hasWarlord || !hasDefCards) && player.getPlayerTurn().getTakeDefCard() > 0 && player.getPlayerTurn().getPutDefCard() > 0) {
    // perform swap
}
```

The action-point cost (1 take + 1 put) is preserved for both the Warlord and coup cases.