### PR TITLE
fix: prevent duplicate heroes when stealing via joker choice (#81)

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -2064,6 +2064,10 @@ public class GameScreen extends ScreenAdapter {
               if (ownerIdx >= 0) {
                 Hero stripped = players.get(ownerIdx).removeHeroByName(heroName);
                 if (stripped != null) {
+                  // Emit heroAcquired BEFORE heroLost so other clients can
+                  // still find the hero in the old owner's list inside
+                  // applyHeroAcquired and transfer it without it disappearing.
+                  completeHeroAcquisition(stripped);
                   try {
                     JSONObject emitData = new JSONObject();
                     emitData.put("playerIndex", ownerIdx);
@@ -2072,7 +2076,6 @@ public class GameScreen extends ScreenAdapter {
                   } catch (JSONException e) {
                     e.printStackTrace();
                   }
-                  completeHeroAcquisition(stripped);
                 }
               }
             }

--- a/core/src/com/mygdx/game/GameState.java
+++ b/core/src/com/mygdx/game/GameState.java
@@ -406,6 +406,14 @@ public class GameState {
    */
   public void applyHeroAcquired(int playerIdx, String heroName) {
     Hero hero = heroesSquare.consumeHeroByName(heroName);
+    if (hero == null) {
+      // Hero was stolen from another player (not drawn from the square).
+      // Strip it from whoever currently owns it so there are no duplicates.
+      int ownerIdx = findHeroOwnerIndex(heroName);
+      if (ownerIdx >= 0 && ownerIdx != playerIdx) {
+        hero = players.get(ownerIdx).removeHeroByName(heroName);
+      }
+    }
     if (hero != null && playerIdx >= 0 && playerIdx < players.size()) {
       players.get(playerIdx).addHero(hero);
     }


### PR DESCRIPTION
Fixes #81.

## Root cause

Two bugs caused the same hero to be active on both the old owner and the new owner simultaneously:

**1. `applyHeroAcquired` only looked in `heroesSquare` (`GameState.java`)**  
When a hero is stolen from a player via joker choice, it is no longer in `heroesSquare` (it was consumed when the original owner acquired it). So `consumeHeroByName` returned `null` and the hero was silently dropped — never added to the new owner on other clients.

**2. Wrong emission order (`GameScreen.java`)**  
`heroLost` was emitted *before* `heroAcquired`. Other clients therefore removed the hero from the old owner's model before `applyHeroAcquired` ran, leaving no hero object to transfer.

## Fix

- **`GameState.java`**: When `consumeHeroByName` returns `null`, search all players' hero lists, strip the hero from the current owner, and add it to the new owner.
- **`GameScreen.java`**: In the joker-choice steal path, call `completeHeroAcquisition` (which emits `heroAcquired`) *before* emitting `heroLost`, so the hero is still findable in the old owner's list when `applyHeroAcquired` runs on other clients.