### PR TITLE
feat: instant hand sort; push unusable cards (prey/denied) to end (#86)

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -2398,9 +2398,12 @@ public class GameScreen extends ScreenAdapter {
     }
 
     // Draw heroes and hand cards only for the current (own) player
+    // Sort BEFORE calling getHandCards() — sortHandCards() replaces the
+    // Player.handCards reference with a new ArrayList, so we must
+    // capture the sorted list after the sort completes.
+    currentPlayer.sortHandCards();
     final ArrayList<Card> handCards = currentPlayer.getHandCards();
     ArrayList<Hero> playerHeroes = currentPlayer.getHeroes();
-    currentPlayer.sortHandCards();
     ArrayList<Integer> deniedCardIds = currentPlayer.getPlayerTurn().getBatteryDeniedAttackCardIds();
     ArrayList<Integer> preyCardIds = currentPlayer.getPlayerTurn().getPreyCardIds();
 

--- a/core/src/com/mygdx/game/Player.java
+++ b/core/src/com/mygdx/game/Player.java
@@ -387,25 +387,38 @@ public class Player {
   }
 
   public void sortHandCards() {
+    // Unusable cards (prey + battery-denied) go to the end.
+    ArrayList<Integer> unusableIds = new ArrayList<Integer>();
+    unusableIds.addAll(playerTurn.getPreyCardIds());
+    unusableIds.addAll(playerTurn.getBatteryDeniedAttackCardIds());
+
     ArrayList<Card> hearts = new ArrayList<Card>();
     ArrayList<Card> diamonds = new ArrayList<Card>();
     ArrayList<Card> spades = new ArrayList<Card>();
     ArrayList<Card> clubs = new ArrayList<Card>();
     ArrayList<Card> jokers = new ArrayList<Card>();
+    ArrayList<Card> unusable = new ArrayList<Card>();
 
-    // sort by symbol
+    // sort by symbol; unusable cards go into their own bucket
     for (int i = 0; i < handCards.size(); i++) {
-      String symbol = handCards.get(i).getSymbol();
+      Card c = handCards.get(i);
+      if (unusableIds.contains(c.getCardId())) {
+        unusable.add(c);
+        continue;
+      }
+      String symbol = c.getSymbol();
       if (symbol == "hearts")
-        hearts.add(handCards.get(i));
+        hearts.add(c);
       else if (symbol == "diamonds")
-        diamonds.add(handCards.get(i));
+        diamonds.add(c);
       else if (symbol == "spades")
-        spades.add(handCards.get(i));
+        spades.add(c);
       else if (symbol == "clubs")
-        clubs.add(handCards.get(i));
+        clubs.add(c);
       else if (symbol == "joker")
-        jokers.add(handCards.get(i));
+        jokers.add(c);
+      else
+        unusable.add(c); // unknown symbol treated as unusable
     }
 
     // sort each symbol by strength
@@ -438,7 +451,7 @@ public class Player {
       }
     }
 
-    // refill handCards sorted
+    // refill handCards sorted; unusable cards at the end
     handCards = new ArrayList<Card>();
     for (int i = 0; i < hearts.size(); i++)
       handCards.add(hearts.get(i));
@@ -450,6 +463,8 @@ public class Player {
       handCards.add(clubs.get(i));
     for (int i = 0; i < jokers.size(); i++)
       handCards.add(jokers.get(i));
+    for (int i = 0; i < unusable.size(); i++)
+      handCards.add(unusable.get(i));
 
   }
 


### PR DESCRIPTION
Closes #86.

## Root cause

**Sort was always one render-cycle late.** In `showHandStage`, `getHandCards()` was called *before* `sortHandCards()`. `sortHandCards()` creates a **new** `ArrayList` and assigns it to `Player.handCards`, but the local reference in `showHandStage` still pointed to the old unsorted list. That's why clicking somewhere in the hand area appeared to "trigger" the sort — it caused a second `show()` call that then picked up the already-sorted list.

## Changes

**`Player.sortHandCards()`**
- Reads `preyCardIds` and `batteryDeniedAttackCardIds` from `PlayerTurn` to identify unusable cards.
- Unusable cards are collected in a separate bucket and appended **after** all usable cards (hearts → diamonds → spades → clubs → jokers → unusable).

**`GameScreen.showHandStage()`**
- Moved `currentPlayer.sortHandCards()` to run *before* `currentPlayer.getHandCards()`, so the captured list reference is always the freshly-sorted one.