### PR TITLE
feat: king defeat grants prey cards and enemy hero steal

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -130,6 +130,8 @@ public class GameScreen extends ScreenAdapter {
   private JSONObject pendingAttackBroadcast = null;
   // Plunder preview broadcast: set from stateUpdate when another player has a pending plunder
   private JSONObject pendingPlunderBroadcast = null;
+  // Pending hero selection after a successful king defeat (attacker must choose one hero)
+  private java.util.ArrayList<String> pendingKingDefeatHeroOptions = null;
   // Battery Tower: card IDs revealed to the defender after they allow or deny
   private JSONArray pendingBatteryResultCards = null;
   // Set when the current player ended their turn without attacking -- they must expose a defense card.
@@ -2073,6 +2075,53 @@ public class GameScreen extends ScreenAdapter {
       }
     }
 
+    // King-defeat hero selection overlay — shown to the attacker when they must pick one of the
+    // defeated player's heroes. Only appears when pendingKingDefeatHeroOptions is populated.
+    if (pendingKingDefeatHeroOptions != null && !pendingKingDefeatHeroOptions.isEmpty()) {
+      final java.util.ArrayList<String> kdOptions = pendingKingDefeatHeroOptions;
+
+      Image kdOverlay = new Image(MyGdxGame.skin, "white");
+      kdOverlay.setFillParent(true);
+      kdOverlay.setColor(0f, 0f, 0f, 0.78f);
+      gameStage.addActor(kdOverlay);
+
+      Label kdTitle = new Label("Choose a Hero from the defeated player:", MyGdxGame.skin);
+      kdTitle.setColor(Color.GOLD);
+      kdTitle.setPosition(MyGdxGame.WIDTH / 2f - kdTitle.getPrefWidth() / 2f, MyGdxGame.WIDTH * 0.78f);
+      gameStage.addActor(kdTitle);
+
+      float btnW    = MyGdxGame.WIDTH / 5f;
+      float btnGapX = MyGdxGame.WIDTH * 0.05f;
+      float startX  = (MyGdxGame.WIDTH - 4f * btnW - 3f * btnGapX) / 2f;
+      float startY  = MyGdxGame.WIDTH * 0.62f;
+      float rowH    = 0f;
+
+      for (int ci = 0; ci < kdOptions.size(); ci++) {
+        final String heroName = kdOptions.get(ci);
+        TextButton heroBtn = new TextButton(heroName, MyGdxGame.skin);
+        if (rowH == 0f) rowH = heroBtn.getHeight() + 8f;
+        int col = ci % 4;
+        int row = ci / 4;
+        heroBtn.setWidth(btnW);
+        heroBtn.setPosition(startX + col * (btnW + btnGapX), startY - row * rowH);
+        heroBtn.addListener(new ClickListener() {
+          @Override
+          public void clicked(InputEvent event, float x, float y) {
+            pendingKingDefeatHeroOptions = null;
+            try {
+              JSONObject emitData = new JSONObject();
+              emitData.put("heroName", heroName);
+              socket.emit("heroSelectedFromKingDefeat", emitData);
+            } catch (JSONException e) {
+              e.printStackTrace();
+            }
+            gameState.setUpdateState(true);
+          }
+        });
+        gameStage.addActor(heroBtn);
+      }
+    }
+
     // Sword overlay on both harvest decks when plunder is available — added late so it sits above all cards.
     // Crone overlay on own king card when king attack is possible.
     if (gameState.getCurrentPlayer() == currentPlayer) {
@@ -3300,6 +3349,21 @@ public class GameScreen extends ScreenAdapter {
         pendingPlunderBroadcast = serverPendingPlunder;
       } else {
         pendingPlunderBroadcast = null;
+      }
+
+      // Sync pending hero selection after king defeat (only relevant to the attacker)
+      JSONObject serverPendingHeroSel = state.optJSONObject("pendingHeroSelection");
+      if (serverPendingHeroSel != null && serverPendingHeroSel.optInt("attackerIdx", -1) == playerIndex) {
+        JSONArray optionsJson = serverPendingHeroSel.optJSONArray("options");
+        if (optionsJson != null && optionsJson.length() > 0) {
+          java.util.ArrayList<String> opts = new java.util.ArrayList<String>();
+          for (int oi = 0; oi < optionsJson.length(); oi++) opts.add(optionsJson.getString(oi));
+          pendingKingDefeatHeroOptions = opts;
+        } else {
+          pendingKingDefeatHeroOptions = null;
+        }
+      } else {
+        pendingKingDefeatHeroOptions = null;
       }
 
       // 5. Rebuild picking decks in-place (keep PickingDeck objects to preserve listeners)

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -447,18 +447,41 @@ class GameState {
     if (kingUsed) attacker.kingCovered = false;
     if (success) {
       this.pushLog(`${this.pname(attackerIdx)} defeated ${this.pname(defenderIdx)}!`, true);
-      // Defender loses their king and is eliminated; attacker gains their cards
+      // Defender loses their king and is eliminated; attacker gains their cards as prey
       defender.isOut = true;
-      for (const cardId of defender.hand) attacker.hand.push(cardId);
+      if (!attacker.preyCards) attacker.preyCards = [];
+      for (const cardId of defender.hand) {
+        attacker.hand.push(cardId);
+        attacker.preyCards.push(cardId);
+      }
       defender.hand = [];
       if (defender.kingCard !== null) {
         attacker.hand.push(defender.kingCard);
+        attacker.preyCards.push(defender.kingCard);
         defender.kingCard = null;
+      }
+      // Hero stealing: auto-transfer if defender has exactly one hero; queue selection otherwise
+      const defHeroes = defender.heroes || [];
+      if (defHeroes.length === 1) {
+        this.heroAcquired(attackerIdx, defHeroes[0]);
+      } else if (defHeroes.length > 1) {
+        this.pendingHeroSelection = { attackerIdx, defenderIdx, options: [...defHeroes] };
       }
     } else {
       this.pushLog(`${this.pname(attackerIdx)} king assault on ${this.pname(defenderIdx)} failed`, false);
       if (kingUsed) attacker.isOut = true;
     }
+  }
+
+  resolveHeroSelection(heroName) {
+    if (!this.pendingHeroSelection) return;
+    const { attackerIdx, defenderIdx } = this.pendingHeroSelection;
+    const defender = this.players[defenderIdx];
+    // Remove all of the defender's heroes (they return to the pool / are lost)
+    defender.heroes = [];
+    // Give the chosen hero to the attacker (heroAcquired removes it from all players first)
+    this.heroAcquired(attackerIdx, heroName);
+    this.pendingHeroSelection = null;
   }
 
   warlordKingSwap(playerIdx, oldKingCardId, newKingCardId) {
@@ -570,6 +593,7 @@ class GameState {
       merchantReveal: this.lastMerchantReveal || null,
       pendingAttack: this.pendingAttack || null,
       pendingPlunder: this.pendingPlunder || null,
+      pendingHeroSelection: this.pendingHeroSelection || null,
     };
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -477,6 +477,18 @@ io.on('connection', function(socket) {
     checkAndHandleWinner(sess);
   });
 
+  socket.on('heroSelectedFromKingDefeat', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
+    var pending = sess.gameState.pendingHeroSelection;
+    if (!pending) return;
+    var userIdx = sess.users.findIndex(function(u) { return u.id === socket.id; });
+    if (userIdx !== pending.attackerIdx) return;
+    console.log("heroSelectedFromKingDefeat: attacker=" + userIdx + " hero=" + data.heroName);
+    sess.gameState.resolveHeroSelection(data.heroName);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+  });
+
   socket.on('exposeDefCard', function(data) {
     var sess = getSession(socket.id);
     if (!sess || !sess.gameState) return;


### PR DESCRIPTION
Closes #98

## Changes

### Server — `server/gameState.js`
- `kingAttackResolved()`: all captured cards (hand + king) are now also pushed into `attacker.preyCards`, so they are locked until the attacker's turn ends.
- If the defeated player has **one hero**: auto-transferred to the attacker via `heroAcquired()`.
- If the defeated player has **two or more heroes**: a `pendingHeroSelection` object is stored on the game state so the attacker can pick one; remaining heroes are discarded.
- New method `resolveHeroSelection(heroName)`: finalises the choice, wipes the defender's hero list, gives the chosen hero to the attacker.
- `serialize()` now includes `pendingHeroSelection` in the broadcast.

### Server — `server/index.js`
- New socket event `heroSelectedFromKingDefeat`: validates sender is the attacker, calls `resolveHeroSelection`, broadcasts state update.

### Client — `core/.../GameScreen.java`
- `applyStateUpdate()`: syncs `pendingHeroSelection` from the server state into `pendingKingDefeatHeroOptions` (only populated for the attacker).
- New hero-selection overlay in `showGameStage()`: shown when `pendingKingDefeatHeroOptions` is non-empty; displays one button per hero option; on tap emits `heroSelectedFromKingDefeat` and clears the overlay.
