### PR TITLE
feat: lobby game management (#62)

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -570,7 +570,10 @@ public class GameScreen extends ScreenAdapter {
     Gdx.app.log("Native Heap", String.valueOf(Gdx.app.getNativeHeap()));
 
     players = gameState.getPlayers();
-    // currentPlayer stays as this client's own player (set in constructor from playerIndex)
+    // Spectators always follow the player whose turn it currently is.
+    if (isSpectator) {
+      currentPlayer = gameState.getCurrentPlayer();
+    }
 
     // On first render, broadcast Reservists count so enemies see the indicator immediately.
     // Also broadcast the starting hero so all clients know each other's heroes (the
@@ -2632,8 +2635,8 @@ public class GameScreen extends ScreenAdapter {
     myPlayerLabel = new Label(currentPlayer.getPlayerName(), MyGdxGame.skin);
     myPlayerLabel.setPosition(Gdx.graphics.getWidth() - myPlayerLabel.getWidth(), finishTurnButton.getHeight());
 
-    // Turn indicator
-    boolean isMyTurn = (gameState.getCurrentPlayer() == currentPlayer);
+    // Turn indicator (spectators are never "my turn")
+    boolean isMyTurn = !isSpectator && (gameState.getCurrentPlayer() == currentPlayer);
 
     // "Sacrifice Joker" button — only on your turn, bottom-left of hand stage
     if (isMyTurn && !currentPlayer.getPlayerTurn().isHeroSelectionPending()) {
@@ -2656,11 +2659,19 @@ public class GameScreen extends ScreenAdapter {
       }
     }
 
-    // Only enable finish-turn button when it is this player's turn
-    finishTurnButton.setVisible(isMyTurn);
-
-    finishTurnButtonListener = new FinishTurnButtonListener(gameState, socket);
-    finishTurnButton.addListener(finishTurnButtonListener);
+    // Spectators: hide finish-turn button and show a spectator indicator instead.
+    // Regular players: show button only on their turn.
+    if (isSpectator) {
+      finishTurnButton.setVisible(false);
+      Label spectatorLabel = new Label("Spectator Mode", MyGdxGame.skin);
+      spectatorLabel.setColor(Color.CYAN);
+      spectatorLabel.setPosition(Gdx.graphics.getWidth() - spectatorLabel.getPrefWidth(), 0);
+      handStage.addActor(spectatorLabel);
+    } else {
+      finishTurnButton.setVisible(isMyTurn);
+      finishTurnButtonListener = new FinishTurnButtonListener(gameState, socket);
+      finishTurnButton.addListener(finishTurnButtonListener);
+    }
 
     handStage.addActor(myPlayerLabel);
 

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -115,6 +115,7 @@ public class GameScreen extends ScreenAdapter {
   private int merchantRevealPlayerIdx = -1;
 
   private int playerIndex;
+  private boolean isSpectator = false;
   private JSONObject centralizedState;
   private SocketClient socket;
   // Battery Tower: stored when this local player is the defender and must allow/deny
@@ -153,18 +154,20 @@ public class GameScreen extends ScreenAdapter {
   public GameScreen(Game game, JSONObject centralizedState, int playerIndex, SocketClient socket, String startingHero) {
     this.startingHero = startingHero;
     this.socket = socket;
-    this.playerIndex = playerIndex;
+    // playerIndex == -1 means spectator — display from player 0's viewpoint, read-only
+    this.isSpectator = (playerIndex < 0);
+    this.playerIndex = this.isSpectator ? 0 : playerIndex;
     this.centralizedState = centralizedState;
 
     // Build all game state from the server-provided authoritative state
     gameState = new GameState(centralizedState);
     gameState.setSocket(socket);
     players = gameState.getPlayers();
-    currentPlayer = players.get(playerIndex);
+    currentPlayer = players.get(this.playerIndex);
 
-    // Apply testing starting hero if one was selected in the menu
-    if (startingHero != null && !startingHero.equals("None")) {
-      gameState.applyHeroAcquired(playerIndex, startingHero);
+    // Apply testing starting hero if one was selected in the menu (not for spectators)
+    if (!isSpectator && startingHero != null && !startingHero.equals("None")) {
+      gameState.applyHeroAcquired(this.playerIndex, startingHero);
     }
 
     // Single stateUpdate listener — replaces all specific sync events
@@ -480,9 +483,17 @@ public class GameScreen extends ScreenAdapter {
       }
     });
 
+    // Game ended — server tells all clients to return to the lobby
+    socket.on("returnToLobby", new SocketListener() {
+      @Override
+      public void call(Object... args) {
+        // MenuScreen's own returnToLobby listener will handle the screen switch;
+        // nothing to do here since MenuScreen is still registered on the socket.
+      }
+    });
+
     // Initialize stages
     gameStage = new Stage();
-    fitVPGame = new FitViewport(Gdx.graphics.getWidth(), Gdx.graphics.getWidth());
     gameStage.setViewport(fitVPGame);
 
     handStage = new Stage();
@@ -496,7 +507,12 @@ public class GameScreen extends ScreenAdapter {
     inMulti = new InputMultiplexer();
     inMulti.addProcessor(gameStage);
     inMulti.addProcessor(handStage);
-    Gdx.input.setInputProcessor(inMulti);
+    // Spectators watch in read-only mode — no input processing
+    if (!isSpectator) {
+      Gdx.input.setInputProcessor(inMulti);
+    } else {
+      Gdx.input.setInputProcessor(null);
+    }
 
     gameBck = new Image(MyGdxGame.skin, "white");
     gameBck.setFillParent(true);
@@ -3019,8 +3035,9 @@ public class GameScreen extends ScreenAdapter {
     Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
     // Block all input when it is not this client's turn,
-    // EXCEPT when a Battery Tower intercept awaits the defender's decision
-    if (gameState.getCurrentPlayer() == currentPlayer || pendingBatteryDefCheck != null || pendingBatteryResultCards != null) {
+    // EXCEPT when a Battery Tower intercept awaits the defender's decision.
+    // Spectators never get input.
+    if (!isSpectator && (gameState.getCurrentPlayer() == currentPlayer || pendingBatteryDefCheck != null || pendingBatteryResultCards != null)) {
       Gdx.input.setInputProcessor(inMulti);
     } else {
       Gdx.input.setInputProcessor(null);

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -494,6 +494,7 @@ public class GameScreen extends ScreenAdapter {
 
     // Initialize stages
     gameStage = new Stage();
+    fitVPGame = new FitViewport(Gdx.graphics.getWidth(), Gdx.graphics.getWidth());
     gameStage.setViewport(fitVPGame);
 
     handStage = new Stage();

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -50,6 +50,7 @@ public class MenuScreen extends AbstractScreen {
   private int currentUsersCount;
   private boolean updateScreen = false;
   boolean timerStarted = false;
+  private boolean gameRunning = false;
 
   // Whether the player has entered a name and joined the lobby.
   private boolean lobbyJoined = false;
@@ -262,38 +263,58 @@ public class MenuScreen extends AbstractScreen {
 
     loggedInUserTable.setPosition(200, 300);
 
-    // check if all players are ready (requires >= 2)
-    if (menuState.allReady() && !timerStarted) {
-      System.out.println("All players ready...");
-      socket.emit("startTimer", 5);
-      menuState.setTimeToStart(5);
-      timerStarted = true;
+    if (gameRunning) {
+      // A game is already in progress — show status and offer spectating
+      Label gameRunningLabel = new Label("Game in progress", MyGdxGame.skin);
+      gameRunningLabel.setColor(Color.YELLOW);
+      gameRunningLabel.setPosition(200, 50);
+      menuStage.addActor(gameRunningLabel);
+
+      TextButton watchButton = new TextButton("Watch game", MyGdxGame.skin);
+      watchButton.setSize(button.getWidth(), button.getHeight());
+      watchButton.setPosition((MyGdxGame.WIDTH - watchButton.getWidth()) / 2f, 0.1f * MyGdxGame.HEIGHT);
+      watchButton.addListener(new ClickListener() {
+        @Override
+        public void clicked(InputEvent event, float x, float y) {
+          socket.emit("joinSpectator", "");
+        }
+      });
+      menuStage.addActor(watchButton);
+    } else {
+      // No game running — show normal ready/start controls
+      // check if all players are ready (requires >= 2)
+      if (menuState.allReady() && !timerStarted) {
+        System.out.println("All players ready...");
+        socket.emit("startTimer", 5);
+        menuState.setTimeToStart(5);
+        timerStarted = true;
+      }
+
+      if (!menuState.allReady() && timerStarted) {
+        timerStarted = false;
+        menuState.setTimeToStart(5);
+      }
+
+      Label timerLabel = new Label("Waiting for players ... ", MyGdxGame.skin);
+      if (timerStarted) {
+        timerLabel = new Label("Time to start ... " + menuState.getTimeToStart(), MyGdxGame.skin);
+      }
+      timerLabel.setPosition(200, 0);
+      menuStage.addActor(timerLabel);
+
+      // Rebuild hero dropdown excluding heroes reserved by other lobby players.
+      refreshHeroDropdown();
+
+      // Add hero selector directly to stage so popup coordinates work correctly
+      Label heroLabel = new Label("Starting hero:", MyGdxGame.skin);
+      heroLabel.setPosition(heroSelectBox.getX(), heroSelectBox.getY() + heroSelectBox.getHeight() + 4);
+      menuStage.addActor(heroLabel);
+      menuStage.addActor(heroSelectBox);
+      menuStage.addActor(button);
     }
 
-    if (!menuState.allReady() && timerStarted) {
-      timerStarted = false;
-      menuState.setTimeToStart(5);
-    }
-
-    Label timerLabel = new Label("Waiting for players ... ", MyGdxGame.skin);
-    if (timerStarted) {
-      timerLabel = new Label("Time to start ... " + menuState.getTimeToStart(), MyGdxGame.skin);
-    }
-    timerLabel.setPosition(200, 0);
-
-    menuStage.addActor(timerLabel);
     menuStage.addActor(loggedInUserTable);
     menuStage.addActor(loggedInCount);
-
-    // Rebuild hero dropdown excluding heroes reserved by other lobby players.
-    refreshHeroDropdown();
-
-    // Add hero selector directly to stage so popup coordinates work correctly
-    Label heroLabel = new Label("Starting hero:", MyGdxGame.skin);
-    heroLabel.setPosition(heroSelectBox.getX(), heroSelectBox.getY() + heroSelectBox.getHeight() + 4);
-    menuStage.addActor(heroLabel);
-    menuStage.addActor(heroSelectBox);
-    menuStage.addActor(button);
     Gdx.input.setInputProcessor(menuStage);
   }
 
@@ -514,6 +535,53 @@ public class MenuScreen extends AbstractScreen {
         } catch (JSONException e) {
           Gdx.app.log("SocketIO", "Error parsing heroReleased");
         }
+      }
+    });
+
+    socket.on("gameStatus", new SocketListener() {
+      @Override
+      public void call(Object... args) {
+        JSONObject data = (JSONObject) args[0];
+        try {
+          final boolean running = data.getBoolean("running");
+          Gdx.app.postRunnable(new Runnable() {
+            @Override
+            public void run() {
+              gameRunning = running;
+              updateScreen = true;
+            }
+          });
+        } catch (JSONException e) {
+          Gdx.app.log("SocketIO", "Error parsing gameStatus");
+        }
+      }
+    });
+
+    socket.on("gameAlreadyRunning", new SocketListener() {
+      @Override
+      public void call(Object... args) {
+        Gdx.app.postRunnable(new Runnable() {
+          @Override
+          public void run() {
+            timerStarted = false;
+            gameRunning = true;
+            updateScreen = true;
+          }
+        });
+      }
+    });
+
+    socket.on("returnToLobby", new SocketListener() {
+      @Override
+      public void call(Object... args) {
+        Gdx.app.postRunnable(new Runnable() {
+          @Override
+          public void run() {
+            timerStarted = false;
+            gameRunning = false;
+            game.setScreen(MenuScreen.this);
+          }
+        });
       }
     });
 

--- a/server/index.js
+++ b/server/index.js
@@ -21,6 +21,7 @@ app.use(require('express').static(path.join(__dirname, 'public')));
 
 
 var users = [];
+var spectators = [];
 var timeToStart;
 var timer;
 var GameState = require('./gameState');
@@ -34,17 +35,18 @@ function checkAndHandleWinner(io) {
   const winner = gameState.checkWinner();
   if (winner >= 0) {
     winnerHandled = true;
-    console.log("Winner found: player " + winner + " — restarting in 5 seconds");
-    // stateUpdate with winnerIndex already broadcast by the caller; schedule restart
+    console.log("Winner found: player " + winner + " — returning to lobby in 5 seconds");
+    // stateUpdate with winnerIndex already broadcast by the caller; schedule return to lobby
     setTimeout(function() {
       winnerHandled = false;
-      gameState = new GameState(users);
-      users.forEach(function(user, idx) {
-        io.to(user.id).emit('gameState', {
-          playerIndex: idx,
-          gameState: gameState.serialize()
-        });
-      });
+      gameState = null;
+      // Return all players and spectators to the lobby
+      users.forEach(function(u) { io.to(u.id).emit('returnToLobby'); });
+      spectators.forEach(function(sid) { io.to(sid).emit('returnToLobby'); });
+      spectators = [];
+      // Reset ready states so next game requires a fresh ready-up
+      users.forEach(function(u) { u.isReady = false; });
+      io.emit('getUsers', users);
     }, 5000);
   }
 }
@@ -58,6 +60,8 @@ io.on('connection', function(socket) {
   console.log("User Connected");
   socket.emit('socketID', { id: socket.id });
   socket.broadcast.emit('newUser', { id: socket.id });
+  // Inform the new client whether a game is already in progress
+  socket.emit('gameStatus', { running: gameState !== null });
 
   socket.on('disconnect', function() {
     console.log("User Disconnected");
@@ -72,6 +76,9 @@ io.on('connection', function(socket) {
         users.splice(i, 1);
       }
     }
+    // Also remove from spectators if present
+    var specIdx = spectators.indexOf(socket.id);
+    if (specIdx !== -1) spectators.splice(specIdx, 1);
     socket.broadcast.emit('getUsers', users);
   });
 
@@ -95,6 +102,11 @@ io.on('connection', function(socket) {
   
   socket.on('startTimer', function(seconds) {
     console.log("Start Timer");
+    if (gameState !== null) {
+      console.log("Game already running — rejecting startTimer");
+      socket.emit('gameAlreadyRunning');
+      return;
+    }
     if (users.length < 2) {
       console.log("Not enough players to start (need at least 2)");
       return;
@@ -341,6 +353,24 @@ io.on('connection', function(socket) {
       users.push(new user(socket.id, name));
     }
     io.emit('getUsers', users);
+    // Tell the joining client whether a game is currently running
+    socket.emit('gameStatus', { running: gameState !== null });
+  });
+
+  socket.on('joinSpectator', function() {
+    if (!gameState) {
+      socket.emit('gameStatus', { running: false });
+      return;
+    }
+    console.log('Spectator joined: ' + socket.id);
+    if (spectators.indexOf(socket.id) === -1) {
+      spectators.push(socket.id);
+    }
+    // Send the full game state to the spectator (playerIndex -1 = spectator/read-only)
+    socket.emit('gameState', {
+      playerIndex: -1,
+      gameState: gameState.serialize()
+    });
   });
 });
 


### PR DESCRIPTION
Closes #62

## Changes

### Server (`server/index.js`)
- Track `spectators[]` separately alongside `users[]`
- Emit `gameStatus { running }` on `connection` and after `joinLobby` so new clients immediately know whether a game is in progress
- Guard `startTimer`: if `gameState !== null`, emit `gameAlreadyRunning` and return
- Add `joinSpectator` handler: push socket ID to `spectators[]`, emit current `gameState` with `playerIndex: -1`
- `checkAndHandleWinner`: after winner detected, wait 5 s then set `gameState = null`, emit `returnToLobby` to all users **and** spectators (instead of auto-restarting), reset ready states, broadcast updated `getUsers`
- `disconnect`: also remove socket from `spectators[]`

### Client – `MenuScreen.java`
- New `gameRunning` boolean field
- `gameStatus` listener: update `gameRunning` and refresh screen
- `gameAlreadyRunning` listener: reset `timerStarted`, set `gameRunning = true`
- `returnToLobby` listener: clear timer/running state, call `game.setScreen(MenuScreen.this)` to return from GameScreen
- `showLobbyScreen()`: when `gameRunning` show a yellow **"Game in progress"** label and a **"Watch game"** button (emits `joinSpectator`); otherwise show the existing ready/start controls

### Client – `GameScreen.java`
- New `isSpectator` boolean: set when `playerIndex < 0`
- Spectator clamps `playerIndex` to `0` for display; skips hero application
- Input processor disabled for spectators in both the constructor and the per-frame render guard
- No-op `returnToLobby` listener stub (actual screen switch handled by `MenuScreen`)