### PR TITLE
feat: host starts game with ready players only (#91)

### DIFF
--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -422,13 +422,13 @@ public class MenuScreen extends AbstractScreen {
     Label headLine1 = new Label("Name", MyGdxGame.skin);
     Label headLine2 = new Label("Status", MyGdxGame.skin);
 
-    loggedInUserTable.add(headLine1);
+    loggedInUserTable.add(headLine1).padRight(60);
     loggedInUserTable.add(headLine2);
     loggedInUserTable.row();
 
     for (int i = 0; i < loggedInUsers.size(); i++) {
       User user = loggedInUsers.get(i);
-      Label nameLabel = new Label(user.getName() + "      ", MyGdxGame.skin);
+      Label nameLabel = new Label(user.getName(), MyGdxGame.skin);
 
       if (user.getUserID().equals(menuState.getMyUserID())) {
         nameLabel.setColor(Color.GOLD);
@@ -443,7 +443,7 @@ public class MenuScreen extends AbstractScreen {
         isReady.setColor(Color.RED);
       }
 
-      loggedInUserTable.add(nameLabel);
+      loggedInUserTable.add(nameLabel).padRight(60);
       loggedInUserTable.add(isReady);
       loggedInUserTable.row();
     }
@@ -451,25 +451,25 @@ public class MenuScreen extends AbstractScreen {
     loggedInUserTable.pack();
     loggedInUserTable.setPosition((MyGdxGame.WIDTH - loggedInUserTable.getWidth()) / 2f, 300);
 
-    // Notification permission status — shown in all lobby states
-    if (MyGdxGame.turnNotifier.isPermissionGranted()) {
-      Label notifLabel = new Label("\uD83D\uDD14 Notifications: ON", MyGdxGame.skin);
-      notifLabel.setColor(Color.GREEN);
-      notifLabel.setPosition(0, 50);
-      menuStage.addActor(notifLabel);
-    } else {
-      TextButton notifButton = new TextButton("\uD83D\uDD14 Enable notifications", MyGdxGame.skin);
-      notifButton.setPosition(0, 50);
-      notifButton.addListener(new ClickListener() {
-        @Override
-        public void clicked(InputEvent event, float x, float y) {
-          MyGdxGame.turnNotifier.requestPermission(new Runnable() {
-            @Override public void run() { show(); }
-          });
-        }
-      });
-      menuStage.addActor(notifButton);
-    }
+    // Notification permission status — temporarily hidden to avoid overlap with lobby buttons
+    // if (MyGdxGame.turnNotifier.isPermissionGranted()) {
+    //   Label notifLabel = new Label("\uD83D\uDD14 Notifications: ON", MyGdxGame.skin);
+    //   notifLabel.setColor(Color.GREEN);
+    //   notifLabel.setPosition(0, 50);
+    //   menuStage.addActor(notifLabel);
+    // } else {
+    //   TextButton notifButton = new TextButton("\uD83D\uDD14 Enable notifications", MyGdxGame.skin);
+    //   notifButton.setPosition(0, 50);
+    //   notifButton.addListener(new ClickListener() {
+    //     @Override
+    //     public void clicked(InputEvent event, float x, float y) {
+    //       MyGdxGame.turnNotifier.requestPermission(new Runnable() {
+    //         @Override public void run() { show(); }
+    //       });
+    //     }
+    //   });
+    //   menuStage.addActor(notifButton);
+    // }
 
     if (gameRunning) {
       // A game is already in progress — show status and offer spectating
@@ -504,6 +504,7 @@ public class MenuScreen extends AbstractScreen {
       boolean isHost = !loggedInUsers.isEmpty()
           && loggedInUsers.get(0).getUserID().equals(menuState.getMyUserID());
       boolean canHostStart = isHost && amReady && readyCount >= 2 && !timerStarted;
+      float buttonY = 0.08f * MyGdxGame.HEIGHT;
 
       Label lobbyStatus = new Label("Ready players: " + readyCount + " / " + loggedInUsers.size(), MyGdxGame.skin);
       lobbyStatus.setPosition(200, 0);
@@ -512,8 +513,10 @@ public class MenuScreen extends AbstractScreen {
       if (isHost) {
         TextButton startGameButton = new TextButton("Start game", MyGdxGame.skin);
         startGameButton.setSize(button.getWidth(), button.getHeight());
-        // Keep Start and Ready separate from hero selector area.
-        startGameButton.setPosition((MyGdxGame.WIDTH - startGameButton.getWidth()) / 2f, 0.01f * MyGdxGame.HEIGHT);
+        float buttonGap = 20f;
+        float readyButtonX = (MyGdxGame.WIDTH / 2f) - button.getWidth() - (buttonGap / 2f);
+        float startButtonX = (MyGdxGame.WIDTH / 2f) + (buttonGap / 2f);
+        startGameButton.setPosition(startButtonX, buttonY);
         startGameButton.setDisabled(!canHostStart);
         startGameButton.setTouchable(!canHostStart
             ? com.badlogic.gdx.scenes.scene2d.Touchable.disabled
@@ -531,10 +534,9 @@ public class MenuScreen extends AbstractScreen {
         });
         menuStage.addActor(startGameButton);
 
-        // Host still needs the ready toggle, but place it below Start.
-        button.setPosition((MyGdxGame.WIDTH - button.getWidth()) / 2f, 0.09f * MyGdxGame.HEIGHT);
+        button.setPosition(readyButtonX, buttonY);
       } else {
-        button.setPosition((MyGdxGame.WIDTH - button.getWidth()) / 2f, 0.1f * MyGdxGame.HEIGHT);
+        button.setPosition((MyGdxGame.WIDTH - button.getWidth()) / 2f, buttonY);
       }
 
       if (timerStarted) {
@@ -596,12 +598,6 @@ public class MenuScreen extends AbstractScreen {
     if (updateScreen) {
       updateScreen = false;
       show();
-    }
-
-    if (menuState.getTimeToStart() <= 0 && timerStarted) {
-      Timer.instance().clear();
-      socket.emit("checkTimer", 0);
-      timerStarted = false;
     }
 
     menuStage.act(delta);

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -504,7 +504,8 @@ public class MenuScreen extends AbstractScreen {
       if (isHost) {
         TextButton startGameButton = new TextButton("Start game", MyGdxGame.skin);
         startGameButton.setSize(button.getWidth(), button.getHeight());
-        startGameButton.setPosition((MyGdxGame.WIDTH - startGameButton.getWidth()) / 2f, 0.1f * MyGdxGame.HEIGHT);
+        // Keep Start and Ready separate so both remain visible to host.
+        startGameButton.setPosition((MyGdxGame.WIDTH - startGameButton.getWidth()) / 2f, 0.18f * MyGdxGame.HEIGHT);
         startGameButton.setDisabled(readyCount < 2);
         startGameButton.setTouchable(readyCount < 2
             ? com.badlogic.gdx.scenes.scene2d.Touchable.disabled
@@ -516,6 +517,11 @@ public class MenuScreen extends AbstractScreen {
           }
         });
         menuStage.addActor(startGameButton);
+
+        // Host still needs the ready toggle, but place it below Start.
+        button.setPosition((MyGdxGame.WIDTH - button.getWidth()) / 2f, 0.08f * MyGdxGame.HEIGHT);
+      } else {
+        button.setPosition((MyGdxGame.WIDTH - button.getWidth()) / 2f, 0.1f * MyGdxGame.HEIGHT);
       }
 
       // Rebuild hero dropdown excluding heroes reserved by other lobby players.

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -489,26 +489,34 @@ public class MenuScreen extends AbstractScreen {
       });
       menuStage.addActor(watchButton);
     } else {
-      // No game running — show normal ready/start controls
-      // check if all players are ready (requires >= 2)
-      if (menuState.allReady() && !timerStarted) {
-        System.out.println("All players ready...");
-        socket.emit("startTimer", 5);
-        menuState.setTimeToStart(5);
-        timerStarted = true;
+      // No game running — host can start once enough players are ready.
+      int readyCount = 0;
+      for (int i = 0; i < loggedInUsers.size(); i++) {
+        if (loggedInUsers.get(i).isReady()) readyCount++;
       }
+      boolean isHost = !loggedInUsers.isEmpty()
+          && loggedInUsers.get(0).getUserID().equals(menuState.getMyUserID());
 
-      if (!menuState.allReady() && timerStarted) {
-        timerStarted = false;
-        menuState.setTimeToStart(5);
-      }
+      Label lobbyStatus = new Label("Ready players: " + readyCount + " / " + loggedInUsers.size(), MyGdxGame.skin);
+      lobbyStatus.setPosition(200, 0);
+      menuStage.addActor(lobbyStatus);
 
-      Label timerLabel = new Label("Waiting for players ... ", MyGdxGame.skin);
-      if (timerStarted) {
-        timerLabel = new Label("Time to start ... " + menuState.getTimeToStart(), MyGdxGame.skin);
+      if (isHost) {
+        TextButton startGameButton = new TextButton("Start game", MyGdxGame.skin);
+        startGameButton.setSize(button.getWidth(), button.getHeight());
+        startGameButton.setPosition((MyGdxGame.WIDTH - startGameButton.getWidth()) / 2f, 0.1f * MyGdxGame.HEIGHT);
+        startGameButton.setDisabled(readyCount < 2);
+        startGameButton.setTouchable(readyCount < 2
+            ? com.badlogic.gdx.scenes.scene2d.Touchable.disabled
+            : com.badlogic.gdx.scenes.scene2d.Touchable.enabled);
+        startGameButton.addListener(new ClickListener() {
+          @Override
+          public void clicked(InputEvent event, float x, float y) {
+            socket.emit("startGame", new JSONObject());
+          }
+        });
+        menuStage.addActor(startGameButton);
       }
-      timerLabel.setPosition(200, 0);
-      menuStage.addActor(timerLabel);
 
       // Rebuild hero dropdown excluding heroes reserved by other lobby players.
       if (sessionAllowHeroSelection) {
@@ -797,6 +805,35 @@ public class MenuScreen extends AbstractScreen {
             timerStarted = false;
             gameRunning = true;
             updateScreen = true;
+          }
+        });
+      }
+    });
+
+    socket.on("notEnoughReadyPlayers", new SocketListener() {
+      @Override
+      public void call(Object... args) {
+        Gdx.app.postRunnable(new Runnable() {
+          @Override
+          public void run() {
+            updateScreen = true;
+          }
+        });
+      }
+    });
+
+    socket.on("leftSessionNotReady", new SocketListener() {
+      @Override
+      public void call(Object... args) {
+        Gdx.app.postRunnable(new Runnable() {
+          @Override
+          public void run() {
+            lobbyJoined = false;
+            timerStarted = false;
+            gameRunning = false;
+            menuState.clearUsers();
+            reservedByOthers.clear();
+            show();
           }
         });
       }

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -494,8 +494,16 @@ public class MenuScreen extends AbstractScreen {
       for (int i = 0; i < loggedInUsers.size(); i++) {
         if (loggedInUsers.get(i).isReady()) readyCount++;
       }
+      boolean amReady = false;
+      for (int i = 0; i < loggedInUsers.size(); i++) {
+        if (loggedInUsers.get(i).getUserID().equals(menuState.getMyUserID())) {
+          amReady = loggedInUsers.get(i).isReady();
+          break;
+        }
+      }
       boolean isHost = !loggedInUsers.isEmpty()
           && loggedInUsers.get(0).getUserID().equals(menuState.getMyUserID());
+      boolean canHostStart = isHost && amReady && readyCount >= 2 && !timerStarted;
 
       Label lobbyStatus = new Label("Ready players: " + readyCount + " / " + loggedInUsers.size(), MyGdxGame.skin);
       lobbyStatus.setPosition(200, 0);
@@ -504,12 +512,17 @@ public class MenuScreen extends AbstractScreen {
       if (isHost) {
         TextButton startGameButton = new TextButton("Start game", MyGdxGame.skin);
         startGameButton.setSize(button.getWidth(), button.getHeight());
-        // Keep Start and Ready separate so both remain visible to host.
-        startGameButton.setPosition((MyGdxGame.WIDTH - startGameButton.getWidth()) / 2f, 0.18f * MyGdxGame.HEIGHT);
-        startGameButton.setDisabled(readyCount < 2);
-        startGameButton.setTouchable(readyCount < 2
+        // Keep Start and Ready separate from hero selector area.
+        startGameButton.setPosition((MyGdxGame.WIDTH - startGameButton.getWidth()) / 2f, 0.01f * MyGdxGame.HEIGHT);
+        startGameButton.setDisabled(!canHostStart);
+        startGameButton.setTouchable(!canHostStart
             ? com.badlogic.gdx.scenes.scene2d.Touchable.disabled
             : com.badlogic.gdx.scenes.scene2d.Touchable.enabled);
+        if (canHostStart) {
+          startGameButton.setColor(0.2f, 0.8f, 0.2f, 1f);
+        } else {
+          startGameButton.setColor(0.6f, 0.6f, 0.6f, 1f);
+        }
         startGameButton.addListener(new ClickListener() {
           @Override
           public void clicked(InputEvent event, float x, float y) {
@@ -519,9 +532,15 @@ public class MenuScreen extends AbstractScreen {
         menuStage.addActor(startGameButton);
 
         // Host still needs the ready toggle, but place it below Start.
-        button.setPosition((MyGdxGame.WIDTH - button.getWidth()) / 2f, 0.08f * MyGdxGame.HEIGHT);
+        button.setPosition((MyGdxGame.WIDTH - button.getWidth()) / 2f, 0.09f * MyGdxGame.HEIGHT);
       } else {
         button.setPosition((MyGdxGame.WIDTH - button.getWidth()) / 2f, 0.1f * MyGdxGame.HEIGHT);
+      }
+
+      if (timerStarted) {
+        Label countdownLabel = new Label("Starting in " + menuState.getTimeToStart() + "...", MyGdxGame.skin);
+        countdownLabel.setPosition(200, 25);
+        menuStage.addActor(countdownLabel);
       }
 
       // Rebuild hero dropdown excluding heroes reserved by other lobby players.
@@ -737,11 +756,26 @@ public class MenuScreen extends AbstractScreen {
         try {
           int timeToStart = data.getInt("seconds");
           menuState.setTimeToStart(timeToStart);
+          timerStarted = timeToStart > 0;
           Gdx.app.log("SocketIO", "Seconds to start game: " + timeToStart);
           show();
         } catch (JSONException e) {
           Gdx.app.log("SocketIO", "Error in timer!");
         }
+      }
+    });
+
+    socket.on("startCountdownCanceled", new SocketListener() {
+      @Override
+      public void call(Object... args) {
+        Gdx.app.postRunnable(new Runnable() {
+          @Override
+          public void run() {
+            timerStarted = false;
+            menuState.setTimeToStart(5);
+            updateScreen = true;
+          }
+        });
       }
     });
 

--- a/server/index.js
+++ b/server/index.js
@@ -69,6 +69,15 @@ function getReadyUsers(sess) {
   return sess.users.filter(function(u) { return u.isReady; });
 }
 
+function canSessionStart(sess, requesterSocketId) {
+  if (!sess || sess.gameState !== null || !sess.users.length || sess.users[0].id !== requesterSocketId) {
+    return false;
+  }
+
+  var requester = sess.users.find(function(u) { return u.id === requesterSocketId; });
+  return !!requester && requester.isReady && getReadyUsers(sess).length >= 2;
+}
+
 function cancelStartCountdown(sess, notifyClients) {
   if (sess.timer) {
     clearInterval(sess.timer);
@@ -81,17 +90,7 @@ function cancelStartCountdown(sess, notifyClients) {
 }
 
 function startCountdownForSession(sess, requesterSocketId, seconds) {
-  if (!sess || sess.gameState !== null) return false;
-
-  // Host is the first player in lobby order.
-  if (!sess.users.length || sess.users[0].id !== requesterSocketId) {
-    return false;
-  }
-
-  var requester = sess.users.find(function(u) { return u.id === requesterSocketId; });
-  var readyUsers = getReadyUsers(sess);
-  // Host must be ready and there must be at least 2 ready players in total.
-  if (!requester || !requester.isReady || readyUsers.length < 2) {
+  if (!canSessionStart(sess, requesterSocketId)) {
     return false;
   }
 
@@ -100,8 +99,7 @@ function startCountdownForSession(sess, requesterSocketId, seconds) {
   io.to(sess.id).emit('updateTimer', { seconds: sess.timeToStart });
 
   sess.timer = setInterval(function() {
-    // If ready players drop below 2, cancel countdown and wait again.
-    if (getReadyUsers(sess).length < 2) {
+    if (!canSessionStart(sess, requesterSocketId)) {
       cancelStartCountdown(sess, true);
       return;
     }
@@ -137,7 +135,7 @@ function startGameForSession(sess, requesterSocketId) {
   removedUsers.forEach(function(u) {
     delete socketToSession[u.id];
     delete sess.heroSelections[u.id];
-    var s = io.sockets.sockets.get(u.id);
+    var s = io.sockets.sockets[u.id];
     if (s) {
       s.leave(sess.id);
       s.emit('leftSessionNotReady');
@@ -163,6 +161,7 @@ function startGameForSession(sess, requesterSocketId) {
       playerIndex: idx,
       gameState: sess.gameState.serialize()
     });
+    console.log('gameState emitted to ' + u.name + ' (' + u.id + ') as player ' + idx);
   });
   broadcastSessionList();
   return true;
@@ -303,7 +302,7 @@ io.on('connection', function(socket) {
         }
       }
     }
-    if (sess.timer && getReadyUsers(sess).length < 2) {
+    if (sess.timer && !canSessionStart(sess, sess.users[0] && sess.users[0].id)) {
       cancelStartCountdown(sess, true);
     }
     io.to(sess.id).emit('getUsers', sess.users);

--- a/server/index.js
+++ b/server/index.js
@@ -65,6 +65,60 @@ function makeUser(id, name) {
   return { id: id, name: name || 'Player', isReady: false };
 }
 
+function getReadyUsers(sess) {
+  return sess.users.filter(function(u) { return u.isReady; });
+}
+
+function cancelStartCountdown(sess, notifyClients) {
+  if (sess.timer) {
+    clearInterval(sess.timer);
+    sess.timer = null;
+  }
+  sess.timeToStart = 0;
+  if (notifyClients) {
+    io.to(sess.id).emit('startCountdownCanceled');
+  }
+}
+
+function startCountdownForSession(sess, requesterSocketId, seconds) {
+  if (!sess || sess.gameState !== null) return false;
+
+  // Host is the first player in lobby order.
+  if (!sess.users.length || sess.users[0].id !== requesterSocketId) {
+    return false;
+  }
+
+  var requester = sess.users.find(function(u) { return u.id === requesterSocketId; });
+  var readyUsers = getReadyUsers(sess);
+  // Host must be ready and there must be at least 2 ready players in total.
+  if (!requester || !requester.isReady || readyUsers.length < 2) {
+    return false;
+  }
+
+  cancelStartCountdown(sess, false);
+  sess.timeToStart = seconds;
+  io.to(sess.id).emit('updateTimer', { seconds: sess.timeToStart });
+
+  sess.timer = setInterval(function() {
+    // If ready players drop below 2, cancel countdown and wait again.
+    if (getReadyUsers(sess).length < 2) {
+      cancelStartCountdown(sess, true);
+      return;
+    }
+
+    sess.timeToStart--;
+    io.to(sess.id).emit('updateTimer', { seconds: sess.timeToStart });
+    console.log("Session " + sess.id + " seconds left: " + sess.timeToStart);
+
+    if (sess.timeToStart <= 0) {
+      cancelStartCountdown(sess, false);
+      startGameForSession(sess, requesterSocketId);
+    }
+  }, 1000);
+
+  return true;
+}
+
 function startGameForSession(sess, requesterSocketId) {
   if (!sess || sess.gameState !== null) return false;
 
@@ -246,9 +300,11 @@ io.on('connection', function(socket) {
           sess.users[i].isReady = true;
         } else {
           sess.users[i].isReady = false;
-          clearInterval(sess.timer);
         }
       }
+    }
+    if (sess.timer && getReadyUsers(sess).length < 2) {
+      cancelStartCountdown(sess, true);
     }
     io.to(sess.id).emit('getUsers', sess.users);
   });
@@ -262,22 +318,9 @@ io.on('connection', function(socket) {
       socket.emit('gameAlreadyRunning');
       return;
     }
-    if (sess.users.length < 2) {
-      console.log("Not enough players to start (need at least 2)");
-      return;
+    if (!startCountdownForSession(sess, socket.id, seconds)) {
+      socket.emit('notEnoughReadyPlayers');
     }
-    sess.timeToStart = seconds;
-    clearInterval(sess.timer);
-    sess.timer = setInterval(function() {
-      sess.timeToStart--;
-      io.to(sess.id).emit('updateTimer', { seconds: sess.timeToStart });
-      console.log("Session " + sess.id + " seconds left: " + sess.timeToStart);
-      if (sess.timeToStart === 0) {
-        console.log("Timer finished for session " + sess.id + ", starting game");
-        startGameForSession(sess, socket.id);
-        clearInterval(sess.timer);
-      }
-    }, 1000);
   });
 
   socket.on('startGame', function() {
@@ -287,7 +330,7 @@ io.on('connection', function(socket) {
       socket.emit('gameAlreadyRunning');
       return;
     }
-    if (!startGameForSession(sess, socket.id)) {
+    if (!startCountdownForSession(sess, socket.id, 5)) {
       socket.emit('notEnoughReadyPlayers');
     }
   });
@@ -295,10 +338,7 @@ io.on('connection', function(socket) {
   socket.on('stopTimer', function() {
     var sess = getSession(socket.id);
     if (!sess) return;
-    if (sess.timeToStart <= 0) {
-      console.log("Timer stopped for session " + sess.id);
-      clearInterval(sess.timer);
-    }
+    cancelStartCountdown(sess, true);
   });
 
   // Client requests full state resync

--- a/server/index.js
+++ b/server/index.js
@@ -65,6 +65,55 @@ function makeUser(id, name) {
   return { id: id, name: name || 'Player', isReady: false };
 }
 
+function startGameForSession(sess, requesterSocketId) {
+  if (!sess || sess.gameState !== null) return false;
+
+  // Host is the first player in lobby order.
+  if (!sess.users.length || sess.users[0].id !== requesterSocketId) {
+    return false;
+  }
+
+  var readyUsers = sess.users.filter(function(u) { return u.isReady; });
+  if (readyUsers.length < 2) {
+    return false;
+  }
+
+  // Users who are not ready are removed from the session and sent back to list.
+  var removedUsers = sess.users.filter(function(u) { return !u.isReady; });
+  removedUsers.forEach(function(u) {
+    delete socketToSession[u.id];
+    delete sess.heroSelections[u.id];
+    var s = io.sockets.sockets.get(u.id);
+    if (s) {
+      s.leave(sess.id);
+      s.emit('leftSessionNotReady');
+      s.emit('sessionList', getSessionList());
+    }
+  });
+
+  sess.users = readyUsers;
+  sess.winnerHandled = false;
+  sess.gameState = new GameState(sess.users);
+
+  // Apply lobby starting hero selections before initial gameState broadcast.
+  sess.users.forEach(function(u, idx) {
+    var hero = sess.heroSelections[u.id];
+    if (hero && hero !== 'None') {
+      sess.gameState.heroAcquired(idx, hero);
+    }
+  });
+
+  io.to(sess.id).emit('getUsers', sess.users);
+  sess.users.forEach(function(u, idx) {
+    io.to(u.id).emit('gameState', {
+      playerIndex: idx,
+      gameState: sess.gameState.serialize()
+    });
+  });
+  broadcastSessionList();
+  return true;
+}
+
 function checkAndHandleWinner(sess) {
   if (!sess.gameState || sess.winnerHandled) return;
   const winner = sess.gameState.checkWinner();
@@ -225,28 +274,22 @@ io.on('connection', function(socket) {
       console.log("Session " + sess.id + " seconds left: " + sess.timeToStart);
       if (sess.timeToStart === 0) {
         console.log("Timer finished for session " + sess.id + ", starting game");
-        sess.winnerHandled = false;
-        sess.gameState = new GameState(sess.users);
-
-        // Apply lobby starting hero selections to the authoritative state BEFORE
-        // the initial gameState packet is sent, so all clients render the same heroes.
-        sess.users.forEach(function(u, idx) {
-          var hero = sess.heroSelections[u.id];
-          if (hero && hero !== 'None') {
-            sess.gameState.heroAcquired(idx, hero);
-          }
-        });
-
-        sess.users.forEach(function(u, idx) {
-          io.to(u.id).emit('gameState', {
-            playerIndex: idx,
-            gameState: sess.gameState.serialize()
-          });
-        });
+        startGameForSession(sess, socket.id);
         clearInterval(sess.timer);
-        broadcastSessionList();
       }
     }, 1000);
+  });
+
+  socket.on('startGame', function() {
+    var sess = getSession(socket.id);
+    if (!sess) return;
+    if (sess.gameState !== null) {
+      socket.emit('gameAlreadyRunning');
+      return;
+    }
+    if (!startGameForSession(sess, socket.id)) {
+      socket.emit('notEnoughReadyPlayers');
+    }
   });
 
   socket.on('stopTimer', function() {


### PR DESCRIPTION
- Add host-only startGame server flow.
- Start requires at least 2 ready players.
- Start includes only ready players in the game state.
- Move unready players back to session list.
- Replace lobby auto-timer start with host Start game button.