### PR TITLE
feat: multi-game sessions + TextField name entry / UI fixes

### DIFF
--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -455,6 +455,7 @@ public class MenuScreen extends AbstractScreen {
     leaveBtn.addListener(new ClickListener() {
       @Override
       public void clicked(InputEvent event, float x, float y) {
+        socket.emit("leaveSession", "");
         lobbyJoined = false;
         timerStarted = false;
         gameRunning = false;

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -153,7 +153,7 @@ public class MenuScreen extends AbstractScreen {
     });
 
     group.addActor(logoImage);
-    group.addActor(button);
+    // button is NOT in the group so it only appears on the lobby screen
 
     menuStage.addActor(group);
     menuStage.getCamera().position.set(MyGdxGame.WIDTH / 2, MyGdxGame.HEIGHT / 2, 0);
@@ -218,16 +218,15 @@ public class MenuScreen extends AbstractScreen {
     nameField.setMaxLength(20);
     nameField.setSize(button.getWidth() * 2, button.getHeight());
     nameField.setPosition(cx - nameField.getWidth() / 2f, 0.3f * MyGdxGame.HEIGHT);
-    // Tapping the field should raise the on-screen keyboard on mobile browsers.
-    nameField.addListener(new ClickListener() {
+    // Mobile browsers only open the keyboard from a touchstart (touchDown), not touchend.
+    nameField.addListener(new com.badlogic.gdx.scenes.scene2d.InputListener() {
       @Override
-      public void clicked(InputEvent event, float x, float y) {
+      public boolean touchDown(InputEvent event, float x, float y, int pointer, int btn) {
         menuStage.setKeyboardFocus(nameField);
         Gdx.input.setOnscreenKeyboardVisible(true);
+        return false;
       }
     });
-    menuStage.setKeyboardFocus(nameField);
-    Gdx.input.setOnscreenKeyboardVisible(true);
 
     TextButton confirmBtn = new TextButton("Play", MyGdxGame.skin);
     confirmBtn.setSize(button.getWidth(), button.getHeight());

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -212,18 +212,26 @@ public class MenuScreen extends AbstractScreen {
 
   private void showNameEntryScreen() {
     float cx = MyGdxGame.WIDTH / 2f;
-    float cy = MyGdxGame.HEIGHT / 2f;
 
     final TextField nameField = new TextField("", MyGdxGame.skin);
     nameField.setMessageText("Enter your name");
     nameField.setMaxLength(20);
     nameField.setSize(button.getWidth() * 2, button.getHeight());
-    nameField.setPosition(cx - nameField.getWidth() / 2f, cy);
+    nameField.setPosition(cx - nameField.getWidth() / 2f, 0.3f * MyGdxGame.HEIGHT);
+    // Tapping the field should raise the on-screen keyboard on mobile browsers.
+    nameField.addListener(new ClickListener() {
+      @Override
+      public void clicked(InputEvent event, float x, float y) {
+        menuStage.setKeyboardFocus(nameField);
+        Gdx.input.setOnscreenKeyboardVisible(true);
+      }
+    });
     menuStage.setKeyboardFocus(nameField);
+    Gdx.input.setOnscreenKeyboardVisible(true);
 
     TextButton confirmBtn = new TextButton("Play", MyGdxGame.skin);
     confirmBtn.setSize(button.getWidth(), button.getHeight());
-    confirmBtn.setPosition(cx - confirmBtn.getWidth() / 2f, cy - confirmBtn.getHeight() * 1.5f);
+    confirmBtn.setPosition(cx - confirmBtn.getWidth() / 2f, 0.3f * MyGdxGame.HEIGHT - confirmBtn.getHeight() * 1.5f);
     confirmBtn.addListener(new ClickListener() {
       @Override
       public void clicked(InputEvent event, float x, float y) {
@@ -288,34 +296,33 @@ public class MenuScreen extends AbstractScreen {
       sessTable.row();
     }
 
-    sessTable.setPosition(cx - 150, 0.35f * MyGdxGame.HEIGHT);
+    sessTable.pack();
+    sessTable.setPosition(cx - sessTable.getWidth() / 2f, 0.35f * MyGdxGame.HEIGHT);
     menuStage.addActor(sessTable);
 
-    // Create new game row
-    final TextField gameNameField = new TextField("", MyGdxGame.skin);
-    gameNameField.setMessageText("Game name");
-    gameNameField.setMaxLength(40);
-    gameNameField.setSize(button.getWidth() * 2, button.getHeight());
-    gameNameField.setPosition(cx - gameNameField.getWidth() / 2f - button.getWidth() * 0.6f, 0.15f * MyGdxGame.HEIGHT);
-
-    TextButton createBtn = new TextButton("Create", MyGdxGame.skin);
-    createBtn.setSize(button.getWidth(), button.getHeight());
-    createBtn.setPosition(cx + gameNameField.getWidth() / 2f - button.getWidth() * 0.1f, 0.15f * MyGdxGame.HEIGHT);
+    TextButton createBtn = new TextButton("Create game", MyGdxGame.skin);
+    createBtn.setSize(button.getWidth() * 1.5f, button.getHeight());
+    createBtn.setPosition(cx - createBtn.getWidth() / 2f, 0.15f * MyGdxGame.HEIGHT);
     createBtn.addListener(new ClickListener() {
       @Override
       public void clicked(InputEvent event, float x, float y) {
-        String rawName = gameNameField.getText().trim();
-        String sessionName = rawName.isEmpty() ? menuState.getMyName() + "'s game" : rawName;
-        JSONObject data = new JSONObject();
-        try {
-          data.put("name", menuState.getMyName());
-          data.put("sessionName", sessionName);
-        } catch (JSONException e) { /* ignore */ }
-        socket.emit("createSession", data);
+        Gdx.input.getTextInput(new com.badlogic.gdx.Input.TextInputListener() {
+          @Override
+          public void input(String text) {
+            String sessionName = text.trim().isEmpty() ? menuState.getMyName() + "'s game" : text.trim();
+            JSONObject data = new JSONObject();
+            try {
+              data.put("name", menuState.getMyName());
+              data.put("sessionName", sessionName);
+            } catch (JSONException e) { /* ignore */ }
+            socket.emit("createSession", data);
+          }
+          @Override
+          public void canceled() { /* stay on session list */ }
+        }, "New game", "", "Enter game name (optional)");
       }
     });
 
-    menuStage.addActor(gameNameField);
     menuStage.addActor(createBtn);
     Gdx.input.setInputProcessor(menuStage);
   }
@@ -367,7 +374,8 @@ public class MenuScreen extends AbstractScreen {
       loggedInUserTable.row();
     }
 
-    loggedInUserTable.setPosition(200, 300);
+    loggedInUserTable.pack();
+    loggedInUserTable.setPosition((MyGdxGame.WIDTH - loggedInUserTable.getWidth()) / 2f, 300);
 
     // Notification permission status — shown in all lobby states
     if (MyGdxGame.turnNotifier.isPermissionGranted()) {

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -17,6 +17,7 @@ import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.CheckBox;
 import com.badlogic.gdx.scenes.scene2d.ui.SelectBox;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
@@ -56,6 +57,13 @@ public class MenuScreen extends AbstractScreen {
 
   // Whether the player has entered a name and reached the session-list screen
   private boolean nameConfirmed = false;
+
+  // True while the session-creation sub-screen is shown
+  private boolean inSessionCreate = false;
+  // Pending game name typed on the create screen (cleared after creation)
+  private String pendingSessionName = "";
+  // Whether hero selection is allowed in the current session
+  private boolean sessionAllowHeroSelection = true;
 
   // The session list received from the server
   private java.util.List<SessionInfo> sessionList = new java.util.ArrayList<SessionInfo>();
@@ -202,6 +210,8 @@ public class MenuScreen extends AbstractScreen {
 
     if (!nameConfirmed) {
       showNameEntryScreen();
+    } else if (!lobbyJoined && inSessionCreate) {
+      showSessionCreateScreen();
     } else if (!lobbyJoined) {
       showSessionListScreen();
     } else {
@@ -301,24 +311,86 @@ public class MenuScreen extends AbstractScreen {
     createBtn.addListener(new ClickListener() {
       @Override
       public void clicked(InputEvent event, float x, float y) {
-        Gdx.input.getTextInput(new com.badlogic.gdx.Input.TextInputListener() {
-          @Override
-          public void input(String text) {
-            String sessionName = text.trim().isEmpty() ? menuState.getMyName() + "'s game" : text.trim();
-            JSONObject data = new JSONObject();
-            try {
-              data.put("name", menuState.getMyName());
-              data.put("sessionName", sessionName);
-            } catch (JSONException e) { /* ignore */ }
-            socket.emit("createSession", data);
-          }
-          @Override
-          public void canceled() { /* stay on session list */ }
-        }, "New game", "", "Enter game name (optional)");
+        inSessionCreate = true;
+        show();
       }
     });
 
     menuStage.addActor(createBtn);
+    Gdx.input.setInputProcessor(menuStage);
+  }
+
+  private void showSessionCreateScreen() {
+    float cx = MyGdxGame.WIDTH / 2f;
+
+    Label title = new Label("New game", MyGdxGame.skin);
+    title.setPosition(cx - title.getWidth() / 2f, 0.75f * MyGdxGame.HEIGHT);
+    menuStage.addActor(title);
+
+    // Button that shows the current game name and opens a native dialog to edit it
+    final String nameDisplay = pendingSessionName.isEmpty() ? "Set name (optional)" : pendingSessionName;
+    final TextButton gameNameBtn = new TextButton(nameDisplay, MyGdxGame.skin);
+    gameNameBtn.setSize(button.getWidth() * 2, button.getHeight());
+    gameNameBtn.setPosition(cx - gameNameBtn.getWidth() / 2f, 0.55f * MyGdxGame.HEIGHT);
+    gameNameBtn.addListener(new ClickListener() {
+      @Override
+      public void clicked(InputEvent event, float x, float y) {
+        Gdx.input.getTextInput(new com.badlogic.gdx.Input.TextInputListener() {
+          @Override
+          public void input(String text) {
+            pendingSessionName = text.trim();
+            Gdx.app.postRunnable(new Runnable() {
+              @Override public void run() { show(); }
+            });
+          }
+          @Override public void canceled() { /* keep current name */ }
+        }, "New game", pendingSessionName, "Enter game name (optional)");
+      }
+    });
+    menuStage.addActor(gameNameBtn);
+
+    // Checkbox: allow starting hero selection
+    final CheckBox heroCheckbox = new CheckBox(" Allow starting hero", MyGdxGame.skin);
+    heroCheckbox.setChecked(sessionAllowHeroSelection);
+    heroCheckbox.pack();
+    heroCheckbox.setPosition(cx - heroCheckbox.getWidth() / 2f, 0.42f * MyGdxGame.HEIGHT);
+    menuStage.addActor(heroCheckbox);
+
+    // Create button
+    TextButton confirmCreateBtn = new TextButton("Create", MyGdxGame.skin);
+    confirmCreateBtn.setSize(button.getWidth(), button.getHeight());
+    confirmCreateBtn.setPosition(cx - confirmCreateBtn.getWidth() / 2f, 0.28f * MyGdxGame.HEIGHT);
+    confirmCreateBtn.addListener(new ClickListener() {
+      @Override
+      public void clicked(InputEvent event, float x, float y) {
+        String sessionName = pendingSessionName.isEmpty()
+            ? menuState.getMyName() + "'s game" : pendingSessionName;
+        sessionAllowHeroSelection = heroCheckbox.isChecked();
+        JSONObject data = new JSONObject();
+        try {
+          data.put("name", menuState.getMyName());
+          data.put("sessionName", sessionName);
+          data.put("allowHeroSelection", sessionAllowHeroSelection);
+        } catch (JSONException e) { /* ignore */ }
+        socket.emit("createSession", data);
+        pendingSessionName = "";
+        inSessionCreate = false;
+      }
+    });
+    menuStage.addActor(confirmCreateBtn);
+
+    // Back button
+    TextButton backBtn = new TextButton("Back", MyGdxGame.skin);
+    backBtn.setPosition(10, MyGdxGame.HEIGHT - backBtn.getHeight() - 10);
+    backBtn.addListener(new ClickListener() {
+      @Override
+      public void clicked(InputEvent event, float x, float y) {
+        inSessionCreate = false;
+        show();
+      }
+    });
+    menuStage.addActor(backBtn);
+
     Gdx.input.setInputProcessor(menuStage);
   }
 
@@ -432,13 +504,15 @@ public class MenuScreen extends AbstractScreen {
       menuStage.addActor(timerLabel);
 
       // Rebuild hero dropdown excluding heroes reserved by other lobby players.
-      refreshHeroDropdown();
+      if (sessionAllowHeroSelection) {
+        refreshHeroDropdown();
 
-      // Add hero selector directly to stage so popup coordinates work correctly
-      Label heroLabel = new Label("Starting hero:", MyGdxGame.skin);
-      heroLabel.setPosition(heroSelectBox.getX(), heroSelectBox.getY() + heroSelectBox.getHeight() + 4);
-      menuStage.addActor(heroLabel);
-      menuStage.addActor(heroSelectBox);
+        // Add hero selector directly to stage so popup coordinates work correctly
+        Label heroLabel = new Label("Starting hero:", MyGdxGame.skin);
+        heroLabel.setPosition(heroSelectBox.getX(), heroSelectBox.getY() + heroSelectBox.getHeight() + 4);
+        menuStage.addActor(heroLabel);
+        menuStage.addActor(heroSelectBox);
+      }
       menuStage.addActor(button);
     }
 
@@ -765,9 +839,13 @@ public class MenuScreen extends AbstractScreen {
     socket.on("sessionJoined", new SocketListener() {
       @Override
       public void call(Object... args) {
+        final JSONObject data = (JSONObject) args[0];
         Gdx.app.postRunnable(new Runnable() {
           @Override
           public void run() {
+            try {
+              sessionAllowHeroSelection = data.optBoolean("allowHeroSelection", true);
+            } catch (Exception e) { /* keep default */ }
             lobbyJoined = true;
             updateScreen = true;
           }

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -19,7 +19,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.SelectBox;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
-import com.badlogic.gdx.Input;
+import com.badlogic.gdx.scenes.scene2d.ui.TextField;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
@@ -54,6 +54,22 @@ public class MenuScreen extends AbstractScreen {
 
   // Whether the player has entered a name and joined the lobby.
   private boolean lobbyJoined = false;
+
+  // Whether the player has entered a name and reached the session-list screen
+  private boolean nameConfirmed = false;
+
+  // The session list received from the server
+  private java.util.List<SessionInfo> sessionList = new java.util.ArrayList<SessionInfo>();
+
+  private static class SessionInfo {
+    String id;
+    String name;
+    int playerCount;
+    boolean running;
+    SessionInfo(String id, String name, int playerCount, boolean running) {
+      this.id = id; this.name = name; this.playerCount = playerCount; this.running = running;
+    }
+  }
 
   // Hero names in display order — used to rebuild the dropdown while preserving order.
   private static final String[] ALL_HERO_NAMES = {
@@ -185,43 +201,132 @@ public class MenuScreen extends AbstractScreen {
 
     menuStage.addActor(group);
 
-    if (!lobbyJoined) {
+    if (!nameConfirmed) {
       showNameEntryScreen();
+    } else if (!lobbyJoined) {
+      showSessionListScreen();
     } else {
       showLobbyScreen();
     }
   }
 
   private void showNameEntryScreen() {
-    TextButton enterNameButton = new TextButton("Enter your name", MyGdxGame.skin);
-    enterNameButton.setSize(button.getWidth(), button.getHeight());
-    enterNameButton.setPosition((MyGdxGame.WIDTH - enterNameButton.getWidth()) / 2f, 0.45f * MyGdxGame.HEIGHT);
-    enterNameButton.addListener(new ClickListener() {
+    float cx = MyGdxGame.WIDTH / 2f;
+    float cy = MyGdxGame.HEIGHT / 2f;
+
+    final TextField nameField = new TextField("", MyGdxGame.skin);
+    nameField.setMessageText("Enter your name");
+    nameField.setMaxLength(20);
+    nameField.setSize(button.getWidth() * 2, button.getHeight());
+    nameField.setPosition(cx - nameField.getWidth() / 2f, cy);
+    menuStage.setKeyboardFocus(nameField);
+
+    TextButton confirmBtn = new TextButton("Play", MyGdxGame.skin);
+    confirmBtn.setSize(button.getWidth(), button.getHeight());
+    confirmBtn.setPosition(cx - confirmBtn.getWidth() / 2f, cy - confirmBtn.getHeight() * 1.5f);
+    confirmBtn.addListener(new ClickListener() {
       @Override
       public void clicked(InputEvent event, float x, float y) {
-        Gdx.input.getTextInput(new Input.TextInputListener() {
-          @Override
-          public void input(String text) {
-            String name = text.trim();
-            if (name.isEmpty()) {
-              showNameEntryScreen();
-              return;
-            }
-            menuState.setMyName(name);
-            lobbyJoined = true;
-            socket.emit("joinLobby", name);
-            show();
-          }
-          @Override
-          public void canceled() {
-            // Stay on name entry screen
-          }
-        }, "Baisch", "", "Enter your name");
+        String name = nameField.getText().trim();
+        if (name.isEmpty()) return;
+        menuState.setMyName(name);
+        nameConfirmed = true;
+        show();
       }
     });
 
-    menuStage.addActor(enterNameButton);
+    menuStage.addActor(nameField);
+    menuStage.addActor(confirmBtn);
     Gdx.input.setInputProcessor(menuStage);
+  }
+
+  private void showSessionListScreen() {
+    float cx = MyGdxGame.WIDTH / 2f;
+
+    Label title = new Label("Games", MyGdxGame.skin);
+    title.setPosition(cx - title.getWidth() / 2f, 0.75f * MyGdxGame.HEIGHT);
+    menuStage.addActor(title);
+
+    Table sessTable = new Table(MyGdxGame.skin);
+    Label h1 = new Label("Name", MyGdxGame.skin);
+    Label h2 = new Label("Players", MyGdxGame.skin);
+    Label h3 = new Label("", MyGdxGame.skin);
+    sessTable.add(h1).padRight(20);
+    sessTable.add(h2).padRight(20);
+    sessTable.add(h3);
+    sessTable.row();
+
+    final java.util.List<SessionInfo> list = new java.util.ArrayList<SessionInfo>(sessionList);
+    for (final SessionInfo s : list) {
+      Label nameL = new Label(s.name, MyGdxGame.skin);
+      Label countL = new Label(s.playerCount + "/4", MyGdxGame.skin);
+      if (s.running) {
+        Label runL = new Label("Playing", MyGdxGame.skin);
+        runL.setColor(Color.YELLOW);
+        TextButton watchBtn = new TextButton("Watch", MyGdxGame.skin);
+        watchBtn.addListener(new ClickListener() {
+          @Override
+          public void clicked(InputEvent event, float x, float y) {
+            socket.emit("joinSessionSpectator", buildJoinData(s.id));
+          }
+        });
+        sessTable.add(nameL).padRight(20);
+        sessTable.add(countL).padRight(20);
+        sessTable.add(watchBtn);
+      } else {
+        TextButton joinBtn = new TextButton("Join", MyGdxGame.skin);
+        joinBtn.addListener(new ClickListener() {
+          @Override
+          public void clicked(InputEvent event, float x, float y) {
+            socket.emit("joinSession", buildJoinData(s.id));
+          }
+        });
+        sessTable.add(nameL).padRight(20);
+        sessTable.add(countL).padRight(20);
+        sessTable.add(joinBtn);
+      }
+      sessTable.row();
+    }
+
+    sessTable.setPosition(cx - 150, 0.35f * MyGdxGame.HEIGHT);
+    menuStage.addActor(sessTable);
+
+    // Create new game row
+    final TextField gameNameField = new TextField("", MyGdxGame.skin);
+    gameNameField.setMessageText("Game name");
+    gameNameField.setMaxLength(40);
+    gameNameField.setSize(button.getWidth() * 2, button.getHeight());
+    gameNameField.setPosition(cx - gameNameField.getWidth() / 2f - button.getWidth() * 0.6f, 0.15f * MyGdxGame.HEIGHT);
+
+    TextButton createBtn = new TextButton("Create", MyGdxGame.skin);
+    createBtn.setSize(button.getWidth(), button.getHeight());
+    createBtn.setPosition(cx + gameNameField.getWidth() / 2f - button.getWidth() * 0.1f, 0.15f * MyGdxGame.HEIGHT);
+    createBtn.addListener(new ClickListener() {
+      @Override
+      public void clicked(InputEvent event, float x, float y) {
+        String rawName = gameNameField.getText().trim();
+        String sessionName = rawName.isEmpty() ? menuState.getMyName() + "'s game" : rawName;
+        JSONObject data = new JSONObject();
+        try {
+          data.put("name", menuState.getMyName());
+          data.put("sessionName", sessionName);
+        } catch (JSONException e) { /* ignore */ }
+        socket.emit("createSession", data);
+      }
+    });
+
+    menuStage.addActor(gameNameField);
+    menuStage.addActor(createBtn);
+    Gdx.input.setInputProcessor(menuStage);
+  }
+
+  private JSONObject buildJoinData(String sessionId) {
+    JSONObject data = new JSONObject();
+    try {
+      data.put("sessionId", sessionId);
+      data.put("name", menuState.getMyName());
+    } catch (JSONException e) { /* ignore */ }
+    return data;
   }
 
   private void showLobbyScreen() {
@@ -234,9 +339,7 @@ public class MenuScreen extends AbstractScreen {
     ArrayList<User> loggedInUsers = menuState.getUsers();
 
     Label headLine1 = new Label("Name", MyGdxGame.skin);
-    headLine1.setFontScale(1.2f);
     Label headLine2 = new Label("Status", MyGdxGame.skin);
-    headLine2.setFontScale(1.2f);
 
     loggedInUserTable.add(headLine1);
     loggedInUserTable.add(headLine2);
@@ -338,6 +441,23 @@ public class MenuScreen extends AbstractScreen {
 
     menuStage.addActor(loggedInUserTable);
     menuStage.addActor(loggedInCount);
+
+    // Leave session — returns to session list
+    TextButton leaveBtn = new TextButton("Leave", MyGdxGame.skin);
+    leaveBtn.setPosition(10, MyGdxGame.HEIGHT - leaveBtn.getHeight() - 10);
+    leaveBtn.addListener(new ClickListener() {
+      @Override
+      public void clicked(InputEvent event, float x, float y) {
+        lobbyJoined = false;
+        timerStarted = false;
+        gameRunning = false;
+        menuState.clearUsers();
+        reservedByOthers.clear();
+        show();
+      }
+    });
+    menuStage.addActor(leaveBtn);
+
     Gdx.input.setInputProcessor(menuStage);
   }
 
@@ -602,7 +722,63 @@ public class MenuScreen extends AbstractScreen {
           public void run() {
             timerStarted = false;
             gameRunning = false;
+            lobbyJoined = false;
+            menuState.clearUsers();
+            reservedByOthers.clear();
             game.setScreen(MenuScreen.this);
+          }
+        });
+      }
+    });
+
+    socket.on("sessionList", new SocketListener() {
+      @Override
+      public void call(Object... args) {
+        final JSONArray arr = (JSONArray) args[0];
+        Gdx.app.postRunnable(new Runnable() {
+          @Override
+          public void run() {
+            sessionList.clear();
+            try {
+              for (int i = 0; i < arr.length(); i++) {
+                JSONObject o = arr.getJSONObject(i);
+                sessionList.add(new SessionInfo(
+                  o.getString("id"),
+                  o.getString("name"),
+                  o.getInt("playerCount"),
+                  o.getBoolean("running")
+                ));
+              }
+            } catch (JSONException e) {
+              Gdx.app.log("SocketIO", "Error parsing sessionList");
+            }
+            if (!lobbyJoined) updateScreen = true;
+          }
+        });
+      }
+    });
+
+    socket.on("sessionJoined", new SocketListener() {
+      @Override
+      public void call(Object... args) {
+        Gdx.app.postRunnable(new Runnable() {
+          @Override
+          public void run() {
+            lobbyJoined = true;
+            updateScreen = true;
+          }
+        });
+      }
+    });
+
+    socket.on("sessionNotFound", new SocketListener() {
+      @Override
+      public void call(Object... args) {
+        Gdx.app.postRunnable(new Runnable() {
+          @Override
+          public void run() {
+            // Session was removed between list refresh and join — just refresh
+            updateScreen = true;
           }
         });
       }

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -212,19 +212,13 @@ public class MenuScreen extends AbstractScreen {
   private void showNameEntryScreen() {
     float cx = MyGdxGame.WIDTH / 2f;
 
-    // Display the current name (or a placeholder) so the player can see what they typed.
-    String displayName = menuState.getMyName().isEmpty() ? "- tap to enter -" : menuState.getMyName();
-    final Label nameDisplayLabel = new Label(displayName, MyGdxGame.skin);
-    nameDisplayLabel.setPosition(cx - nameDisplayLabel.getWidth() / 2f, 0.35f * MyGdxGame.HEIGHT);
-    menuStage.addActor(nameDisplayLabel);
-
     // A button-shaped area that opens the native text dialog on click/tap.
     // getTextInput() is called synchronously from the DOM click event inside GWT,
-    // so the mobile keyboard always opens — unlike setOnscreenKeyboardVisible which
-    // is rejected by browsers that require focus() to originate from a touchstart.
-    TextButton enterNameButton = new TextButton("Enter your name", MyGdxGame.skin);
+    // so the mobile keyboard always opens.
+    String label = menuState.getMyName().isEmpty() ? "Enter your name" : menuState.getMyName();
+    TextButton enterNameButton = new TextButton(label, MyGdxGame.skin);
     enterNameButton.setSize(button.getWidth() * 2, button.getHeight());
-    enterNameButton.setPosition(cx - enterNameButton.getWidth() / 2f, 0.25f * MyGdxGame.HEIGHT);
+    enterNameButton.setPosition(cx - enterNameButton.getWidth() / 2f, 0.3f * MyGdxGame.HEIGHT);
     enterNameButton.addListener(new ClickListener() {
       @Override
       public void clicked(InputEvent event, float x, float y) {

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -19,7 +19,6 @@ import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.SelectBox;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
-import com.badlogic.gdx.scenes.scene2d.ui.TextField;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
@@ -213,37 +212,40 @@ public class MenuScreen extends AbstractScreen {
   private void showNameEntryScreen() {
     float cx = MyGdxGame.WIDTH / 2f;
 
-    final TextField nameField = new TextField("", MyGdxGame.skin);
-    nameField.setMessageText("Enter your name");
-    nameField.setMaxLength(20);
-    nameField.setSize(button.getWidth() * 2, button.getHeight());
-    nameField.setPosition(cx - nameField.getWidth() / 2f, 0.3f * MyGdxGame.HEIGHT);
-    // Mobile browsers only open the keyboard from a touchstart (touchDown), not touchend.
-    nameField.addListener(new com.badlogic.gdx.scenes.scene2d.InputListener() {
-      @Override
-      public boolean touchDown(InputEvent event, float x, float y, int pointer, int btn) {
-        menuStage.setKeyboardFocus(nameField);
-        Gdx.input.setOnscreenKeyboardVisible(true);
-        return false;
-      }
-    });
+    // Display the current name (or a placeholder) so the player can see what they typed.
+    String displayName = menuState.getMyName().isEmpty() ? "- tap to enter -" : menuState.getMyName();
+    final Label nameDisplayLabel = new Label(displayName, MyGdxGame.skin);
+    nameDisplayLabel.setPosition(cx - nameDisplayLabel.getWidth() / 2f, 0.35f * MyGdxGame.HEIGHT);
+    menuStage.addActor(nameDisplayLabel);
 
-    TextButton confirmBtn = new TextButton("Play", MyGdxGame.skin);
-    confirmBtn.setSize(button.getWidth(), button.getHeight());
-    confirmBtn.setPosition(cx - confirmBtn.getWidth() / 2f, 0.3f * MyGdxGame.HEIGHT - confirmBtn.getHeight() * 1.5f);
-    confirmBtn.addListener(new ClickListener() {
+    // A button-shaped area that opens the native text dialog on click/tap.
+    // getTextInput() is called synchronously from the DOM click event inside GWT,
+    // so the mobile keyboard always opens — unlike setOnscreenKeyboardVisible which
+    // is rejected by browsers that require focus() to originate from a touchstart.
+    TextButton enterNameButton = new TextButton("Enter your name", MyGdxGame.skin);
+    enterNameButton.setSize(button.getWidth() * 2, button.getHeight());
+    enterNameButton.setPosition(cx - enterNameButton.getWidth() / 2f, 0.25f * MyGdxGame.HEIGHT);
+    enterNameButton.addListener(new ClickListener() {
       @Override
       public void clicked(InputEvent event, float x, float y) {
-        String name = nameField.getText().trim();
-        if (name.isEmpty()) return;
-        menuState.setMyName(name);
-        nameConfirmed = true;
-        show();
+        Gdx.input.getTextInput(new com.badlogic.gdx.Input.TextInputListener() {
+          @Override
+          public void input(String text) {
+            String name = text.trim();
+            if (name.isEmpty()) return;
+            menuState.setMyName(name);
+            nameConfirmed = true;
+            Gdx.app.postRunnable(new Runnable() {
+              @Override public void run() { show(); }
+            });
+          }
+          @Override
+          public void canceled() { /* stay on name entry screen */ }
+        }, "Baisch", menuState.getMyName(), "Enter your name");
       }
     });
 
-    menuStage.addActor(nameField);
-    menuStage.addActor(confirmBtn);
+    menuStage.addActor(enterNameButton);
     Gdx.input.setInputProcessor(menuStage);
   }
 

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -63,7 +63,7 @@ public class MenuScreen extends AbstractScreen {
   // Pending game name typed on the create screen (cleared after creation)
   private String pendingSessionName = "";
   // Whether hero selection is allowed in the current session
-  private boolean sessionAllowHeroSelection = true;
+  private boolean sessionAllowHeroSelection = false;
 
   // The session list received from the server
   private java.util.List<SessionInfo> sessionList = new java.util.ArrayList<SessionInfo>();
@@ -182,6 +182,8 @@ public class MenuScreen extends AbstractScreen {
    */
   private void refreshHeroDropdown() {
     String currentSelected = heroSelectBox.getSelected();
+    // Treat null (empty SelectBox) the same as "None" so we don't wipe startingHero.
+    if (currentSelected == null) currentSelected = "None";
     Array<String> items = new Array<String>();
     items.add("None");
     for (int i = 0; i < ALL_HERO_NAMES.length; i++) {
@@ -192,11 +194,14 @@ public class MenuScreen extends AbstractScreen {
     updatingDropdown = true;
     heroSelectBox.setItems(items);
     // Keep the previous selection if it is still available; otherwise fall back to "None".
-    if (currentSelected != null && !reservedByOthers.contains(currentSelected)) {
+    if (!currentSelected.equals("None") && !reservedByOthers.contains(currentSelected)) {
       heroSelectBox.setSelected(currentSelected);
-    } else {
+    } else if (!currentSelected.equals("None")) {
+      // Hero was reserved by another player — reset.
       heroSelectBox.setSelected("None");
       menuState.setStartingHero("None");
+    } else {
+      heroSelectBox.setSelected("None");
     }
     updatingDropdown = false;
   }
@@ -323,15 +328,17 @@ public class MenuScreen extends AbstractScreen {
   private void showSessionCreateScreen() {
     float cx = MyGdxGame.WIDTH / 2f;
 
+    // All elements must sit below the logo (logo bottom ≈ 0.9*H - logoHeight ≈ 449px on a
+    // 800px-high screen). Use the lower half of the display for all create-screen widgets.
     Label title = new Label("New game", MyGdxGame.skin);
-    title.setPosition(cx - title.getWidth() / 2f, 0.75f * MyGdxGame.HEIGHT);
+    title.setPosition(cx - title.getWidth() / 2f, 0.50f * MyGdxGame.HEIGHT);
     menuStage.addActor(title);
 
     // Button that shows the current game name and opens a native dialog to edit it
     final String nameDisplay = pendingSessionName.isEmpty() ? "Set name (optional)" : pendingSessionName;
     final TextButton gameNameBtn = new TextButton(nameDisplay, MyGdxGame.skin);
     gameNameBtn.setSize(button.getWidth() * 2, button.getHeight());
-    gameNameBtn.setPosition(cx - gameNameBtn.getWidth() / 2f, 0.55f * MyGdxGame.HEIGHT);
+    gameNameBtn.setPosition(cx - gameNameBtn.getWidth() / 2f, 0.38f * MyGdxGame.HEIGHT);
     gameNameBtn.addListener(new ClickListener() {
       @Override
       public void clicked(InputEvent event, float x, float y) {
@@ -353,13 +360,13 @@ public class MenuScreen extends AbstractScreen {
     final CheckBox heroCheckbox = new CheckBox(" Allow starting hero", MyGdxGame.skin);
     heroCheckbox.setChecked(sessionAllowHeroSelection);
     heroCheckbox.pack();
-    heroCheckbox.setPosition(cx - heroCheckbox.getWidth() / 2f, 0.42f * MyGdxGame.HEIGHT);
+    heroCheckbox.setPosition(cx - heroCheckbox.getWidth() / 2f, 0.26f * MyGdxGame.HEIGHT);
     menuStage.addActor(heroCheckbox);
 
     // Create button
     TextButton confirmCreateBtn = new TextButton("Create", MyGdxGame.skin);
     confirmCreateBtn.setSize(button.getWidth(), button.getHeight());
-    confirmCreateBtn.setPosition(cx - confirmCreateBtn.getWidth() / 2f, 0.28f * MyGdxGame.HEIGHT);
+    confirmCreateBtn.setPosition(cx - confirmCreateBtn.getWidth() / 2f, 0.14f * MyGdxGame.HEIGHT);
     confirmCreateBtn.addListener(new ClickListener() {
       @Override
       public void clicked(InputEvent event, float x, float y) {
@@ -512,6 +519,9 @@ public class MenuScreen extends AbstractScreen {
         heroLabel.setPosition(heroSelectBox.getX(), heroSelectBox.getY() + heroSelectBox.getHeight() + 4);
         menuStage.addActor(heroLabel);
         menuStage.addActor(heroSelectBox);
+      } else {
+        // No hero selection in this session — clear any stale hero from a previous session.
+        menuState.setStartingHero("None");
       }
       menuStage.addActor(button);
     }

--- a/html/webapp/index.html
+++ b/html/webapp/index.html
@@ -16,6 +16,18 @@
        </body>
 
        <script>
+              // Prevent libGDX's global keydown handler from swallowing backspace
+              // when the user is typing inside a native text input (getTextInput overlay).
+              // useCapture=true ensures this runs before libGDX's bubbling-phase listener.
+              document.addEventListener('keydown', function(e) {
+                if (e.keyCode === 8) { // Backspace
+                  var el = document.activeElement;
+                  if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA')) {
+                    e.stopImmediatePropagation();
+                  }
+                }
+              }, true);
+
               function handleMouseDown(evt) {
                 evt.preventDefault();
                 evt.stopPropagation();

--- a/server/index.js
+++ b/server/index.js
@@ -69,15 +69,17 @@ function checkAndHandleWinner(sess) {
   const winner = sess.gameState.checkWinner();
   if (winner >= 0) {
     sess.winnerHandled = true;
-    console.log("Session " + sess.id + " winner: player " + winner + " — returning to lobby in 5 seconds");
+    console.log("Session " + sess.id + " winner: player " + winner + " — closing session in 5 seconds");
     setTimeout(function() {
-      sess.winnerHandled = false;
-      sess.gameState = null;
-      sess.heroSelections = {};
-      sess.users.forEach(function(u) { u.isReady = false; });
-      io.to(sess.id).emit('returnToLobby');
-      sess.spectators = [];
-      io.to(sess.id).emit('getUsers', sess.users);
+      var sessId = sess.id;
+      // Notify all participants to return to the session list
+      io.to(sessId).emit('returnToLobby');
+      // Remove all socket→session mappings so these sockets are session-less again
+      sess.users.forEach(function(u) { delete socketToSession[u.id]; });
+      sess.spectators.forEach(function(sid) { delete socketToSession[sid]; });
+      if (sess.timer) clearInterval(sess.timer);
+      // Delete the session entirely — it won't appear in the session list anymore
+      delete sessions[sessId];
       broadcastSessionList();
     }, 5000);
   }

--- a/server/index.js
+++ b/server/index.js
@@ -19,34 +19,66 @@ app.get('/', function(req, res, next) {
 
 app.use(require('express').static(path.join(__dirname, 'public')));
 
-
-var users = [];
-var spectators = [];
-var timeToStart;
-var timer;
 var GameState = require('./gameState');
-var gameState = null;
-var winnerHandled = false;
-// Tracks which hero each socket has reserved in the lobby (socketId -> heroName or 'None').
-var heroSelections = {};
 
-function checkAndHandleWinner(io) {
-  if (!gameState || winnerHandled) return;
-  const winner = gameState.checkWinner();
+// ─── Session management ───────────────────────────────────────────────────────
+// sessions: { [sessionId]: { id, name, users[], spectators[], gameState,
+//             heroSelections{}, winnerHandled, timeToStart, timer } }
+var sessions = {};
+// socketToSession: { [socketId]: sessionId } — for O(1) session lookup
+var socketToSession = {};
+var _nextSessionId = 1;
+
+function createSession(name) {
+  var id = 's' + (_nextSessionId++);
+  sessions[id] = {
+    id: id,
+    name: name,
+    users: [],
+    spectators: [],
+    gameState: null,
+    heroSelections: {},
+    winnerHandled: false,
+    timeToStart: 0,
+    timer: null
+  };
+  return sessions[id];
+}
+
+function getSession(socketId) {
+  var sid = socketToSession[socketId];
+  return sid ? sessions[sid] : null;
+}
+
+function getSessionList() {
+  return Object.values(sessions).map(function(s) {
+    return { id: s.id, name: s.name, playerCount: s.users.length, running: s.gameState !== null };
+  });
+}
+
+function broadcastSessionList() {
+  io.emit('sessionList', getSessionList());
+}
+
+function makeUser(id, name) {
+  return { id: id, name: name || 'Player', isReady: false };
+}
+
+function checkAndHandleWinner(sess) {
+  if (!sess.gameState || sess.winnerHandled) return;
+  const winner = sess.gameState.checkWinner();
   if (winner >= 0) {
-    winnerHandled = true;
-    console.log("Winner found: player " + winner + " — returning to lobby in 5 seconds");
-    // stateUpdate with winnerIndex already broadcast by the caller; schedule return to lobby
+    sess.winnerHandled = true;
+    console.log("Session " + sess.id + " winner: player " + winner + " — returning to lobby in 5 seconds");
     setTimeout(function() {
-      winnerHandled = false;
-      gameState = null;
-      // Return all players and spectators to the lobby
-      users.forEach(function(u) { io.to(u.id).emit('returnToLobby'); });
-      spectators.forEach(function(sid) { io.to(sid).emit('returnToLobby'); });
-      spectators = [];
-      // Reset ready states so next game requires a fresh ready-up
-      users.forEach(function(u) { u.isReady = false; });
-      io.emit('getUsers', users);
+      sess.winnerHandled = false;
+      sess.gameState = null;
+      sess.heroSelections = {};
+      sess.users.forEach(function(u) { u.isReady = false; });
+      io.to(sess.id).emit('returnToLobby');
+      sess.spectators = [];
+      io.to(sess.id).emit('getUsers', sess.users);
+      broadcastSessionList();
     }, 5000);
   }
 }
@@ -57,340 +89,414 @@ server.listen(PORT, function() {
 });
 
 io.on('connection', function(socket) {
-  console.log("User Connected");
+  console.log("User Connected: " + socket.id);
   socket.emit('socketID', { id: socket.id });
-  socket.broadcast.emit('newUser', { id: socket.id });
-  // Inform the new client whether a game is already in progress
-  socket.emit('gameStatus', { running: gameState !== null });
+  socket.emit('sessionList', getSessionList());
 
   socket.on('disconnect', function() {
-    console.log("User Disconnected");
-    socket.broadcast.emit('userDisconnected', { id:socket.id } );
-    // Release any lobby hero reservation so other players can pick it.
-    if (heroSelections[socket.id] && heroSelections[socket.id] !== 'None') {
-      socket.broadcast.emit('heroReleased', { heroName: heroSelections[socket.id] });
-    }
-    delete heroSelections[socket.id];
-    for (var i = 0; i < users.length; i++) {
-      if (users[i].id == socket.id) {
-        users.splice(i, 1);
+    console.log("User Disconnected: " + socket.id);
+    var sess = getSession(socket.id);
+    if (sess) {
+      // Release any lobby hero reservation so other session members can pick it.
+      var hero = sess.heroSelections[socket.id];
+      if (hero && hero !== 'None') {
+        socket.to(sess.id).emit('heroReleased', { heroName: hero });
       }
+      delete sess.heroSelections[socket.id];
+      // Remove from users
+      var userIdx = sess.users.findIndex(function(u) { return u.id === socket.id; });
+      if (userIdx !== -1) sess.users.splice(userIdx, 1);
+      // Remove from spectators if present
+      var specIdx = sess.spectators.indexOf(socket.id);
+      if (specIdx !== -1) sess.spectators.splice(specIdx, 1);
+      // Notify remaining session members
+      io.to(sess.id).emit('userDisconnected', { id: socket.id });
+      io.to(sess.id).emit('getUsers', sess.users);
+      // Clean up empty session
+      if (sess.users.length === 0 && sess.spectators.length === 0) {
+        if (sess.timer) clearInterval(sess.timer);
+        delete sessions[sess.id];
+        console.log("Session " + sess.id + " deleted (empty)");
+      }
+      delete socketToSession[socket.id];
+      broadcastSessionList();
     }
-    // Also remove from spectators if present
-    var specIdx = spectators.indexOf(socket.id);
-    if (specIdx !== -1) spectators.splice(specIdx, 1);
-    socket.broadcast.emit('getUsers', users);
   });
 
+  // ── Session management events ────────────────────────────────────────────
+
+  socket.on('createSession', function(data) {
+    var name = (data && data.name) ? String(data.name).slice(0, 30) : 'Player';
+    var sessionName = (data && data.sessionName) ? String(data.sessionName).slice(0, 50) : name + "'s game";
+    var sess = createSession(sessionName);
+    sess.users.push(makeUser(socket.id, name));
+    socketToSession[socket.id] = sess.id;
+    socket.join(sess.id);
+    console.log("Session created: " + sess.id + " '" + sess.name + "' by " + name);
+    socket.emit('sessionJoined', { sessionId: sess.id });
+    io.to(sess.id).emit('getUsers', sess.users);
+    socket.emit('gameStatus', { running: false });
+    broadcastSessionList();
+  });
+
+  socket.on('joinSession', function(data) {
+    if (!data || !data.sessionId) return;
+    var sess = sessions[data.sessionId];
+    if (!sess) { socket.emit('sessionNotFound'); return; }
+    if (sess.gameState !== null) { socket.emit('gameStatus', { running: true }); return; }
+    var name = (data.name) ? String(data.name).slice(0, 30) : 'Player';
+    var existing = sess.users.find(function(u) { return u.id === socket.id; });
+    if (!existing) sess.users.push(makeUser(socket.id, name));
+    socketToSession[socket.id] = sess.id;
+    socket.join(sess.id);
+    console.log("User " + name + " joined session " + sess.id);
+    // Send existing hero reservations to the new joiner
+    Object.keys(sess.heroSelections).forEach(function(sid) {
+      var h = sess.heroSelections[sid];
+      if (h && h !== 'None' && sid !== socket.id) {
+        socket.emit('heroReserved', { heroName: h });
+      }
+    });
+    socket.emit('sessionJoined', { sessionId: sess.id });
+    io.to(sess.id).emit('getUsers', sess.users);
+    socket.emit('gameStatus', { running: false });
+    broadcastSessionList();
+  });
+
+  socket.on('joinSessionSpectator', function(data) {
+    if (!data || !data.sessionId) return;
+    var sess = sessions[data.sessionId];
+    if (!sess || !sess.gameState) { socket.emit('gameStatus', { running: false }); return; }
+    console.log("Spectator joined session " + sess.id + ": " + socket.id);
+    if (sess.spectators.indexOf(socket.id) === -1) sess.spectators.push(socket.id);
+    socketToSession[socket.id] = sess.id;
+    socket.join(sess.id);
+    socket.emit('sessionJoined', { sessionId: sess.id });
+    socket.emit('gameState', { playerIndex: -1, gameState: sess.gameState.serialize() });
+  });
+
+  // ── Lobby events ─────────────────────────────────────────────────────────
+
   socket.on('setUserReady', function(id) {
-    console.log("Set User Ready" + id);
-    //socket.emit('userReady', { id:socket.id } );
-    //socket.broadcast.emit('userReady', { id:socket.id } );
-    for (var i = 0; i < users.length; i++) {
-      if (users[i].id == id) {
-        if (users[i].isReady == false) {
-          users[i].isReady = true;
+    var sess = getSession(socket.id);
+    if (!sess) return;
+    console.log("Set User Ready: " + id);
+    for (var i = 0; i < sess.users.length; i++) {
+      if (sess.users[i].id === id) {
+        if (sess.users[i].isReady === false) {
+          sess.users[i].isReady = true;
         } else {
-          users[i].isReady = false;
-          clearInterval(timer);
+          sess.users[i].isReady = false;
+          clearInterval(sess.timer);
         }
       }
     }
-    socket.emit('getUsers', users);
-    socket.broadcast.emit('getUsers', users);
+    io.to(sess.id).emit('getUsers', sess.users);
   });
   
   socket.on('startTimer', function(seconds) {
-    console.log("Start Timer");
-    if (gameState !== null) {
+    var sess = getSession(socket.id);
+    if (!sess) return;
+    console.log("Start Timer for session " + sess.id);
+    if (sess.gameState !== null) {
       console.log("Game already running — rejecting startTimer");
       socket.emit('gameAlreadyRunning');
       return;
     }
-    if (users.length < 2) {
+    if (sess.users.length < 2) {
       console.log("Not enough players to start (need at least 2)");
       return;
     }
-    timeToStart = seconds;
-    clearInterval(timer);
-    timer = setInterval(function() {
-      timeToStart--;
-      socket.emit('updateTimer', { seconds: timeToStart });
-      socket.broadcast.emit('updateTimer', { seconds: timeToStart });
-      console.log("Seconds left ... " + timeToStart)
-      if (timeToStart == 0) {
-        console.log("Timer finished, broadcast to users");
-        winnerHandled = false;
-        gameState = new GameState(users);
-        users.forEach((user, idx) => {
-          io.to(user.id).emit('gameState', {
+    sess.timeToStart = seconds;
+    clearInterval(sess.timer);
+    sess.timer = setInterval(function() {
+      sess.timeToStart--;
+      io.to(sess.id).emit('updateTimer', { seconds: sess.timeToStart });
+      console.log("Session " + sess.id + " seconds left: " + sess.timeToStart);
+      if (sess.timeToStart === 0) {
+        console.log("Timer finished for session " + sess.id + ", starting game");
+        sess.winnerHandled = false;
+        sess.gameState = new GameState(sess.users);
+        sess.users.forEach(function(u, idx) {
+          io.to(u.id).emit('gameState', {
             playerIndex: idx,
-            gameState: gameState.serialize()
+            gameState: sess.gameState.serialize()
           });
         });
-        clearInterval(timer);
+        clearInterval(sess.timer);
+        broadcastSessionList();
       }
     }, 1000);
   });
-  
-  socket.on('stopTimer', function(none) {
-    if (timeToStart <= 0) {
-      console.log("Timer stopped!");
-      clearInterval(timer);
+
+  socket.on('stopTimer', function() {
+    var sess = getSession(socket.id);
+    if (!sess) return;
+    if (sess.timeToStart <= 0) {
+      console.log("Timer stopped for session " + sess.id);
+      clearInterval(sess.timer);
     }
   });
 
-  // Client requests full state resync — used when a tab was inactive during initialization
-  // and may have missed stateUpdate events before its GameScreen was fully set up.
+  // Client requests full state resync
   socket.on('requestStateSync', function() {
-    if (gameState) {
-      socket.emit('stateUpdate', gameState.serialize());
+    var sess = getSession(socket.id);
+    if (sess && sess.gameState) {
+      socket.emit('stateUpdate', sess.gameState.serialize());
     }
   });
 
   socket.on('finishTurn', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
     console.log("Turn finished by player index: " + data.currentPlayerIndex);
-    // Guard: only advance if the requesting client agrees on who the current player is.
-    // Rejects stale or duplicate finishTurn events from desynced clients.
-    if (data.currentPlayerIndex !== gameState.currentPlayerIndex) {
-      console.log("finishTurn rejected: server currentPlayerIndex=" + gameState.currentPlayerIndex + ", client sent=" + data.currentPlayerIndex);
+    if (data.currentPlayerIndex !== sess.gameState.currentPlayerIndex) {
+      console.log("finishTurn rejected: server currentPlayerIndex=" + sess.gameState.currentPlayerIndex + ", client sent=" + data.currentPlayerIndex);
       return;
     }
-    gameState.finishTurn();
-    io.emit('stateUpdate', gameState.serialize());
+    sess.gameState.finishTurn();
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
   socket.on('putDefCard', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
     console.log("putDefCard: playerIdx=" + data.playerIdx + " pos=" + data.positionId + " cardId=" + data.cardId);
-    gameState.putDefCard(data.playerIdx, data.positionId, data.cardId);
-    io.emit('stateUpdate', gameState.serialize());
+    sess.gameState.putDefCard(data.playerIdx, data.positionId, data.cardId);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
   socket.on('takeDefCard', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
     console.log("takeDefCard: playerIdx=" + data.playerIdx + " pos=" + data.positionId);
-    gameState.takeDefCard(data.playerIdx, data.positionId);
-    io.emit('stateUpdate', gameState.serialize());
+    sess.gameState.takeDefCard(data.playerIdx, data.positionId);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
   socket.on('addToCemetery', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
     console.log("addToCemetery: playerIdx=" + data.playerIdx + " cardIds=" + data.cardIds + " draw=" + data.drawFromDeck);
-    gameState.addToCemetery(data.playerIdx, data.cardIds || [], data.drawFromDeck || 0);
-    io.emit('stateUpdate', gameState.serialize());
+    sess.gameState.addToCemetery(data.playerIdx, data.cardIds || [], data.drawFromDeck || 0);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
   socket.on('discardDefCards', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
     console.log("discardDefCards: playerIdx=" + data.playerIdx);
-    gameState.discardDefCards(data.playerIdx, data.slots || []);
-    io.emit('stateUpdate', gameState.serialize());
+    sess.gameState.discardDefCards(data.playerIdx, data.slots || []);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
   socket.on('plunderPreview', function(data) {
-    if (!gameState) return;
-    gameState.setPlunderPreview(data);
-    io.emit('stateUpdate', gameState.serialize());
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
+    sess.gameState.setPlunderPreview(data);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
   socket.on('plunderResolved', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
     console.log("plunderResolved: attackerIdx=" + data.attackerIdx + " deckIndex=" + data.deckIndex + " success=" + data.success);
-    gameState.plunderResolved(data.attackerIdx, data.deckIndex, data.success, data.attackCardIds || [], data.kingUsed || false, data.attackerOwnDefCardIds || []);
-    io.emit('stateUpdate', gameState.serialize());
-    checkAndHandleWinner(io);
+    sess.gameState.plunderResolved(data.attackerIdx, data.deckIndex, data.success, data.attackCardIds || [], data.kingUsed || false, data.attackerOwnDefCardIds || []);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+    checkAndHandleWinner(sess);
   });
 
   socket.on('attackPreview', function(data) {
-    if (!gameState) return;
-    gameState.setAttackPreview(data);
-    io.emit('stateUpdate', gameState.serialize());
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
+    sess.gameState.setAttackPreview(data);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
   socket.on('defAttackResolved', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
     console.log("defAttackResolved: attackerIdx=" + data.attackerIdx + " targetPlayerIdx=" + data.targetPlayerIdx + " success=" + data.success);
-    gameState.defAttackResolved(data.attackerIdx, data.targetPlayerIdx, data.positionId, data.level, data.success, data.attackCardIds || [], data.kingUsed || false, data.attackerOwnDefCardIds || []);
-    io.emit('stateUpdate', gameState.serialize());
-    checkAndHandleWinner(io);
+    sess.gameState.defAttackResolved(data.attackerIdx, data.targetPlayerIdx, data.positionId, data.level, data.success, data.attackCardIds || [], data.kingUsed || false, data.attackerOwnDefCardIds || []);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+    checkAndHandleWinner(sess);
   });
 
   socket.on('kingAttackResolved', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
     console.log("kingAttackResolved: attackerIdx=" + data.attackerIdx + " defenderIdx=" + data.defenderIdx + " success=" + data.success);
-    gameState.kingAttackResolved(data.attackerIdx, data.defenderIdx, data.success, data.attackCardIds || [], data.kingUsed || false);
-    io.emit('stateUpdate', gameState.serialize());
-    checkAndHandleWinner(io);
+    sess.gameState.kingAttackResolved(data.attackerIdx, data.defenderIdx, data.success, data.attackCardIds || [], data.kingUsed || false);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+    checkAndHandleWinner(sess);
   });
 
   socket.on('jokerSacrifice', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
     console.log("jokerSacrifice: playerIdx=" + data.playerIdx);
-    gameState.jokerSacrifice(data.playerIdx, data.jokerCardId, data.drawnCardId);
-    io.emit('stateUpdate', gameState.serialize());
+    sess.gameState.jokerSacrifice(data.playerIdx, data.jokerCardId, data.drawnCardId);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
-  // Relay hero acquisition to all OTHER clients so they can update their local state.
   socket.on('heroAcquired', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess) return;
     console.log("heroAcquired: playerIndex=" + data.playerIndex + " heroName=" + data.heroName);
-    socket.broadcast.emit('heroAcquired', data);
+    socket.to(sess.id).emit('heroAcquired', data);
   });
 
-  // Relay hero loss to all OTHER clients (joker draw stripped hero from its owner).
   socket.on('heroLost', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess) return;
     console.log("heroLost: playerIndex=" + data.playerIndex + " heroName=" + data.heroName);
-    socket.broadcast.emit('heroLost', data);
+    socket.to(sess.id).emit('heroLost', data);
   });
 
-  // A player selected (or deselected) a hero in the lobby.
-  // Broadcast heroReserved / heroReleased so other lobby screens update their dropdowns.
   socket.on('heroSelected', function(heroName) {
-    var oldHero = heroSelections[socket.id] || 'None';
-    heroSelections[socket.id] = heroName;
+    var sess = getSession(socket.id);
+    if (!sess) return;
+    var oldHero = sess.heroSelections[socket.id] || 'None';
+    sess.heroSelections[socket.id] = heroName;
     if (oldHero !== 'None') {
-      socket.broadcast.emit('heroReleased', { heroName: oldHero });
+      socket.to(sess.id).emit('heroReleased', { heroName: oldHero });
     }
     if (heroName !== 'None') {
-      socket.broadcast.emit('heroReserved', { heroName: heroName });
+      socket.to(sess.id).emit('heroReserved', { heroName: heroName });
     }
   });
 
-  // Relay mercenary defense boost to all OTHER clients (boost is client-side only, not in server state).
   socket.on('mercDefBoost', function(data) {
-    socket.broadcast.emit('mercDefBoost', data);
+    var sess = getSession(socket.id);
+    if (!sess) return;
+    socket.to(sess.id).emit('mercDefBoost', data);
   });
 
-  // Relay Reservists ready count to all OTHER clients.
   socket.on('reservistsKingBoost', function(data) {
-    socket.broadcast.emit('reservistsKingBoost', data);
+    var sess = getSession(socket.id);
+    if (!sess) return;
+    socket.to(sess.id).emit('reservistsKingBoost', data);
   });
 
-  // Warlord: swap king card with a hand card (costs 1 take + 1 put).
   socket.on('warlordKingSwap', function(data) {
-    gameState.warlordKingSwap(data.playerIdx, data.oldKingCardId, data.newKingCardId);
-    io.emit('stateUpdate', gameState.serialize());
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
+    sess.gameState.warlordKingSwap(data.playerIdx, data.oldKingCardId, data.newKingCardId);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
-  // Merchant: player discards a card and draws a replacement (1st draw, face-down to others).
   socket.on('merchantTrade', function(data) {
-    gameState.merchantTrade(data.playerIdx, data.discardedCardId, data.drawnCardId);
-    io.emit('stateUpdate', gameState.serialize());
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
+    sess.gameState.merchantTrade(data.playerIdx, data.discardedCardId, data.drawnCardId);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
-  // Merchant 2nd try: player discards 1st drawn card, draws once more (2nd draw revealed to all).
   socket.on('merchantSecondTry', function(data) {
-    gameState.merchantSecondTry(data.playerIdx, data.firstCardId, data.secondCardId, data.isJoker);
-    io.emit('stateUpdate', gameState.serialize());
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
+    sess.gameState.merchantSecondTry(data.playerIdx, data.firstCardId, data.secondCardId, data.isJoker);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
-  // Fortified Tower: stack a hand card on top of an existing defense card.
   socket.on('fortifiedTowerStack', function(data) {
-    gameState.putTopDefCard(data.playerIdx, data.slot, data.cardId);
-    io.emit('stateUpdate', gameState.serialize());
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
+    sess.gameState.putTopDefCard(data.playerIdx, data.slot, data.cardId);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
-  // Magician: discard enemy defense card(s) and replace with a new deck card.
   socket.on('magicianSwap', function(data) {
-    gameState.magicianSwap(data.playerIdx, data.targetPlayerIdx, data.positionId,
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
+    sess.gameState.magicianSwap(data.playerIdx, data.targetPlayerIdx, data.positionId,
         data.bottomCardId, data.bottomCovered, data.topCardId, data.topCovered);
-    io.emit('stateUpdate', gameState.serialize());
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
-  // Relay spy flip to all OTHER clients.
   socket.on('spyFlip', function(data) {
-    socket.broadcast.emit('spyFlip', data);
+    var sess = getSession(socket.id);
+    if (!sess) return;
+    socket.to(sess.id).emit('spyFlip', data);
   });
 
-  // Battery Tower: relay attack intercept and responses between attacker and defender.
   socket.on('batteryDefenseCheck', function(data) {
-    socket.broadcast.emit('batteryDefenseCheck', data);
+    var sess = getSession(socket.id);
+    if (!sess) return;
+    socket.to(sess.id).emit('batteryDefenseCheck', data);
   });
+
   socket.on('batteryAllowAttack', function(data) {
-    socket.broadcast.emit('batteryAllowAttack', data);
+    var sess = getSession(socket.id);
+    if (!sess) return;
+    socket.to(sess.id).emit('batteryAllowAttack', data);
   });
+
   socket.on('batteryDenyAttack', function(data) {
-    socket.broadcast.emit('batteryDenyAttack', data);
+    var sess = getSession(socket.id);
+    if (!sess) return;
+    socket.to(sess.id).emit('batteryDenyAttack', data);
   });
 
-  // Priest: attacker takes a matching card from an enemy's hand.
   socket.on('priestConvert', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
     console.log("priestConvert: attackerIdx=" + data.attackerIdx + " targetIdx=" + data.targetPlayerIdx + " cardId=" + data.cardId);
-    gameState.priestConvert(data.attackerIdx, data.targetPlayerIdx, data.cardId);
-    io.emit('stateUpdate', gameState.serialize());
+    sess.gameState.priestConvert(data.attackerIdx, data.targetPlayerIdx, data.cardId);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
-  // Saboteurs: place a saboteur on an enemy defense slot (card or empty field).
   socket.on('sabotage', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
     console.log("sabotage: attackerIdx=" + data.attackerIdx + " defenderIdx=" + data.defenderIdx + " pos=" + data.positionId);
-    gameState.sabotage(data.attackerIdx, data.defenderIdx, data.positionId);
-    io.emit('stateUpdate', gameState.serialize());
+    sess.gameState.sabotage(data.attackerIdx, data.defenderIdx, data.positionId);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
-  // Saboteurs: owner recalls a saboteur from an enemy slot.
   socket.on('sabotageCallback', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
     console.log("sabotageCallback: attackerIdx=" + data.attackerIdx + " defenderIdx=" + data.defenderIdx + " pos=" + data.positionId);
-    gameState.sabotageCallback(data.attackerIdx, data.defenderIdx, data.positionId);
-    io.emit('stateUpdate', gameState.serialize());
+    sess.gameState.sabotageCallback(data.attackerIdx, data.defenderIdx, data.positionId);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
-  // Saboteurs: defender sacrifices their defense card to destroy the saboteur.
   socket.on('sabotageSacrifice', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
     console.log("sabotageSacrifice: defenderIdx=" + data.defenderIdx + " pos=" + data.positionId);
-    const attackerIdx = gameState.sabotageSacrifice(data.defenderIdx, data.positionId);
-    if (attackerIdx !== undefined && users[attackerIdx]) {
-      io.to(users[attackerIdx].id).emit('saboteurDestroyed', { attackerIdx: attackerIdx });
+    const attackerIdx = sess.gameState.sabotageSacrifice(data.defenderIdx, data.positionId);
+    if (attackerIdx !== undefined && sess.users[attackerIdx]) {
+      io.to(sess.users[attackerIdx].id).emit('saboteurDestroyed', { attackerIdx: attackerIdx });
     }
-    io.emit('stateUpdate', gameState.serialize());
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
-  // Saboteurs: defender sacrifices a hand card to destroy a saboteur on an empty slot.
   socket.on('sabotageEmptySlotSacrifice', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
     console.log("sabotageEmptySlotSacrifice: defenderIdx=" + data.defenderIdx + " pos=" + data.positionId + " card=" + data.handCardId);
-    const attackerIdx = gameState.sabotageEmptySlotSacrifice(data.defenderIdx, data.positionId, data.handCardId);
-    if (attackerIdx !== undefined && users[attackerIdx]) {
-      io.to(users[attackerIdx].id).emit('saboteurDestroyed', { attackerIdx: attackerIdx });
+    const attackerIdx = sess.gameState.sabotageEmptySlotSacrifice(data.defenderIdx, data.positionId, data.handCardId);
+    if (attackerIdx !== undefined && sess.users[attackerIdx]) {
+      io.to(sess.users[attackerIdx].id).emit('saboteurDestroyed', { attackerIdx: attackerIdx });
     }
-    io.emit('stateUpdate', gameState.serialize());
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
   socket.on('giveUp', function(data) {
-    if (!gameState) return;
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
     var playerIdx = data.playerIndex;
-    if (playerIdx < 0 || playerIdx >= gameState.players.length) return;
-    var player = gameState.players[playerIdx];
+    if (playerIdx < 0 || playerIdx >= sess.gameState.players.length) return;
+    var player = sess.gameState.players[playerIdx];
     if (player.isOut) return;
-    console.log("Player " + playerIdx + " (" + player.name + ") gave up");
+    console.log("Player " + playerIdx + " (" + player.name + ") gave up in session " + sess.id);
     player.isOut = true;
-    if (gameState.currentPlayerIndex === playerIdx) {
-      gameState.finishTurn();
+    if (sess.gameState.currentPlayerIndex === playerIdx) {
+      sess.gameState.finishTurn();
     }
-    io.emit('stateUpdate', gameState.serialize());
-    checkAndHandleWinner(io);
-  });
-
-  socket.on('joinLobby', function(name) {
-    console.log('User joined lobby: ' + name);
-    var existing = users.find(function(u) { return u.id === socket.id; });
-    if (!existing) {
-      users.push(new user(socket.id, name));
-    }
-    io.emit('getUsers', users);
-    // Tell the joining client whether a game is currently running
-    socket.emit('gameStatus', { running: gameState !== null });
-  });
-
-  socket.on('joinSpectator', function() {
-    if (!gameState) {
-      socket.emit('gameStatus', { running: false });
-      return;
-    }
-    console.log('Spectator joined: ' + socket.id);
-    if (spectators.indexOf(socket.id) === -1) {
-      spectators.push(socket.id);
-    }
-    // Send the full game state to the spectator (playerIndex -1 = spectator/read-only)
-    socket.emit('gameState', {
-      playerIndex: -1,
-      gameState: gameState.serialize()
-    });
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+    checkAndHandleWinner(sess);
   });
 });
-
-function user(id, name) {
-  this.id = id;
-  this.name = name || 'Player';
-  this.isReady = false;
-}

--- a/server/index.js
+++ b/server/index.js
@@ -83,6 +83,29 @@ function checkAndHandleWinner(sess) {
   }
 }
 
+function leaveCurrentSession(socket) {
+  var sess = getSession(socket.id);
+  if (!sess) return;
+  var hero = sess.heroSelections[socket.id];
+  if (hero && hero !== 'None') {
+    socket.to(sess.id).emit('heroReleased', { heroName: hero });
+  }
+  delete sess.heroSelections[socket.id];
+  var userIdx = sess.users.findIndex(function(u) { return u.id === socket.id; });
+  if (userIdx !== -1) sess.users.splice(userIdx, 1);
+  var specIdx = sess.spectators.indexOf(socket.id);
+  if (specIdx !== -1) sess.spectators.splice(specIdx, 1);
+  socket.leave(sess.id);
+  io.to(sess.id).emit('getUsers', sess.users);
+  if (sess.users.length === 0 && sess.spectators.length === 0) {
+    if (sess.timer) clearInterval(sess.timer);
+    delete sessions[sess.id];
+    console.log('Session ' + sess.id + ' deleted (empty)');
+  }
+  delete socketToSession[socket.id];
+  broadcastSessionList();
+}
+
 var PORT = process.env.PORT || 8082;
 server.listen(PORT, function() {
   console.log("Server is now running on port " + PORT);
@@ -95,37 +118,18 @@ io.on('connection', function(socket) {
 
   socket.on('disconnect', function() {
     console.log("User Disconnected: " + socket.id);
-    var sess = getSession(socket.id);
-    if (sess) {
-      // Release any lobby hero reservation so other session members can pick it.
-      var hero = sess.heroSelections[socket.id];
-      if (hero && hero !== 'None') {
-        socket.to(sess.id).emit('heroReleased', { heroName: hero });
-      }
-      delete sess.heroSelections[socket.id];
-      // Remove from users
-      var userIdx = sess.users.findIndex(function(u) { return u.id === socket.id; });
-      if (userIdx !== -1) sess.users.splice(userIdx, 1);
-      // Remove from spectators if present
-      var specIdx = sess.spectators.indexOf(socket.id);
-      if (specIdx !== -1) sess.spectators.splice(specIdx, 1);
-      // Notify remaining session members
-      io.to(sess.id).emit('userDisconnected', { id: socket.id });
-      io.to(sess.id).emit('getUsers', sess.users);
-      // Clean up empty session
-      if (sess.users.length === 0 && sess.spectators.length === 0) {
-        if (sess.timer) clearInterval(sess.timer);
-        delete sessions[sess.id];
-        console.log("Session " + sess.id + " deleted (empty)");
-      }
-      delete socketToSession[socket.id];
-      broadcastSessionList();
-    }
+    leaveCurrentSession(socket);
   });
 
   // ── Session management events ────────────────────────────────────────────
 
+  socket.on('leaveSession', function() {
+    console.log('User ' + socket.id + ' left session');
+    leaveCurrentSession(socket);
+  });
+
   socket.on('createSession', function(data) {
+    leaveCurrentSession(socket); // clean up any previous session first
     var name = (data && data.name) ? String(data.name).slice(0, 30) : 'Player';
     var sessionName = (data && data.sessionName) ? String(data.sessionName).slice(0, 50) : name + "'s game";
     var sess = createSession(sessionName);
@@ -144,6 +148,8 @@ io.on('connection', function(socket) {
     var sess = sessions[data.sessionId];
     if (!sess) { socket.emit('sessionNotFound'); return; }
     if (sess.gameState !== null) { socket.emit('gameStatus', { running: true }); return; }
+    leaveCurrentSession(socket); // leave any previous session first
+    sess = sessions[data.sessionId]; // re-fetch — leaveCurrentSession may have deleted a different session
     var name = (data.name) ? String(data.name).slice(0, 30) : 'Player';
     var existing = sess.users.find(function(u) { return u.id === socket.id; });
     if (!existing) sess.users.push(makeUser(socket.id, name));

--- a/server/index.js
+++ b/server/index.js
@@ -29,11 +29,12 @@ var sessions = {};
 var socketToSession = {};
 var _nextSessionId = 1;
 
-function createSession(name) {
+function createSession(name, allowHeroSelection) {
   var id = 's' + (_nextSessionId++);
   sessions[id] = {
     id: id,
     name: name,
+    allowHeroSelection: allowHeroSelection !== false, // default true
     users: [],
     spectators: [],
     gameState: null,
@@ -134,12 +135,13 @@ io.on('connection', function(socket) {
     leaveCurrentSession(socket); // clean up any previous session first
     var name = (data && data.name) ? String(data.name).slice(0, 30) : 'Player';
     var sessionName = (data && data.sessionName) ? String(data.sessionName).slice(0, 50) : name + "'s game";
-    var sess = createSession(sessionName);
+    var allowHeroSelection = (data && data.allowHeroSelection !== false);
+    var sess = createSession(sessionName, allowHeroSelection);
     sess.users.push(makeUser(socket.id, name));
     socketToSession[socket.id] = sess.id;
     socket.join(sess.id);
-    console.log("Session created: " + sess.id + " '" + sess.name + "' by " + name);
-    socket.emit('sessionJoined', { sessionId: sess.id });
+    console.log("Session created: " + sess.id + " '" + sess.name + "' by " + name + " (heroes: " + allowHeroSelection + ")");
+    socket.emit('sessionJoined', { sessionId: sess.id, allowHeroSelection: sess.allowHeroSelection });
     io.to(sess.id).emit('getUsers', sess.users);
     socket.emit('gameStatus', { running: false });
     broadcastSessionList();
@@ -165,7 +167,7 @@ io.on('connection', function(socket) {
         socket.emit('heroReserved', { heroName: h });
       }
     });
-    socket.emit('sessionJoined', { sessionId: sess.id });
+    socket.emit('sessionJoined', { sessionId: sess.id, allowHeroSelection: sess.allowHeroSelection });
     io.to(sess.id).emit('getUsers', sess.users);
     socket.emit('gameStatus', { running: false });
     broadcastSessionList();


### PR DESCRIPTION
## Summary

Implements issue #68 (multi-game session management) and fixes issue #67 (UI improvements) in a single branch.

---

### Issue #68 — Multiple concurrent game sessions

**Server (`server/index.js`)**
- Replaced global single-game state (`users`, `gameState`, etc.) with a `sessions{}` map, each session having its own `users[]`, `spectators[]`, `gameState`, `heroSelections`, `winnerHandled`, `timeToStart`, and `timer`.
- Added `socketToSession{}` map (`socketId → sessionId`) for O(1) session lookup — game events don't need a `sessionId` in their payload.
- New socket events:
  - `createSession({ name, sessionName })` — creates a new session, adds the creator, joins the socket.io room for that session.
  - `joinSession({ sessionId, name })` — joins an existing open session; sends existing hero reservations to the new joiner.
  - `joinSessionSpectator({ sessionId })` — joins a running session as spectator.
- `sessionList` broadcast (`[{ id, name, playerCount, running }]`) sent to all clients whenever sessions change (create/join/disconnect/game over).
- All game events (`finishTurn`, `putDefCard`, hero events, etc.) now operate on the per-session state and broadcast only to the session's socket.io room.
- Empty sessions are automatically cleaned up on disconnect.

**Client (`MenuScreen.java`)**
- New pre-game flow: **name entry → session list → per-session lobby**
- `showSessionListScreen()`: lists all open/running sessions in a table; buttons to Join (open game), Watch (running game), and Create a new game with an optional name field.
- `sessionJoined` / `sessionList` / `sessionNotFound` socket event handlers.
- `returnToLobby` now returns to the session list (not the name entry screen), resetting lobby state cleanly.

---

### Issue #67 — UI improvements

- **TextField name entry**: `showNameEntryScreen()` now renders a libGDX `TextField` widget directly on-screen with a "Play" button, replacing the native OS `getTextInput()` dialog. This fixes unreliable backspace on mobile and shows the typed text on-screen.
- **Clean table headers**: removed `setFontScale(1.2f)` from "Name"/"Status" column headers in `showLobbyScreen()` — bitmap font scaling caused blurry rendering.
- **Leave button**: added a "Leave" button in the lobby to return to the session list without disconnecting.

---

Closes #67
Closes #68