### PR TITLE
fix: enemy heroes visible in slot 1 (left side) for 2-player game (#88)

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -173,11 +173,6 @@ public class GameScreen extends ScreenAdapter {
     players = gameState.getPlayers();
     currentPlayer = players.get(this.playerIndex);
 
-    // Apply testing starting hero if one was selected in the menu (not for spectators)
-    if (!isSpectator && startingHero != null && !startingHero.equals("None")) {
-      gameState.applyHeroAcquired(this.playerIndex, startingHero);
-    }
-
     // Single stateUpdate listener — replaces all specific sync events
     final int notifyPlayerIdx = this.playerIndex; // capture field before parameter shadows it
     socket.on("stateUpdate", new SocketListener() {
@@ -599,8 +594,6 @@ public class GameScreen extends ScreenAdapter {
     }
 
     // On first render, broadcast Reservists count so enemies see the indicator immediately.
-    // Also broadcast the starting hero so all clients know each other's heroes (the
-    // startingHero is applied locally in the constructor but never emitted via heroAcquired).
     if (!initialReservistsBroadcastDone) {
       initialReservistsBroadcastDone = true;
       for (Hero h : currentPlayer.getHeroes()) {
@@ -608,16 +601,6 @@ public class GameScreen extends ScreenAdapter {
           emitReservistsKingBoost(((Reservists) h).countReady());
           break;
         }
-      }
-      // Broadcast starting hero to all other clients
-      if (startingHero != null && !startingHero.equals("None") && socket != null) {
-        try {
-          JSONObject emitData = new JSONObject();
-          emitData.put("playerIndex", playerIndex);
-          emitData.put("heroName", startingHero);
-          emitData.put("jokerCardId", -1);
-          socket.emit("heroAcquired", emitData);
-        } catch (Exception e) { e.printStackTrace(); }
       }
     }
 
@@ -3278,6 +3261,9 @@ public class GameScreen extends ScreenAdapter {
         p.getPlayerTurn().setPreyCardIds(newPreyIds);
         p.getPlayerTurn().setAttackCounter(pj.optInt("attackCount", 0));
       }
+
+      // Sync heroes from server-authoritative state so missed relay events do not desync views.
+      gameState.rebuildHeroesFromState(playersJson);
 
       // Sync local Saboteurs hero active count: count how many slots across all players are
       // owned by the local player (playerIndex) to keep the hero state consistent with server.

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -1133,7 +1133,7 @@ public class GameScreen extends ScreenAdapter {
           break;
         case 1:
           playerHeroes.get(j).setPosition(playerHeroes.get(j).getX(),
-              playerHeroes.get(j).getY() + j * playerHeroes.get(j).getHeight() / 3);
+              playerHeroes.get(j).getY() + 2 * playerLabel.getHeight() + j * playerHeroes.get(j).getHeight() / 3);
           break;
         case 2:
           playerHeroes.get(j).setPosition(

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -1124,7 +1124,7 @@ public class GameScreen extends ScreenAdapter {
               MyGdxGame.WIDTH - playerHeroes.get(j).getHeight());
           break;
         case 3:
-          playerHeroes.get(j).setPosition(playerHeroes.get(j).getX(),
+          playerHeroes.get(j).setPosition(MyGdxGame.WIDTH - playerHeroes.get(j).getWidth(),
               playerHeroes.get(j).getY() - 2 * playerLabel.getHeight() - j * playerHeroes.get(j).getHeight() / 3);
           break;
         default:

--- a/core/src/com/mygdx/game/GameState.java
+++ b/core/src/com/mygdx/game/GameState.java
@@ -211,8 +211,8 @@ public class GameState {
       cemeteryDeckListener = new CemeteryDeckListener(this);
       cemeteryDeck.addListener(cemeteryDeckListener);
 
-      // 7. Heroes (deterministic per player index, same as doRandomSetup)
-      doHeroSetup(players.size());
+      // 7. Heroes from server-authoritative state
+      rebuildHeroesFromState(playersJson);
 
     } catch (JSONException e) {
       e.printStackTrace();
@@ -398,6 +398,30 @@ public class GameState {
 
   public void setUpdateState(boolean updateState) {
     this.updateState = updateState;
+  }
+
+  /**
+   * Rebuild all heroes from a server-authoritative players JSON array.
+   * This resets the hero pool and player hero lists first, then reapplies
+   * ownership by player index to keep all clients deterministic.
+   */
+  public void rebuildHeroesFromState(JSONArray playersJson) throws JSONException {
+    heroesSquare = new HeroesSquare();
+
+    for (int i = 0; i < players.size(); i++) {
+      players.get(i).getHeroes().clear();
+    }
+
+    for (int i = 0; i < playersJson.length(); i++) {
+      JSONObject pj = playersJson.getJSONObject(i);
+      int idx = pj.getInt("index");
+      JSONArray heroesJson = pj.optJSONArray("heroes");
+      if (heroesJson == null) continue;
+
+      for (int h = 0; h < heroesJson.length(); h++) {
+        applyHeroAcquired(idx, heroesJson.getString(h));
+      }
+    }
   }
 
   /**

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -12,6 +12,7 @@ class GameState {
       defCards: {},
       topDefCards: {},
       kingCard: null,
+      heroes: [],
       preyCards: [],
     }));
     this.pickingDecks = [[], []]; // each entry: { id, covered }
@@ -513,6 +514,35 @@ class GameState {
     this.pushLog(`${this.pname(playerIdx)} used Merchant 2nd try`, true, true);
   }
 
+  heroAcquired(playerIdx, heroName) {
+    if (!heroName) return;
+    if (playerIdx < 0 || playerIdx >= this.players.length) return;
+
+    // Keep hero ownership unique across all players.
+    for (const p of this.players) {
+      p.heroes = (p.heroes || []).filter(h => h !== heroName);
+    }
+
+    const target = this.players[playerIdx];
+    if (!target.heroes) target.heroes = [];
+    target.heroes.push(heroName);
+  }
+
+  heroLost(playerIdx, heroName) {
+    if (!heroName) return;
+
+    if (playerIdx >= 0 && playerIdx < this.players.length) {
+      const p = this.players[playerIdx];
+      p.heroes = (p.heroes || []).filter(h => h !== heroName);
+      return;
+    }
+
+    // Fallback: remove from everyone if the sender index is invalid.
+    for (const p of this.players) {
+      p.heroes = (p.heroes || []).filter(h => h !== heroName);
+    }
+  }
+
   serialize() {
     return {
       currentPlayerIndex: this.currentPlayerIndex,
@@ -530,6 +560,7 @@ class GameState {
         kingCovered: p.kingCovered !== undefined ? p.kingCovered : true,
         isOut: p.isOut || false,
         sabotaged: Object.assign({}, p.sabotaged || {}),
+        heroes: [...(p.heroes || [])],
         preyCards: [...(p.preyCards || [])],
         attackCount: p.attackCount || 0,
       })),

--- a/server/index.js
+++ b/server/index.js
@@ -227,6 +227,16 @@ io.on('connection', function(socket) {
         console.log("Timer finished for session " + sess.id + ", starting game");
         sess.winnerHandled = false;
         sess.gameState = new GameState(sess.users);
+
+        // Apply lobby starting hero selections to the authoritative state BEFORE
+        // the initial gameState packet is sent, so all clients render the same heroes.
+        sess.users.forEach(function(u, idx) {
+          var hero = sess.heroSelections[u.id];
+          if (hero && hero !== 'None') {
+            sess.gameState.heroAcquired(idx, hero);
+          }
+        });
+
         sess.users.forEach(function(u, idx) {
           io.to(u.id).emit('gameState', {
             playerIndex: idx,
@@ -367,16 +377,18 @@ io.on('connection', function(socket) {
 
   socket.on('heroAcquired', function(data) {
     var sess = getSession(socket.id);
-    if (!sess) return;
+    if (!sess || !sess.gameState) return;
     console.log("heroAcquired: playerIndex=" + data.playerIndex + " heroName=" + data.heroName);
-    socket.to(sess.id).emit('heroAcquired', data);
+    sess.gameState.heroAcquired(data.playerIndex, data.heroName);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
   socket.on('heroLost', function(data) {
     var sess = getSession(socket.id);
-    if (!sess) return;
+    if (!sess || !sess.gameState) return;
     console.log("heroLost: playerIndex=" + data.playerIndex + " heroName=" + data.heroName);
-    socket.to(sess.id).emit('heroLost', data);
+    sess.gameState.heroLost(data.playerIndex, data.heroName);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
   socket.on('heroSelected', function(heroName) {


### PR DESCRIPTION
## Root Cause

In a 2-player game, player 1 (index 0) sees player 2 at visual slot 1 (left side). The hero placement for slot 1 used:

```java
y = playerLabel.getY() + j * heroHeight / 3
```

For `j=0`, this places the first hero **exactly at `playerLabel.getY()`** — i.e. the same position as the player label. Since heroes are added to the stage *before* the label, the label renders on top, completely hiding the heroes.

## Fix

Mirror the working case 3 (right side) which offsets heroes by `2 * labelHeight` below the label:

```java
// Before (slot 1 — broken):
y = playerLabel.getY() + j * heroHeight / 3

// After (slot 1 — fixed, mirrors case 3):
y = playerLabel.getY() + 2 * playerLabel.getHeight() + j * heroHeight / 3
```

This places heroes above the player label (slot 1 is the left-side player whose label is at the vertical midpoint), symmetrically to how case 3 places them below on the right side.

Closes #88