### PR TITLE
feat: add Rules button in session menu (issue #94)

### DIFF
--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -32,6 +32,8 @@ import com.mygdx.game.net.SocketListener;
 
 public class MenuScreen extends AbstractScreen {
 
+  private static final String RULES_URL = "https://perahrens.github.io/baisch/";
+
   private SocketClient socket;
 
   private Stage menuStage;
@@ -461,6 +463,17 @@ public class MenuScreen extends AbstractScreen {
       playersTable.setPosition(Math.round(cx - playersTable.getWidth() / 2f), Math.round(0.45f * MyGdxGame.HEIGHT));
       menuStage.addActor(playersTable);
     }
+
+    TextButton rulesBtn = new TextButton("Rules", MyGdxGame.skin);
+    rulesBtn.setSize(button.getWidth(), button.getHeight());
+    rulesBtn.setPosition(20f, 0.08f * MyGdxGame.HEIGHT);
+    rulesBtn.addListener(new ClickListener() {
+      @Override
+      public void clicked(InputEvent event, float x, float y) {
+        Gdx.net.openURI(RULES_URL);
+      }
+    });
+    menuStage.addActor(rulesBtn);
 
     Gdx.input.setInputProcessor(menuStage);
   }


### PR DESCRIPTION
Closes #94

## What changed
- Added a Rules button to the post-name session list screen.
- Button opens https://perahrens.github.io/baisch/ via Gdx.net.openURI.
- Kept existing session-list, create, and join flows unchanged.

## File
- core/src/com/mygdx/game/MenuScreen.java