### PR TITLE
feat: expose defense card (or king) when ending turn without attacking

### DIFF
--- a/core/src/com/mygdx/game/PlayerTurn.java
+++ b/core/src/com/mygdx/game/PlayerTurn.java
@@ -33,6 +33,10 @@ public class PlayerTurn {
     return attackCounter;
   }
 
+  public void setAttackCounter(int v) {
+    attackCounter = v;
+  }
+
   public void decreaseTakeDefCard() {
     takeDefCard -= 1;
   }

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -56,6 +56,7 @@ class GameState {
       p.defCardsCovered = { 1: true, 2: true, 3: true };
       p.topDefCardsCovered = {};
       p.sabotaged = {}; // { slotId: attackerPlayerIdx } — tracks which slots have a saboteur
+      p.attackCount = 0; // number of enemy attacks this turn (reset on finishTurn)
     }
   }
 
@@ -322,6 +323,7 @@ class GameState {
   defAttackResolved(attackerIdx, defenderIdx, positionId, level, success, attackCardIds, kingUsed, attackerOwnDefCardIds) {
     this.pendingAttack = null;
     const attacker = this.players[attackerIdx];
+    attacker.attackCount = (attacker.attackCount || 0) + 1;
     const defender = this.players[defenderIdx];
     for (const cardId of attackCardIds) {
       const i = attacker.hand.indexOf(cardId);
@@ -374,7 +376,10 @@ class GameState {
     // Always use the server's own authoritative currentPlayerIndex — never trust the client.
     const currentPlayerIndex = this.currentPlayerIndex;
     this.lastMerchantReveal = null; // clear Merchant 2nd-try reveal on turn end
-    if (this.players[currentPlayerIndex]) this.players[currentPlayerIndex].preyCards = [];
+    if (this.players[currentPlayerIndex]) {
+      this.players[currentPlayerIndex].preyCards = [];
+      this.players[currentPlayerIndex].attackCount = 0; // reset for next turn
+    }
     // Advance to the next non-eliminated player (server is authoritative)
     const n = this.players.length;
     let next = (currentPlayerIndex + 1) % n;
@@ -383,6 +388,27 @@ class GameState {
       next = (next + 1) % n;
     }
     this.currentPlayerIndex = next;
+  }
+
+  exposeDefCard(playerIdx, slot) {
+    const p = this.players[playerIdx];
+    if (!p) return;
+    if (!p.defCardsCovered) p.defCardsCovered = {};
+    if (!p.topDefCardsCovered) p.topDefCardsCovered = {};
+    // Expose the top card first if present (it sits on the regular card)
+    if (p.topDefCards[slot] !== undefined) {
+      p.topDefCardsCovered[slot] = false;
+    } else if (p.defCards[slot] !== undefined) {
+      p.defCardsCovered[slot] = false;
+    }
+    this.pushLog(`${this.pname(playerIdx)} exposed slot ${slot} (no attack)`, false, true);
+  }
+
+  exposeKingCard(playerIdx) {
+    const p = this.players[playerIdx];
+    if (!p) return;
+    p.kingCovered = false;
+    this.pushLog(`${this.pname(playerIdx)} exposed their king (no attack)`, false, true);
   }
 
   checkWinner() {
@@ -410,6 +436,7 @@ class GameState {
 
   kingAttackResolved(attackerIdx, defenderIdx, success, attackCardIds, kingUsed) {
     const attacker = this.players[attackerIdx];
+    attacker.attackCount = (attacker.attackCount || 0) + 1;
     const defender = this.players[defenderIdx];
     for (const cardId of attackCardIds) {
       const i = attacker.hand.indexOf(cardId);
@@ -504,6 +531,7 @@ class GameState {
         isOut: p.isOut || false,
         sabotaged: Object.assign({}, p.sabotaged || {}),
         preyCards: [...(p.preyCards || [])],
+        attackCount: p.attackCount || 0,
       })),
       pickingDecks: this.pickingDecks.map(d => d.map(c => ({ id: c.id, covered: c.covered }))),
       winnerIndex: this.checkWinner(),

--- a/server/index.js
+++ b/server/index.js
@@ -341,6 +341,22 @@ io.on('connection', function(socket) {
     checkAndHandleWinner(sess);
   });
 
+  socket.on('exposeDefCard', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
+    console.log("exposeDefCard: playerIdx=" + data.playerIdx + " slot=" + data.slot);
+    sess.gameState.exposeDefCard(data.playerIdx, data.slot);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+  });
+
+  socket.on('exposeKingCard', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
+    console.log("exposeKingCard: playerIdx=" + data.playerIdx);
+    sess.gameState.exposeKingCard(data.playerIdx);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+  });
+
   socket.on('jokerSacrifice', function(data) {
     var sess = getSession(socket.id);
     if (!sess || !sess.gameState) return;


### PR DESCRIPTION
Closes #71

## What's implemented

If a player ends their turn without having attacked any enemy, they are forced to expose one of their covered defense cards.

### Flow
1. **Player presses "Finish Turn"** without having attacked → penalty check runs client-side.
2. **Has covered defense cards** → a selection overlay appears ("No attack — expose a defense card: Slot 1 / Slot 2 / Slot 3"). The turn cannot end until the player picks a slot.
3. **All defense cards already face-up** → the king card is exposed automatically via server event, then the turn ends.
4. **Player attacked** → turn ends normally, no penalty.

### Changes
| File | Change |
|---|---|
| `server/gameState.js` | Track `attackCount` per player; reset on `finishTurn`; `exposeDefCard()` and `exposeKingCard()` methods |
| `server/index.js` | `exposeDefCard` and `exposeKingCard` socket event handlers |
| `core/…/PlayerTurn.java` | Public `setAttackCounter()` setter |
| `core/…/GameScreen.java` | `pendingExposeCard` flag; penalty check in finish-turn listener; `addExposeCardOverlay()` in `handStage`; sync `attackCount` from server in `applyStateUpdate` |