### PR TITLE
feat: tabbed session browser with live player list, logo only on name entry (#89)

### DIFF
--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -531,10 +531,13 @@ public class MenuScreen extends AbstractScreen {
     Image actionBar = new Image(MyGdxGame.skin.newDrawable("white", new Color(0f, 0f, 0f, 0.12f)));
     actionBar.setSize(0.86f * MyGdxGame.WIDTH, button.getHeight() + 24f);
     actionBar.setPosition(cx - actionBar.getWidth() / 2f, buttonY - 10f);
+    actionBar.setTouchable(com.badlogic.gdx.scenes.scene2d.Touchable.disabled);
 
     Label lobbyTitle = new Label("Game lobby", MyGdxGame.skin);
-    lobbyTitle.setColor(1f, 1f, 1f, 0.95f);
-    lobbyTitle.setPosition(cx - lobbyTitle.getWidth() / 2f, 0.83f * MyGdxGame.HEIGHT);
+    float lobbyTitleScale = 1.35f;
+    lobbyTitle.setFontScale(lobbyTitleScale);
+    lobbyTitle.setColor(1f, 1f, 1f, 0.98f);
+    lobbyTitle.setPosition(cx - (lobbyTitle.getPrefWidth() * lobbyTitleScale) / 2f, 0.835f * MyGdxGame.HEIGHT);
 
     // logged in count
     loggedInCount = new Label("Players in lobby: " + currentUsersCount, MyGdxGame.skin);

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -280,32 +280,59 @@ public class MenuScreen extends AbstractScreen {
     float cx = MyGdxGame.WIDTH / 2f;
 
     // ── Tab bar ──────────────────────────────────────────────────────────────
-    TextButton gamesTab = new TextButton("Games", MyGdxGame.skin);
-    TextButton playersTab = new TextButton("Players", MyGdxGame.skin);
+    // Plain labels (no button box) with a colored underline on the active tab.
+    final Color ACTIVE_COLOR   = Color.WHITE;
+    final Color INACTIVE_COLOR = new Color(1f, 1f, 1f, 0.35f);
+    final Color UNDERLINE_COLOR = new Color(0.98f, 0.80f, 0.25f, 1f); // warm gold
+
+    Label gamesTab   = new Label("Games",   MyGdxGame.skin);
+    Label playersTab = new Label("Players", MyGdxGame.skin);
     gamesTab.pack();
     playersTab.pack();
-    float tabGap = 16f;
+
+    float tabGap    = 32f;
     float tabsWidth = gamesTab.getWidth() + tabGap + playersTab.getWidth();
-    float tabY = 0.88f * MyGdxGame.HEIGHT;
+    float tabY      = 0.88f * MyGdxGame.HEIGHT;
+    float underlineH = 3f;
+    float underlinePad = 0f; // underline extends full label width
+
     gamesTab.setPosition(cx - tabsWidth / 2f, tabY);
     playersTab.setPosition(cx - tabsWidth / 2f + gamesTab.getWidth() + tabGap, tabY);
-    if (!showPlayersTab) {
-      gamesTab.setColor(Color.WHITE);
-      playersTab.setColor(0.55f, 0.55f, 0.55f, 1f);
-    } else {
-      gamesTab.setColor(0.55f, 0.55f, 0.55f, 1f);
-      playersTab.setColor(Color.WHITE);
-    }
-    gamesTab.addListener(new ClickListener() {
+
+    gamesTab.setColor(!showPlayersTab ? ACTIVE_COLOR : INACTIVE_COLOR);
+    playersTab.setColor(showPlayersTab  ? ACTIVE_COLOR : INACTIVE_COLOR);
+    // Labels are visual only; click handling comes from the larger invisible hit actors.
+    gamesTab.setTouchable(com.badlogic.gdx.scenes.scene2d.Touchable.disabled);
+    playersTab.setTouchable(com.badlogic.gdx.scenes.scene2d.Touchable.disabled);
+
+    // Underline under the active tab
+    Label activeTab = !showPlayersTab ? gamesTab : playersTab;
+    Image underline = new Image(MyGdxGame.skin.newDrawable("white", UNDERLINE_COLOR));
+    underline.setSize(activeTab.getWidth() - underlinePad * 2, underlineH);
+    underline.setPosition(activeTab.getX() + underlinePad, activeTab.getY() - underlineH - 2f);
+
+    // Hit areas: invisible touch actors behind each label so tap targets are generous
+    com.badlogic.gdx.scenes.scene2d.Actor gamesHit = new com.badlogic.gdx.scenes.scene2d.Actor();
+    gamesHit.setBounds(gamesTab.getX() - 8f, tabY - 8f,
+        gamesTab.getWidth() + 16f, gamesTab.getHeight() + 16f);
+    gamesHit.addListener(new ClickListener() {
       @Override public void clicked(InputEvent event, float x, float y) {
         showPlayersTab = false; show();
       }
     });
-    playersTab.addListener(new ClickListener() {
+
+    com.badlogic.gdx.scenes.scene2d.Actor playersHit = new com.badlogic.gdx.scenes.scene2d.Actor();
+    playersHit.setBounds(playersTab.getX() - 8f, tabY - 8f,
+        playersTab.getWidth() + 16f, playersTab.getHeight() + 16f);
+    playersHit.addListener(new ClickListener() {
       @Override public void clicked(InputEvent event, float x, float y) {
         showPlayersTab = true; show();
       }
     });
+
+    menuStage.addActor(gamesHit);
+    menuStage.addActor(playersHit);
+    menuStage.addActor(underline);
     menuStage.addActor(gamesTab);
     menuStage.addActor(playersTab);
 
@@ -488,20 +515,44 @@ public class MenuScreen extends AbstractScreen {
     return data;
   }
 
+  private Table createStatusBadge(String text, Color bgColor, Color textColor) {
+    Table badge = new Table();
+    badge.setBackground(MyGdxGame.skin.newDrawable("white", bgColor));
+    Label label = new Label(text, MyGdxGame.skin);
+    label.setColor(textColor);
+    badge.add(label).pad(2f, 8f, 2f, 8f);
+    return badge;
+  }
+
   private void showLobbyScreen() {
+    float cx = MyGdxGame.WIDTH / 2f;
+    float buttonY = 0.08f * MyGdxGame.HEIGHT;
+
+    Image actionBar = new Image(MyGdxGame.skin.newDrawable("white", new Color(0f, 0f, 0f, 0.12f)));
+    actionBar.setSize(0.86f * MyGdxGame.WIDTH, button.getHeight() + 24f);
+    actionBar.setPosition(cx - actionBar.getWidth() / 2f, buttonY - 10f);
+
+    Label lobbyTitle = new Label("Game lobby", MyGdxGame.skin);
+    lobbyTitle.setColor(1f, 1f, 1f, 0.95f);
+    lobbyTitle.setPosition(cx - lobbyTitle.getWidth() / 2f, 0.83f * MyGdxGame.HEIGHT);
+
     // logged in count
     loggedInCount = new Label("Players in lobby: " + currentUsersCount, MyGdxGame.skin);
-    loggedInCount.setPosition(0, 0);
+    loggedInCount.setPosition(0.05f * MyGdxGame.WIDTH, 0.01f * MyGdxGame.HEIGHT);
 
     // table with all logged in users
     Table loggedInUserTable = new Table(MyGdxGame.skin);
+    loggedInUserTable.setBackground(MyGdxGame.skin.newDrawable("white", new Color(0f, 0f, 0f, 0.14f)));
+    loggedInUserTable.pad(14f, 18f, 14f, 18f);
     ArrayList<User> loggedInUsers = menuState.getUsers();
 
     Label headLine1 = new Label("Name", MyGdxGame.skin);
     Label headLine2 = new Label("Status", MyGdxGame.skin);
+    headLine1.setColor(1f, 1f, 1f, 0.9f);
+    headLine2.setColor(1f, 1f, 1f, 0.9f);
 
-    loggedInUserTable.add(headLine1).padRight(60);
-    loggedInUserTable.add(headLine2);
+    loggedInUserTable.add(headLine1).padRight(60).padBottom(8f);
+    loggedInUserTable.add(headLine2).padBottom(8f);
     loggedInUserTable.row();
 
     for (int i = 0; i < loggedInUsers.size(); i++) {
@@ -512,22 +563,26 @@ public class MenuScreen extends AbstractScreen {
         nameLabel.setColor(Color.GOLD);
       }
 
-      Label isReady;
+      Table statusBadge;
       if (user.isReady()) {
-        isReady = new Label("READY", MyGdxGame.skin);
-        isReady.setColor(Color.GREEN);
+        statusBadge = createStatusBadge("READY", new Color(0.14f, 0.56f, 0.24f, 1f), Color.WHITE);
       } else {
-        isReady = new Label("WAIT", MyGdxGame.skin);
-        isReady.setColor(Color.RED);
+        statusBadge = createStatusBadge("WAIT", new Color(0.64f, 0.14f, 0.14f, 1f), new Color(1f, 0.94f, 0.94f, 1f));
       }
 
-      loggedInUserTable.add(nameLabel).padRight(60);
-      loggedInUserTable.add(isReady);
+      loggedInUserTable.add(nameLabel).padRight(60).padBottom(6f);
+      loggedInUserTable.add(statusBadge).left().padBottom(6f);
       loggedInUserTable.row();
+      if (i < loggedInUsers.size() - 1) {
+        Image sep = new Image(MyGdxGame.skin.newDrawable("white", new Color(1f, 1f, 1f, 0.14f)));
+        loggedInUserTable.add(sep).colspan(2).growX().height(1f).padTop(2f).padBottom(5f);
+        loggedInUserTable.row();
+      }
     }
 
     loggedInUserTable.pack();
-    loggedInUserTable.setPosition((MyGdxGame.WIDTH - loggedInUserTable.getWidth()) / 2f, 300);
+    loggedInUserTable.setPosition(cx - loggedInUserTable.getWidth() / 2f,
+        0.47f * MyGdxGame.HEIGHT - loggedInUserTable.getHeight() / 2f);
 
     // Notification permission status — temporarily hidden to avoid overlap with lobby buttons
     // if (MyGdxGame.turnNotifier.isPermissionGranted()) {
@@ -553,7 +608,7 @@ public class MenuScreen extends AbstractScreen {
       // A game is already in progress — show status and offer spectating
       Label gameRunningLabel = new Label("Game in progress", MyGdxGame.skin);
       gameRunningLabel.setColor(Color.YELLOW);
-      gameRunningLabel.setPosition(200, 50);
+      gameRunningLabel.setPosition(cx - gameRunningLabel.getWidth() / 2f, 0.11f * MyGdxGame.HEIGHT + 46f);
       menuStage.addActor(gameRunningLabel);
 
       TextButton watchButton = new TextButton("Watch game", MyGdxGame.skin);
@@ -582,10 +637,10 @@ public class MenuScreen extends AbstractScreen {
       boolean isHost = !loggedInUsers.isEmpty()
           && loggedInUsers.get(0).getUserID().equals(menuState.getMyUserID());
       boolean canHostStart = isHost && amReady && readyCount >= 2 && !timerStarted;
-      float buttonY = 0.08f * MyGdxGame.HEIGHT;
 
       Label lobbyStatus = new Label("Ready players: " + readyCount + " / " + loggedInUsers.size(), MyGdxGame.skin);
-      lobbyStatus.setPosition(200, 0);
+        lobbyStatus.setPosition(MyGdxGame.WIDTH - lobbyStatus.getWidth() - 0.05f * MyGdxGame.WIDTH,
+          0.01f * MyGdxGame.HEIGHT);
       menuStage.addActor(lobbyStatus);
 
       if (isHost) {
@@ -619,7 +674,8 @@ public class MenuScreen extends AbstractScreen {
 
       if (timerStarted) {
         Label countdownLabel = new Label("Starting in " + menuState.getTimeToStart() + "...", MyGdxGame.skin);
-        countdownLabel.setPosition(200, 25);
+        countdownLabel.setColor(Color.YELLOW);
+        countdownLabel.setPosition(cx - countdownLabel.getWidth() / 2f, buttonY + button.getHeight() + 14f);
         menuStage.addActor(countdownLabel);
       }
 
@@ -639,6 +695,8 @@ public class MenuScreen extends AbstractScreen {
       menuStage.addActor(button);
     }
 
+    menuStage.addActor(actionBar);
+    menuStage.addActor(lobbyTitle);
     menuStage.addActor(loggedInUserTable);
     menuStage.addActor(loggedInCount);
 

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -78,6 +78,19 @@ public class MenuScreen extends AbstractScreen {
     }
   }
 
+  // Live list of all named online players, broadcast by the server.
+  private java.util.List<OnlinePlayerInfo> onlinePlayers = new java.util.ArrayList<OnlinePlayerInfo>();
+  private boolean showPlayersTab = false;
+
+  private static class OnlinePlayerInfo {
+    String id;
+    String name;
+    String status;
+    OnlinePlayerInfo(String id, String name, String status) {
+      this.id = id; this.name = name; this.status = status;
+    }
+  }
+
   // Hero names in display order — used to rebuild the dropdown while preserving order.
   private static final String[] ALL_HERO_NAMES = {
     "Mercenaries", "Marshal", "Spy", "Battery Tower", "Merchant", "Priest",
@@ -211,9 +224,9 @@ public class MenuScreen extends AbstractScreen {
     heroSelectBox.hideList();
     menuStage.clear();
 
-    menuStage.addActor(group);
-
     if (!nameConfirmed) {
+      // Logo only shown on the name-entry screen.
+      menuStage.addActor(group);
       showNameEntryScreen();
     } else if (!lobbyJoined && inSessionCreate) {
       showSessionCreateScreen();
@@ -244,6 +257,11 @@ public class MenuScreen extends AbstractScreen {
             if (name.isEmpty()) return;
             menuState.setMyName(name);
             nameConfirmed = true;
+            try {
+              JSONObject reg = new JSONObject();
+              reg.put("name", name);
+              socket.emit("registerPlayer", reg);
+            } catch (JSONException e) { /* ignore */ }
             Gdx.app.postRunnable(new Runnable() {
               @Override public void run() { show(); }
             });
@@ -261,67 +279,127 @@ public class MenuScreen extends AbstractScreen {
   private void showSessionListScreen() {
     float cx = MyGdxGame.WIDTH / 2f;
 
-    Label title = new Label("Games", MyGdxGame.skin);
-    title.setPosition(cx - title.getWidth() / 2f, 0.75f * MyGdxGame.HEIGHT);
-    menuStage.addActor(title);
-
-    Table sessTable = new Table(MyGdxGame.skin);
-    Label h1 = new Label("Name", MyGdxGame.skin);
-    Label h2 = new Label("Players", MyGdxGame.skin);
-    Label h3 = new Label("", MyGdxGame.skin);
-    sessTable.add(h1).padRight(20);
-    sessTable.add(h2).padRight(20);
-    sessTable.add(h3);
-    sessTable.row();
-
-    final java.util.List<SessionInfo> list = new java.util.ArrayList<SessionInfo>(sessionList);
-    for (final SessionInfo s : list) {
-      Label nameL = new Label(s.name, MyGdxGame.skin);
-      Label countL = new Label(s.playerCount + "/4", MyGdxGame.skin);
-      if (s.running) {
-        Label runL = new Label("Playing", MyGdxGame.skin);
-        runL.setColor(Color.YELLOW);
-        TextButton watchBtn = new TextButton("Watch", MyGdxGame.skin);
-        watchBtn.addListener(new ClickListener() {
-          @Override
-          public void clicked(InputEvent event, float x, float y) {
-            socket.emit("joinSessionSpectator", buildJoinData(s.id));
-          }
-        });
-        sessTable.add(nameL).padRight(20);
-        sessTable.add(countL).padRight(20);
-        sessTable.add(watchBtn);
-      } else {
-        TextButton joinBtn = new TextButton("Join", MyGdxGame.skin);
-        joinBtn.addListener(new ClickListener() {
-          @Override
-          public void clicked(InputEvent event, float x, float y) {
-            socket.emit("joinSession", buildJoinData(s.id));
-          }
-        });
-        sessTable.add(nameL).padRight(20);
-        sessTable.add(countL).padRight(20);
-        sessTable.add(joinBtn);
-      }
-      sessTable.row();
+    // ── Tab bar ──────────────────────────────────────────────────────────────
+    TextButton gamesTab = new TextButton("Games", MyGdxGame.skin);
+    TextButton playersTab = new TextButton("Players", MyGdxGame.skin);
+    gamesTab.pack();
+    playersTab.pack();
+    float tabGap = 16f;
+    float tabsWidth = gamesTab.getWidth() + tabGap + playersTab.getWidth();
+    float tabY = 0.88f * MyGdxGame.HEIGHT;
+    gamesTab.setPosition(cx - tabsWidth / 2f, tabY);
+    playersTab.setPosition(cx - tabsWidth / 2f + gamesTab.getWidth() + tabGap, tabY);
+    if (!showPlayersTab) {
+      gamesTab.setColor(Color.WHITE);
+      playersTab.setColor(0.55f, 0.55f, 0.55f, 1f);
+    } else {
+      gamesTab.setColor(0.55f, 0.55f, 0.55f, 1f);
+      playersTab.setColor(Color.WHITE);
     }
-
-    sessTable.pack();
-    sessTable.setPosition(cx - sessTable.getWidth() / 2f, 0.35f * MyGdxGame.HEIGHT);
-    menuStage.addActor(sessTable);
-
-    TextButton createBtn = new TextButton("Create game", MyGdxGame.skin);
-    createBtn.setSize(button.getWidth() * 1.5f, button.getHeight());
-    createBtn.setPosition(cx - createBtn.getWidth() / 2f, 0.15f * MyGdxGame.HEIGHT);
-    createBtn.addListener(new ClickListener() {
-      @Override
-      public void clicked(InputEvent event, float x, float y) {
-        inSessionCreate = true;
-        show();
+    gamesTab.addListener(new ClickListener() {
+      @Override public void clicked(InputEvent event, float x, float y) {
+        showPlayersTab = false; show();
       }
     });
+    playersTab.addListener(new ClickListener() {
+      @Override public void clicked(InputEvent event, float x, float y) {
+        showPlayersTab = true; show();
+      }
+    });
+    menuStage.addActor(gamesTab);
+    menuStage.addActor(playersTab);
 
-    menuStage.addActor(createBtn);
+    if (!showPlayersTab) {
+      // ── Games tab ───────────────────────────────────────────────────────────
+      Table sessTable = new Table(MyGdxGame.skin);
+      Label h1 = new Label("Name", MyGdxGame.skin);
+      Label h2 = new Label("Players", MyGdxGame.skin);
+      Label h3 = new Label("", MyGdxGame.skin);
+      sessTable.add(h1).padRight(20);
+      sessTable.add(h2).padRight(20);
+      sessTable.add(h3);
+      sessTable.row();
+
+      final java.util.List<SessionInfo> list = new java.util.ArrayList<SessionInfo>(sessionList);
+      for (final SessionInfo s : list) {
+        Label nameL = new Label(s.name, MyGdxGame.skin);
+        Label countL = new Label(s.playerCount + "/4", MyGdxGame.skin);
+        if (s.running) {
+          TextButton watchBtn = new TextButton("Watch", MyGdxGame.skin);
+          watchBtn.addListener(new ClickListener() {
+            @Override
+            public void clicked(InputEvent event, float x, float y) {
+              socket.emit("joinSessionSpectator", buildJoinData(s.id));
+            }
+          });
+          sessTable.add(nameL).padRight(20);
+          sessTable.add(countL).padRight(20);
+          sessTable.add(watchBtn);
+        } else {
+          TextButton joinBtn = new TextButton("Join", MyGdxGame.skin);
+          joinBtn.addListener(new ClickListener() {
+            @Override
+            public void clicked(InputEvent event, float x, float y) {
+              socket.emit("joinSession", buildJoinData(s.id));
+            }
+          });
+          sessTable.add(nameL).padRight(20);
+          sessTable.add(countL).padRight(20);
+          sessTable.add(joinBtn);
+        }
+        sessTable.row();
+      }
+
+      sessTable.pack();
+      sessTable.setPosition(cx - sessTable.getWidth() / 2f, 0.45f * MyGdxGame.HEIGHT);
+      menuStage.addActor(sessTable);
+
+      TextButton createBtn = new TextButton("Create game", MyGdxGame.skin);
+      createBtn.setSize(button.getWidth() * 1.5f, button.getHeight());
+      createBtn.setPosition(cx - createBtn.getWidth() / 2f, 0.08f * MyGdxGame.HEIGHT);
+      createBtn.addListener(new ClickListener() {
+        @Override
+        public void clicked(InputEvent event, float x, float y) {
+          inSessionCreate = true;
+          show();
+        }
+      });
+      menuStage.addActor(createBtn);
+    } else {
+      // ── Players tab ─────────────────────────────────────────────────────────
+      Table playersTable = new Table(MyGdxGame.skin);
+      Label ph1 = new Label("Name", MyGdxGame.skin);
+      Label ph2 = new Label("Status", MyGdxGame.skin);
+      playersTable.add(ph1).padRight(40);
+      playersTable.add(ph2);
+      playersTable.row();
+
+      final java.util.List<OnlinePlayerInfo> snapshot =
+          new java.util.ArrayList<OnlinePlayerInfo>(onlinePlayers);
+      for (OnlinePlayerInfo p : snapshot) {
+        Label nameL = new Label(p.name, MyGdxGame.skin);
+        if (p.id.equals(menuState.getMyUserID())) nameL.setColor(Color.GOLD);
+        Label statusL = new Label(p.status, MyGdxGame.skin);
+        if (p.status.startsWith("In game")) statusL.setColor(Color.GREEN);
+        else if (p.status.startsWith("In lobby")) statusL.setColor(Color.YELLOW);
+        else if (p.status.startsWith("Watching")) statusL.setColor(Color.CYAN);
+        playersTable.add(nameL).padRight(40);
+        playersTable.add(statusL);
+        playersTable.row();
+      }
+
+      if (snapshot.isEmpty()) {
+        Label empty = new Label("No players online", MyGdxGame.skin);
+        empty.setColor(0.6f, 0.6f, 0.6f, 1f);
+        playersTable.add(empty).colspan(2);
+        playersTable.row();
+      }
+
+      playersTable.pack();
+      playersTable.setPosition(cx - playersTable.getWidth() / 2f, 0.45f * MyGdxGame.HEIGHT);
+      menuStage.addActor(playersTable);
+    }
+
     Gdx.input.setInputProcessor(menuStage);
   }
 
@@ -867,6 +945,7 @@ public class MenuScreen extends AbstractScreen {
             lobbyJoined = false;
             timerStarted = false;
             gameRunning = false;
+            showPlayersTab = false;
             menuState.clearUsers();
             reservedByOthers.clear();
             show();
@@ -884,6 +963,7 @@ public class MenuScreen extends AbstractScreen {
             timerStarted = false;
             gameRunning = false;
             lobbyJoined = false;
+            showPlayersTab = false;
             menuState.clearUsers();
             reservedByOthers.clear();
             game.setScreen(MenuScreen.this);
@@ -912,6 +992,32 @@ public class MenuScreen extends AbstractScreen {
               }
             } catch (JSONException e) {
               Gdx.app.log("SocketIO", "Error parsing sessionList");
+            }
+            if (!lobbyJoined) updateScreen = true;
+          }
+        });
+      }
+    });
+
+    socket.on("playerList", new SocketListener() {
+      @Override
+      public void call(Object... args) {
+        final JSONArray arr = (JSONArray) args[0];
+        Gdx.app.postRunnable(new Runnable() {
+          @Override
+          public void run() {
+            onlinePlayers.clear();
+            try {
+              for (int i = 0; i < arr.length(); i++) {
+                JSONObject p = arr.getJSONObject(i);
+                onlinePlayers.add(new OnlinePlayerInfo(
+                  p.getString("id"),
+                  p.getString("name"),
+                  p.getString("status")
+                ));
+              }
+            } catch (JSONException e) {
+              Gdx.app.log("SocketIO", "Error parsing playerList");
             }
             if (!lobbyJoined) updateScreen = true;
           }

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -339,16 +339,25 @@ public class MenuScreen extends AbstractScreen {
     if (!showPlayersTab) {
       // ── Games tab ───────────────────────────────────────────────────────────
       Table sessTable = new Table(MyGdxGame.skin);
+      sessTable.setBackground(MyGdxGame.skin.newDrawable("white", new Color(0f, 0f, 0f, 0.14f)));
+      sessTable.pad(14f, 18f, 14f, 18f);
+
       Label h1 = new Label("Name", MyGdxGame.skin);
       Label h2 = new Label("Players", MyGdxGame.skin);
       Label h3 = new Label("", MyGdxGame.skin);
-      sessTable.add(h1).padRight(20);
-      sessTable.add(h2).padRight(20);
-      sessTable.add(h3);
+      h1.setColor(1f, 1f, 1f, 0.9f);
+      h2.setColor(1f, 1f, 1f, 0.9f);
+      sessTable.add(h1).padRight(40).padBottom(8f).left();
+      sessTable.add(h2).padRight(40).padBottom(8f);
+      sessTable.add(h3).padBottom(8f);
+      sessTable.row();
+      Image hSep = new Image(MyGdxGame.skin.newDrawable("white", new Color(1f, 1f, 1f, 0.25f)));
+      sessTable.add(hSep).colspan(3).growX().height(1f).padBottom(6f);
       sessTable.row();
 
       final java.util.List<SessionInfo> list = new java.util.ArrayList<SessionInfo>(sessionList);
-      for (final SessionInfo s : list) {
+      for (int si = 0; si < list.size(); si++) {
+        final SessionInfo s = list.get(si);
         Label nameL = new Label(s.name, MyGdxGame.skin);
         Label countL = new Label(s.playerCount + "/4", MyGdxGame.skin);
         if (s.running) {
@@ -359,9 +368,9 @@ public class MenuScreen extends AbstractScreen {
               socket.emit("joinSessionSpectator", buildJoinData(s.id));
             }
           });
-          sessTable.add(nameL).padRight(20);
-          sessTable.add(countL).padRight(20);
-          sessTable.add(watchBtn);
+          sessTable.add(nameL).padRight(40).padBottom(6f).left();
+          sessTable.add(countL).padRight(40).padBottom(6f);
+          sessTable.add(watchBtn).padBottom(6f);
         } else {
           TextButton joinBtn = new TextButton("Join", MyGdxGame.skin);
           joinBtn.addListener(new ClickListener() {
@@ -370,15 +379,27 @@ public class MenuScreen extends AbstractScreen {
               socket.emit("joinSession", buildJoinData(s.id));
             }
           });
-          sessTable.add(nameL).padRight(20);
-          sessTable.add(countL).padRight(20);
-          sessTable.add(joinBtn);
+          sessTable.add(nameL).padRight(40).padBottom(6f).left();
+          sessTable.add(countL).padRight(40).padBottom(6f);
+          sessTable.add(joinBtn).padBottom(6f);
         }
+        sessTable.row();
+        if (si < list.size() - 1) {
+          Image sep = new Image(MyGdxGame.skin.newDrawable("white", new Color(1f, 1f, 1f, 0.14f)));
+          sessTable.add(sep).colspan(3).growX().height(1f).padTop(2f).padBottom(5f);
+          sessTable.row();
+        }
+      }
+
+      if (list.isEmpty()) {
+        Label empty = new Label("No games available", MyGdxGame.skin);
+        empty.setColor(0.6f, 0.6f, 0.6f, 1f);
+        sessTable.add(empty).colspan(3);
         sessTable.row();
       }
 
       sessTable.pack();
-      sessTable.setPosition(cx - sessTable.getWidth() / 2f, 0.45f * MyGdxGame.HEIGHT);
+      sessTable.setPosition(Math.round(cx - sessTable.getWidth() / 2f), Math.round(0.45f * MyGdxGame.HEIGHT));
       menuStage.addActor(sessTable);
 
       TextButton createBtn = new TextButton("Create game", MyGdxGame.skin);
@@ -395,24 +416,38 @@ public class MenuScreen extends AbstractScreen {
     } else {
       // ── Players tab ─────────────────────────────────────────────────────────
       Table playersTable = new Table(MyGdxGame.skin);
+      playersTable.setBackground(MyGdxGame.skin.newDrawable("white", new Color(0f, 0f, 0f, 0.14f)));
+      playersTable.pad(14f, 18f, 14f, 18f);
+
       Label ph1 = new Label("Name", MyGdxGame.skin);
       Label ph2 = new Label("Status", MyGdxGame.skin);
-      playersTable.add(ph1).padRight(40);
-      playersTable.add(ph2);
+      ph1.setColor(1f, 1f, 1f, 0.9f);
+      ph2.setColor(1f, 1f, 1f, 0.9f);
+      playersTable.add(ph1).padRight(40).padBottom(8f).left();
+      playersTable.add(ph2).padBottom(8f);
+      playersTable.row();
+      Image phSep = new Image(MyGdxGame.skin.newDrawable("white", new Color(1f, 1f, 1f, 0.25f)));
+      playersTable.add(phSep).colspan(2).growX().height(1f).padBottom(6f);
       playersTable.row();
 
       final java.util.List<OnlinePlayerInfo> snapshot =
           new java.util.ArrayList<OnlinePlayerInfo>(onlinePlayers);
-      for (OnlinePlayerInfo p : snapshot) {
+      for (int pi = 0; pi < snapshot.size(); pi++) {
+        OnlinePlayerInfo p = snapshot.get(pi);
         Label nameL = new Label(p.name, MyGdxGame.skin);
         if (p.id.equals(menuState.getMyUserID())) nameL.setColor(Color.GOLD);
         Label statusL = new Label(p.status, MyGdxGame.skin);
         if (p.status.startsWith("In game")) statusL.setColor(Color.GREEN);
         else if (p.status.startsWith("In lobby")) statusL.setColor(Color.YELLOW);
         else if (p.status.startsWith("Watching")) statusL.setColor(Color.CYAN);
-        playersTable.add(nameL).padRight(40);
-        playersTable.add(statusL);
+        playersTable.add(nameL).padRight(40).padBottom(6f).left();
+        playersTable.add(statusL).padBottom(6f);
         playersTable.row();
+        if (pi < snapshot.size() - 1) {
+          Image sep = new Image(MyGdxGame.skin.newDrawable("white", new Color(1f, 1f, 1f, 0.14f)));
+          playersTable.add(sep).colspan(2).growX().height(1f).padTop(2f).padBottom(5f);
+          playersTable.row();
+        }
       }
 
       if (snapshot.isEmpty()) {
@@ -423,7 +458,7 @@ public class MenuScreen extends AbstractScreen {
       }
 
       playersTable.pack();
-      playersTable.setPosition(cx - playersTable.getWidth() / 2f, 0.45f * MyGdxGame.HEIGHT);
+      playersTable.setPosition(Math.round(cx - playersTable.getWidth() / 2f), Math.round(0.45f * MyGdxGame.HEIGHT));
       menuStage.addActor(playersTable);
     }
 
@@ -537,7 +572,7 @@ public class MenuScreen extends AbstractScreen {
     float lobbyTitleScale = 1.35f;
     lobbyTitle.setFontScale(lobbyTitleScale);
     lobbyTitle.setColor(1f, 1f, 1f, 0.98f);
-    lobbyTitle.setPosition(cx - (lobbyTitle.getPrefWidth() * lobbyTitleScale) / 2f, 0.835f * MyGdxGame.HEIGHT);
+    lobbyTitle.setPosition(Math.round(cx - lobbyTitle.getPrefWidth() / 2f), Math.round(0.835f * MyGdxGame.HEIGHT));
 
     // logged in count
     loggedInCount = new Label("Players in lobby: " + currentUsersCount, MyGdxGame.skin);

--- a/server/index.js
+++ b/server/index.js
@@ -29,6 +29,29 @@ var sessions = {};
 var socketToSession = {};
 var _nextSessionId = 1;
 
+// All connected sockets with their display names (set via registerPlayer).
+// { [socketId]: { id, name } }
+var connectedPlayers = {};
+
+function getPlayerStatus(socketId) {
+  var sessId = socketToSession[socketId];
+  if (!sessId) return 'Online';
+  var sess = sessions[sessId];
+  if (!sess) return 'Online';
+  if (sess.spectators.indexOf(socketId) !== -1) return 'Watching: ' + sess.name;
+  if (sess.gameState !== null) return 'In game: ' + sess.name;
+  return 'In lobby: ' + sess.name;
+}
+
+function broadcastPlayerList() {
+  var list = Object.keys(connectedPlayers)
+    .filter(function(sid) { return connectedPlayers[sid].name; })
+    .map(function(sid) {
+      return { id: sid, name: connectedPlayers[sid].name, status: getPlayerStatus(sid) };
+    });
+  io.emit('playerList', list);
+}
+
 function createSession(name, allowHeroSelection) {
   var id = 's' + (_nextSessionId++);
   sessions[id] = {
@@ -209,6 +232,7 @@ function leaveCurrentSession(socket) {
   }
   delete socketToSession[socket.id];
   broadcastSessionList();
+  broadcastPlayerList();
 }
 
 var PORT = process.env.PORT || 8082;
@@ -218,12 +242,20 @@ server.listen(PORT, function() {
 
 io.on('connection', function(socket) {
   console.log("User Connected: " + socket.id);
+  connectedPlayers[socket.id] = { id: socket.id, name: '' };
   socket.emit('socketID', { id: socket.id });
   socket.emit('sessionList', getSessionList());
+  socket.emit('playerList', Object.keys(connectedPlayers)
+    .filter(function(sid) { return connectedPlayers[sid].name; })
+    .map(function(sid) {
+      return { id: sid, name: connectedPlayers[sid].name, status: getPlayerStatus(sid) };
+    }));
 
   socket.on('disconnect', function() {
     console.log("User Disconnected: " + socket.id);
+    delete connectedPlayers[socket.id];
     leaveCurrentSession(socket);
+    broadcastPlayerList();
   });
 
   // ── Session management events ────────────────────────────────────────────
@@ -233,9 +265,16 @@ io.on('connection', function(socket) {
     leaveCurrentSession(socket);
   });
 
+  socket.on('registerPlayer', function(data) {
+    var name = (data && data.name) ? String(data.name).slice(0, 30) : '';
+    if (connectedPlayers[socket.id]) connectedPlayers[socket.id].name = name;
+    broadcastPlayerList();
+  });
+
   socket.on('createSession', function(data) {
     leaveCurrentSession(socket); // clean up any previous session first
     var name = (data && data.name) ? String(data.name).slice(0, 30) : 'Player';
+    if (connectedPlayers[socket.id]) connectedPlayers[socket.id].name = name;
     var sessionName = (data && data.sessionName) ? String(data.sessionName).slice(0, 50) : name + "'s game";
     var allowHeroSelection = (data && data.allowHeroSelection !== false);
     var sess = createSession(sessionName, allowHeroSelection);
@@ -247,6 +286,7 @@ io.on('connection', function(socket) {
     io.to(sess.id).emit('getUsers', sess.users);
     socket.emit('gameStatus', { running: false });
     broadcastSessionList();
+    broadcastPlayerList();
   });
 
   socket.on('joinSession', function(data) {
@@ -257,6 +297,7 @@ io.on('connection', function(socket) {
     leaveCurrentSession(socket); // leave any previous session first
     sess = sessions[data.sessionId]; // re-fetch — leaveCurrentSession may have deleted a different session
     var name = (data.name) ? String(data.name).slice(0, 30) : 'Player';
+    if (connectedPlayers[socket.id]) connectedPlayers[socket.id].name = name;
     var existing = sess.users.find(function(u) { return u.id === socket.id; });
     if (!existing) sess.users.push(makeUser(socket.id, name));
     socketToSession[socket.id] = sess.id;
@@ -273,6 +314,7 @@ io.on('connection', function(socket) {
     io.to(sess.id).emit('getUsers', sess.users);
     socket.emit('gameStatus', { running: false });
     broadcastSessionList();
+    broadcastPlayerList();
   });
 
   socket.on('joinSessionSpectator', function(data) {

--- a/server/index.js
+++ b/server/index.js
@@ -187,6 +187,7 @@ function startGameForSession(sess, requesterSocketId) {
     console.log('gameState emitted to ' + u.name + ' (' + u.id + ') as player ' + idx);
   });
   broadcastSessionList();
+  broadcastPlayerList();
   return true;
 }
 
@@ -207,6 +208,7 @@ function checkAndHandleWinner(sess) {
       // Delete the session entirely — it won't appear in the session list anymore
       delete sessions[sessId];
       broadcastSessionList();
+      broadcastPlayerList();
     }, 5000);
   }
 }


### PR DESCRIPTION
Closes #89

## Changes

### Server (`server/index.js`)
- Added `connectedPlayers` map to track all connected sockets with their name and session state
- Added `getPlayerStatus(socketId)` helper returning `"Online"`, `"In lobby: X"`, `"In game: X"`, or `"Watching: X"`
- Added `broadcastPlayerList()` that emits a `playerList` array (named players only) to all clients
- New `registerPlayer` event: client sends name on entry so the server tracks it before session creation
- `createSession` / `joinSession` now update the player's name in `connectedPlayers` and broadcast the updated list
- `disconnect` removes the player and broadcasts the update

### Client (`core/src/com/mygdx/game/MenuScreen.java`)
- Added `OnlinePlayerInfo` inner class (`id`, `name`, `status`) and `onlinePlayers` list
- Added `showPlayersTab` flag (reset to `false` when returning from lobby)
- **Logo** is now only added to the stage on the name-entry screen
- **Name entry**: emits `registerPlayer` immediately after the user confirms their name
- **Session list screen** rewritten with a **Games | Players** tab bar:
  - *Games tab*: existing session table + "Create game" button (unchanged functionality)
  - *Players tab*: table of all named online players with coloured status labels (Gold = self, Green = in game, Yellow = in lobby, Cyan = watching)
- New `playerList` socket handler updates `onlinePlayers` and triggers a screen refresh