### PR TITLE
docs: rewrite GitHub Pages rules book (#95)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,215 +1,128 @@
-# Game Instructions
+# Baisch - Rules Book
 
-## Preparation
+This page is the short and practical rules reference for live games.
 
-The game components include a complete deck of 52 cards and three Jokers. 
-Additionally, chess pieces are required, and their attributes are described in the [Heroes](#heroes) 
-section.
+## Goal
 
-At the beginning of the game, each player receives eight cards. Then each player:
-- selects two cards to be thrown on the graveyard
-- selects one card as to be his King card
-- selects up to three defense cards
-- the remaining cards are kept as hand cards
+Be the last player still in the game.
 
-Now, a card is placed face up in the middle of the playing field. 
-Another card is placed face down on top of it, so that the lower card is still visible. 
-This process is repeated, creating two stacks, each consisting of two cards in the middle of the playing field. 
-These two stacks are referred to as the Harvest stacks. The stack with the remaining cards is placed beside them.
+You are eliminated when your king is defeated in a king assault.
 
-Next, a game of Rock, Paper, Scissors is played. The first winner then selects one of the twelve heroes for each opponent. 
-Then, the next winner chooses one of the remaining heroes for each opponent. This continues until each player has two heroes. 
-The first winner now designates a person to start the game. From there, the game proceeds clockwise.
+## Setup Overview
 
-## Gameplay
+Each player starts with:
+- 1 king card (face-down)
+- up to 3 defense cards in slots 1-3 (face-down)
+- hand cards
 
-During a turn, a player can perform various actions, which are described below. 
-If an attack is played, whether on a stack or an opponent's defense card, the first symbol (Diamond, Heart, Spade, Club) determines the attack symbol that must be used for the subsequent attacks during the turn. 
-For attacks, cards of the same symbol can be combined freely, so the attack value is the sum of the individual card values. The attack value of the cards corresponds to the numeric value depicted on them. The values for Jack, Queen, King, and Ace correspond to numeric values from 11 to 14. The Joker can be played regardless of the current attack symbol, and its attack value is arbitrarily high.
+Shared board:
+- main deck
+- cemetery (discard pile)
+- 2 center picking decks for plunder
 
-### Plunder
+At round start, players roll dice to determine turn order.
 
-During their turn, the player has one opportunity to attack one of the two Harvest stacks in the center.
+## Turn Flow
 
-#### Success
+On your turn, you can:
+- take one of your defense cards back to hand
+- put a hand card as a new face-down defense card
+- plunder one picking deck
+- attack enemy defense cards
+- attack an enemy king if legal
+- use hero abilities
 
-If the attack value is higher than the defense value of the top card on the stack, the player receives all the cards from that stack. The cards used for this attack are placed face up in the graveyard. After a successful attack, a card is placed face down on the other Harvest stack. On the stack that was defeated, another card is placed face up, and one face down.
+End your turn with Finish Turn.
 
-The cards that are won can be used during the current turn.
+## Card Strength Basics
 
-#### Failed
+- Number cards: face value
+- J, Q, K, A: 11, 12, 13, 14
+- Joker in hand attacks as a wild high-impact card
+- Joker as a defense card counts as 1
 
-If the attack value is equal to or less than the top card of the attacked Harvest stack, the attack cards used are placed face up in the graveyard. A new card is placed face down on top of the revealed card in the attacked Harvest stack. Even in the case of a failed attack, the Harvest stacks cannot be attacked during the current turn.
+## Core Actions
 
-### Attack Enemy
+### 1) Plunder
 
-Furthermore, the player has the option to attack an opponent's defense card or an opponent's King as many times as desired. If the attack value is higher than the value of the defense card, the player acquires the attacked card. Otherwise, it remains in the opponent's defense. In both cases, the cards used for the attack are placed face up in the graveyard. If the defense card was previously face down, it is now face up.
+Attack one of the two center picking decks.
 
-If an opponent has no defense cards left, their King can be attacked. If the King is defeated, the player receives all the hand cards of the defeated player, and the defeated player is eliminated from the game.
+- Success: you take all cards from that picking deck.
+- Fail: the deck grows and becomes a larger future target.
 
-It should be noted that cards won through conquest can only be used in the next turn. They must remain in the hand cards during the current turn.
+### 2) Attack Enemy Defense
 
-If no attack is played during the turn, the player must reveal one of their defense cards.
+Use hand cards to beat an enemy defense value.
 
-### Manage Defense
+- Success: captured card(s) go to your hand as prey cards.
+- Fail: target remains and is usually revealed.
 
-During their turn, the player has the option to draw a card from their defense cards and to place one face down.
+### 3) King Assault (Attack Enemy King)
 
-### Play Heroes
+If the enemy has no defense left, you can attack their king.
 
-Furthermore, during their turn, the player has the option to use the abilities of their heroes. The specific characteristics and abilities of each hero are described in the Heroes section.
+- Success: defender is eliminated.
+- If you used your own king and fail, you can be eliminated.
 
-Jokers can also be used to draw an additional hero from the remaining heroes or to take a hero from another player. When a new hero is drawn, their ability can only be used in the next turn. A taken hero is returned to the remaining heroes and becomes available to the next player who plays a Joker.
+### 4) Manage Defense
 
-### Attack with King
+Build and reposition your defense to stay protected while preparing attacks.
 
-If the player no longer has a defense card in front of them, they have the option to attack with their own King if the King's symbol matches the current attack symbol. They can attack both an opponent's defense card and a Harvest stack. To do so, the King card must be revealed. Only one attack with the King is allowed per turn.
+## Prey Cards
 
-In the case of a successful attack, the King card remains in its place. If the King's attack value is lower than the value of the attacked card, the player loses, and all their cards go to the graveyard. If the values are equal, nothing happens.
+Captured cards this turn are prey cards.
 
-It is not possible to combine the King with other attack cards, but it can be reinforced with Mercenaries or Reservists.
-
-### How to Win 
-
-The goal of the game is to be the last player remaining. A player is considered defeated when their King has been defeated.
+- Prey cards are locked for the rest of your current turn.
+- They become usable normally on your next turn.
 
 ## Heroes
 
-### White Force
+You gain heroes by sacrificing a joker.
 
-#### Mercenaries
+Draw mapping:
 
-<div style="display: flex; align-items: center;">
-    <img src="images/mercenaries.png" alt="Image description" width="200" style="margin-right: 10px;">
-    <div style="flex: 1;">
-        The player receives four starting figures. At the beginning of each turn, four of the maximum eight Mercenaries are drawn. During the turn, any number of Mercenaries can be used to reinforce an attack, with one Mercenary counting as one attack point. After the attack, the Mercenaries are put back and are no longer available to the player. At the end of the turn, Mercenaries can be placed on defense cards to reinforce them. If the respective defense card is defeated, the corresponding Mercenaries are also defeated.
-    </div>
-</div>
+| Drawn Card | Hero / Result |
+|---|---|
+| 2 | Mercenaries |
+| 3 | Marshal |
+| 4 | Spy |
+| 5 | Battery Tower |
+| 6 | Merchant |
+| 7 | Priest |
+| 8 | Reservists |
+| 9 | Banneret |
+| 10 | Saboteurs |
+| J | Fortified Tower |
+| Q | Magician |
+| K | Warlord |
+| Red Ace | Choose a white hero (2-7) |
+| Black Ace | Choose a black hero (8-K) |
+| Joker | Free choice of any hero |
 
-#### Spy
+Hero quick summary:
 
-<div style="display: flex; align-items: center;">
-    <img src="images/spy.png" alt="Image description" width="200" style="margin-right: 10px;">
-    <div style="flex: 1;">
-        With the Spy, the player can reveal a facedown defense card of an opponent during their turn. If the player discards one of their hand cards, they can reveal two more cards. If an opponent has no more defense cards to reveal, their King can also be uncovered.
-    </div>
-</div>
+- Mercenaries: spend units for temporary attack boosts.
+- Marshal: stronger take/put economy per turn.
+- Spy: reveal hidden enemy defense cards.
+- Battery Tower: deny one incoming attack and lock attacker cards.
+- Merchant: discard one card to draw one card.
+- Priest: convert matching-suit enemy hand cards after attack setup.
+- Reservists: boost king defense and optionally boost attack.
+- Banneret: allows mixed-color attack behavior and own-defense attack support.
+- Saboteurs: block enemy defense slots.
+- Fortified Tower: add a top defense card to stack defense values.
+- Magician: replace defense cards with fresh draws.
+- Warlord: special king-driven attack options and king swap utility.
 
-#### General
+## Win Condition
 
-<div style="display: flex; align-items: center;">
-    <img src="images/general.png" alt="Image description" width="200" style="margin-right: 10px;">
-    <div style="flex: 1;">
-        The General allows the player to mobilize their defense cards more quickly. The player 
-can take three actions, with one action corresponding to placing or removing a defense card.
-    </div>
-</div>
+The last non-eliminated player wins.
 
-#### Battery Tower
+## New Player Tips
 
-<div style="display: flex; align-items: center;">
-    <img src="images/batterytower.png" alt="Image description" width="200" style="margin-right: 
-10px;">
-    <div style="flex: 1;">
-        The Battery Tower allows the player to decline an attack. The attacking player no longer 
-has 
-access to the corresponding attack cards during their turn. After a blocked attack, the Battery 
-Tower can no longer be used and must be reactivated during the owner's next turn. The attacking 
-player can keep the attack cards face down during the attack as long as the Battery Tower is 
-still active.
-    </div>
-</div>
-
-
-#### Merchant
-
-<div style="display: flex; align-items: center;">
-    <img src="images/merchant.png" alt="Image description" width="200" style="margin-right: 
-10px;">
-    <div style="flex: 1;">
-        The Merchant allows the player to discard any hand card and draw a new card from the stack during their turn. The discarded card is then visible to the other players, while the newly acquired card can remain face down.
-    </div>
-</div>
-
-#### Priest
-
-<div style="display: flex; align-items: center;">
-    <img src="images/priest.png" alt="Image description" width="200" style="margin-right: 
-10px;">
-    <div style="flex: 1;">
-        After the player has initiated an attack, thus setting the attack symbol for their turn, they can use the ability of the Priest. The player can now draw a card from the hand cards of any opponent. If the symbol matches the attack symbol, the player may keep the card; otherwise, they must return it. If the first attempt fails, the process can be repeated once. The second card can also be drawn from a different opponent.
-    </div>
-</div>
-
-### Dark Force
-
-#### Reservists
-
-<div style="display: flex; align-items: center;">
-    <img src="images/reservists.png" alt="Image description" width="200" style="margin-right: 
-10px;">
-    <div style="flex: 1;">
-        The player receives two Reservists upon acquiring the Hero. At the beginning of each turn, 
-two more of the four Reservists can be enlisted. Reservists can be used to enhance attacks, with each Reservist counting as one attack point and no longer being available to the player after the attack. Reservists can also be used for post-attack reinforcement. Thus, a narrowly lost attack can still turn into a successful attack
-    </div>
-</div>
-
-#### Saboteurs
-
-<div style="display: flex; align-items: center;">
-    <img src="images/saboteurs.png" alt="Image description" width="200" style="margin-right: 
-10px;">
-    <div style="flex: 1;">
-        During their turn, the player can place Saboteurs on the opponent's defense cards, whether they are face up or face down. The cards are thus blocked for the respective opponent and cannot be drawn by them during their turn. If the card is defeated, the besieging Saboteur returns to the owning player.
-    </div>
-</div>
-
-#### Lieutenant
-
-<div style="display: flex; align-items: center;">
-    <img src="images/lieutenant.png" alt="Image description" width="200" style="margin-right: 
-10px;">
-    <div style="flex: 1;">
-        The Field Marshal allows the player to use defense cards directly for the attack. The first card played in this manner determines the attack symbol for the subsequent attacks from the defense cards. The defense cards can be combined with each other in this case. Defense cards laid during the turn can also be used for the attack.
-    </div>
-</div>
-
-#### Fortified Tower
-
-<div style="display: flex; align-items: center;">
-    <img src="images/fortifiedtower.png" alt="Image description" width="200" style="margin-right: 
-10px;">
-    <div style="flex: 1;">
-        With the Watchtower, the player can, during their turn, place a card face down on one of their defense cards. The symbols must match. If the card is attacked, both defense cards are revealed, and their values are counted together as the defense value. If the card is spied upon, only the top card is revealed. When picking up the defense cards, both cards must be added to the hand cards, and this is counted as one action.
-    </div>
-</div>
-
-#### Mage
-
-<div style="display: flex; align-items: center;">
-    <img src="images/mage.png" alt="Image description" width="200" style="margin-right: 
-10px;">
-    <div style="flex: 1;">
-        With the Magician, the player can, during their turn, remove an opponent's defense card and replace it with a new one from the stack. If the card was previously face down, the new card is placed face up, and vice versa.
-    </div>
-</div>
-
-#### Warlord
-
-<div style="display: flex; align-items: center;">
-    <img src="images/warlord.png" alt="Image description" width="200" style="margin-right: 
-10px;">
-    <div style="flex: 1;">
-        The Warlord allows the player to initiate a direct attack with the King. The stack 
-cannot be attacked in this case, and the King cannot be combined with other attack cards. The King's symbol must match the current attack symbol. If the defense and attack values are equal, nothing happens. If the King's value is lower than the defense value, the player loses. The King can be reinforced with Mercenaries and Reservists.
-    </div>
-</div>
-
-## Variants
-
-### Speed-Baisch
-
-### Basic-Baisch
-
-## FAQ
+1. Keep at least one strong hidden defense while building offense.
+2. Plunder early if your hand is weak.
+3. Avoid king assault unless odds are clearly good.
+4. Use jokers when a hero can immediately impact your turn.
+5. Track enemy hero resources before committing attacks.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,37 +111,94 @@ Draw mapping:
 
 ![Mercenaries](images/mercenaries.png)
 
-You can spend mercenary units to add temporary attack power. Units regenerate over time, so this hero is best for creating short, explosive attack turns.
+How to use:
+- Select Mercenaries during your turn before resolving an attack.
+- Spend one ready mercenary to add +1 attack value.
+- Repeat as needed while ready units are available.
+
+Important rules:
+- Mercenaries are temporary units and recover over turns.
+- They can be used to swing close attack or plunder calculations.
+- If a mercenary on a defended position is destroyed, it is lost and must recover.
+
+Best use:
+- Save units for key combats where +1 to +3 changes the outcome.
 
 #### Marshal
 
 ![Marshal](images/general.png)
 
-Improves defense management economy. You can perform more efficient take/put sequencing each turn, which helps stabilize your board while still preparing attacks.
+How to use:
+- Marshal modifies your defense management economy each turn.
+- You can perform more mobilization actions (take/put) than normal.
+
+Important rules:
+- Mobilization means taking a defense card back to hand or placing one from hand to defense.
+- Use this to rebuild defense without sacrificing tempo.
+
+Best use:
+- Reorganize weak slots and still keep enough cards for attacks in the same turn.
 
 #### Spy
 
 ![Spy](images/spy.png)
 
-Reveals hidden enemy defense cards. With extra cost, Spy can reveal additional cards. This turns uncertainty into information and enables stronger attack planning.
+How to use:
+- Activate Spy during your turn to reveal a face-down enemy defense card.
+- If available in your ruleset, discard one hand card to gain additional reveals.
+
+Important rules:
+- Revealed cards remove uncertainty and let you plan exact attack sums.
+- Spy is strongest before committing high-value attack cards.
+
+Best use:
+- Reveal first, then choose the lowest-risk attack target.
 
 #### Battery Tower
 
 ![Battery Tower](images/batterytower.png)
 
-Can deny one incoming attack (when charged), causing the attacker to lose access to the committed attack cards for that turn. Excellent defensive tempo tool.
+How to use:
+- Battery Tower triggers when an opponent attacks your defense or king.
+- Choose to deny the attack while the tower is charged.
+
+Important rules:
+- Denied attack cards are locked for the attacker for the rest of that turn.
+- Tower typically has limited charges and must recover.
+
+Best use:
+- Deny expensive attacks to create major tempo advantage.
 
 #### Merchant
 
 ![Merchant](images/merchant.png)
 
-Trade one card for a fresh draw. Useful for filtering weak cards out of hand and improving attack or defense consistency.
+How to use:
+- During your turn, select Merchant and one card you want to replace.
+- Discard that card and draw a replacement from the main deck.
+
+Important rules:
+- Merchant is usually limited to one trade per turn.
+- Use it to remove low-impact or off-plan cards.
+
+Best use:
+- Fix weak hands before a planned attack turn.
 
 #### Priest
 
 ![Priest](images/priest.png)
 
-After attack setup, can attempt to convert enemy hand cards matching the current attack suit. Strong when timed around suit control.
+How to use:
+- First establish your current attack suit (by starting an attack).
+- Activate Priest and choose an opponent hand target.
+- If revealed card matches your active suit, you convert/steal it; otherwise it is returned.
+
+Important rules:
+- Priest has limited attempts per turn.
+- Timing matters: Priest is only strong after suit has been fixed for your turn.
+
+Best use:
+- Use right after setting a suit where opponents are likely to hold many cards.
 
 ### Dark Heroes
 
@@ -149,37 +206,91 @@ After attack setup, can attempt to convert enemy hand cards matching the current
 
 ![Reservists](images/reservists.png)
 
-Provide passive king-defense value and can also be spent as temporary attack boosts. Flexible hero for both defense and finishing power.
+How to use:
+- Reservists passively reinforce king defense.
+- During attack/plunder resolution, spend reservists for +1 attack each when needed.
+
+Important rules:
+- Units are finite and recover over turns.
+- Spending too many reduces your king safety.
+
+Best use:
+- Keep a defensive baseline, spend only the minimum needed to secure key wins.
 
 #### Banneret
 
 ![Banneret](images/lieutenant.png)
 
-Expands attack composition and supports using own defense cards in attack scenarios. High tactical depth hero for advanced turns.
+How to use:
+- Banneret allows broader attack composition (paired suits / mixed pattern, depending on your table rules).
+- It also enables attack lines that include your own defense cards.
+
+Important rules:
+- Confirm your active suit pattern before committing cards.
+- You trade board security for offensive burst when using own defense cards.
+
+Best use:
+- Convert a stable defense into a sudden high-value finishing attack.
 
 #### Saboteurs
 
 ![Saboteurs](images/saboteurs.png)
 
-Can block enemy defense slots, limiting opponent defense management options until the saboteur is removed.
+How to use:
+- During your turn, place a saboteur on an enemy defense slot.
+- That slot becomes blocked for defense management until cleared.
+
+Important rules:
+- Saboteurs are limited units with recovery time after destruction.
+- Opponents can remove them by resolving the slot through combat/sacrifice rules.
+
+Best use:
+- Lock high-value slots to prevent enemy repositioning before your next attack.
 
 #### Fortified Tower
 
 ![Fortified Tower](images/fortifiedtower.png)
 
-Allows stacking a top defense card onto an existing slot. Attackers must beat the combined defense strength.
+How to use:
+- Select Fortified Tower and choose one of your existing defense slots.
+- Place an extra face-down top defense card onto that slot.
+
+Important rules:
+- Attacker must beat the combined defense value to capture it.
+- Usually limited number of tower uses per turn.
+
+Best use:
+- Protect key slot(s) right before passing turn.
 
 #### Magician
 
 ![Magician](images/mage.png)
 
-Can replace defense cards with fresh cards from the deck. Useful for disruption or for forcing uncertainty onto key enemy slots.
+How to use:
+- During your turn, target an existing defense slot (yours or enemy, depending on table rules).
+- Replace the slot card(s) with fresh draw(s) from the main deck.
+
+Important rules:
+- Replaced cards go to cemetery.
+- Usually one spell use per turn.
+
+Best use:
+- Reset strong revealed enemy defenses into unknown or weaker values.
 
 #### Warlord
 
 ![Warlord](images/warlord.png)
 
-Enables special king-driven attack options and king swap utility, allowing aggressive tactical lines that are not available to other heroes.
+How to use:
+- Warlord unlocks aggressive king-based attack options.
+- You can launch special king attacks and use king-swap tactics.
+
+Important rules:
+- King-based attacks are high risk: failed commits can expose your own king.
+- Respect one-use/charge limits per turn where applicable.
+
+Best use:
+- Use after reducing enemy defense to convert initiative into elimination pressure.
 
 ## Optional Rules
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,91 +1,108 @@
-# Baisch - Rules Book
+# Baisch - Complete Rulebook
 
-This page is the short and practical rules reference for live games.
+This rulebook is written to work for both:
+- offline/tabletop card play
+- the online implementation at https://perahrens.github.io/baisch/
 
-## Goal
+The interface can differ, but the gameplay rules are the same.
 
-Be the last player still in the game.
+## 1. Goal
 
-You are eliminated when your king is defeated in a king assault.
+Eliminate all opponents.
 
-## Setup Overview
+A player is eliminated when their king is defeated in a king assault.
+
+## 2. Components
+
+- Standard 52-card deck
+- 3 Joker cards
+- Hero pieces/tokens (or equivalent markers)
+- Optional dice (for turn-order variant)
+
+## 3. Setup
 
 Each player starts with:
 - 1 king card (face-down)
-- up to 3 defense cards in slots 1-3 (face-down)
-- hand cards
+- up to 3 face-down defense cards in slots 1 to 3
+- remaining cards in hand
 
-Shared board:
-- main deck
-- cemetery (discard pile)
-- 2 center picking decks for plunder
+Shared area:
+- Main deck (draw pile)
+- Cemetery (discard pile)
+- 2 center picking decks (plunder targets)
 
-## Turn Order
+## 4. Turn Order
 
 Default rule:
-- At round start, players roll dice to determine turn order.
+- At the start of each round, players roll dice.
+- Highest roll goes first; continue in descending order.
 
 Optional rule:
-- Skip dice and use fixed clockwise order from a chosen starting player.
+- No dice roll.
+- Use fixed clockwise order from a chosen starting player.
 
-## Turn Flow
-
-On your turn, you can:
-- take one of your defense cards back to hand
-- put a hand card as a new face-down defense card
-- plunder one picking deck
-- attack enemy defense cards
-- attack an enemy king if legal
-- use hero abilities
-
-End your turn with Finish Turn.
-
-## Card Strength Basics
+## 5. Card Values
 
 - Number cards: face value
-- J, Q, K, A: 11, 12, 13, 14
-- Joker in hand attacks as a wild high-impact card
-- Joker as a defense card counts as 1
+- J = 11, Q = 12, K = 13, A = 14
+- Joker:
+  - in defense counts as 1
+  - in attack is a wild high-impact card
 
-## Core Actions
+## 6. Turn Structure
 
-### 1) Plunder
+On your turn, you may perform legal actions in any valid order, then finish turn.
 
-Attack one of the two center picking decks.
+Core actions:
+- Manage defense (take/put)
+- Plunder a center picking deck
+- Attack enemy defense cards
+- Assault enemy king (when legal)
+- Use hero abilities
 
-- Success: you take all cards from that picking deck.
-- Fail: the deck grows and becomes a larger future target.
+## 7. Core Rules
 
-### 2) Attack Enemy Defense
+### 7.1 Manage Defense (Take/Put)
 
-Use hand cards to beat an enemy defense value.
+- Take: move one of your own defense cards back to hand.
+- Put: place one hand card face-down into an open defense slot.
 
-- Success: captured card(s) go to your hand as prey cards.
-- Fail: target remains and is usually revealed.
+### 7.2 Plunder
 
-### 3) King Assault (Attack Enemy King)
+Attack one of the 2 center picking decks.
 
-If the enemy has no defense left, you can attack their king.
+- Success: if your attack value beats the top defense value, you take all cards in that picking deck.
+- Failure: attack cards go to cemetery; the attacked picking deck grows.
 
-- Success: defender is eliminated.
-- If you used your own king and fail, you can be eliminated.
+### 7.3 Attack Enemy Defense
 
-### 4) Manage Defense
+- Build attack value with legal attack cards.
+- If attack value beats target defense value: capture target card(s).
+- If not: target remains; hidden card is usually revealed.
 
-Build and reposition your defense to stay protected while preparing attacks.
+### 7.4 King Assault
 
-## Prey Cards
+You may attack an enemy king only when king-assault conditions are met by your rule set (normally when enemy defense is cleared).
 
-Captured cards this turn are prey cards.
+- Success: enemy is eliminated.
+- Failure with your own king committed: you can be eliminated.
 
-- Prey cards are locked for the rest of your current turn.
-- They become usable normally on your next turn.
+### 7.5 Prey Cards
 
-## Heroes
+Cards captured during your current turn are prey cards.
 
-You gain heroes by sacrificing a joker.
+- Prey cards are locked for the rest of the turn.
+- They become usable from your next turn onward.
 
-Draw mapping:
+### 7.6 No-Attack Reveal Rule
+
+If your turn ends without performing an attack, reveal one of your defense cards.
+
+## 8. Hero Acquisition
+
+Heroes are obtained by sacrificing a Joker.
+
+Hero mapping by drawn card:
 
 | Drawn Card | Hero / Result |
 |---|---|
@@ -105,6 +122,8 @@ Draw mapping:
 | Black Ace | Choose a black hero (8-K) |
 | Joker | Free choice of any hero |
 
+## 9. Complete Hero Rules (How To Use)
+
 ### White Heroes
 
 #### Mercenaries
@@ -112,93 +131,80 @@ Draw mapping:
 ![Mercenaries](images/mercenaries.png)
 
 How to use:
-- Select Mercenaries during your turn before resolving an attack.
-- Spend one ready mercenary to add +1 attack value.
-- Repeat as needed while ready units are available.
+1. Before resolving an attack/plunder, activate Mercenaries.
+2. Spend ready units: each spent unit gives +1 attack value.
+3. Resolve combat with boosted total.
 
-Important rules:
-- Mercenaries are temporary units and recover over turns.
-- They can be used to swing close attack or plunder calculations.
-- If a mercenary on a defended position is destroyed, it is lost and must recover.
-
-Best use:
-- Save units for key combats where +1 to +3 changes the outcome.
+Limits and details:
+- Units are finite and recover over turns.
+- In the online game, up to 8 total units exist, with ready/destroyed states.
+- Use only what is needed to secure the result.
 
 #### Marshal
 
 ![Marshal](images/general.png)
 
 How to use:
-- Marshal modifies your defense management economy each turn.
-- You can perform more mobilization actions (take/put) than normal.
+1. During your turn, perform additional mobilization actions.
+2. Mobilization means take or put of defense cards.
 
-Important rules:
-- Mobilization means taking a defense card back to hand or placing one from hand to defense.
-- Use this to rebuild defense without sacrificing tempo.
-
-Best use:
-- Reorganize weak slots and still keep enough cards for attacks in the same turn.
+Limits and details:
+- Marshal increases defense-management economy versus baseline rules.
+- Online implementation uses a higher per-turn mobilization budget.
 
 #### Spy
 
 ![Spy](images/spy.png)
 
 How to use:
-- Activate Spy during your turn to reveal a face-down enemy defense card.
-- If available in your ruleset, discard one hand card to gain additional reveals.
+1. Activate Spy and choose a face-down enemy defense card.
+2. Reveal it (information gain).
+3. Optional extension: discard one hand card to gain extra spy reveals.
 
-Important rules:
-- Revealed cards remove uncertainty and let you plan exact attack sums.
-- Spy is strongest before committing high-value attack cards.
-
-Best use:
-- Reveal first, then choose the lowest-risk attack target.
+Complete Spy details:
+- Base: 1 spy reveal attack per turn.
+- Extension: you may discard one card to gain +2 additional spy reveals.
+- This extension can be used once per turn (while extend is available).
+- If no face-down enemy defense card is available (all are face-up), Spy may target and reveal the enemy king.
 
 #### Battery Tower
 
 ![Battery Tower](images/batterytower.png)
 
 How to use:
-- Battery Tower triggers when an opponent attacks your defense or king.
-- Choose to deny the attack while the tower is charged.
+1. Opponent declares attack on your defense/king.
+2. If Battery Tower is charged, choose to deny.
+3. Attack is canceled/denied per rules, and attacker loses access to committed attack cards for that turn.
 
-Important rules:
-- Denied attack cards are locked for the attacker for the rest of that turn.
-- Tower typically has limited charges and must recover.
-
-Best use:
-- Deny expensive attacks to create major tempo advantage.
+Limits and details:
+- Usually one charge/use per turn cycle.
+- Must recover/recharge before next deny.
 
 #### Merchant
 
 ![Merchant](images/merchant.png)
 
 How to use:
-- During your turn, select Merchant and one card you want to replace.
-- Discard that card and draw a replacement from the main deck.
+1. During your turn, choose one card to trade (from hand; in some variants also legal from defense interactions).
+2. Discard chosen card to cemetery.
+3. Draw replacement from main deck.
 
-Important rules:
-- Merchant is usually limited to one trade per turn.
-- Use it to remove low-impact or off-plan cards.
-
-Best use:
-- Fix weak hands before a planned attack turn.
+Limits and details:
+- Usually 1 trade per turn.
+- Online rules may reveal the final trade draw to all players.
 
 #### Priest
 
 ![Priest](images/priest.png)
 
 How to use:
-- First establish your current attack suit (by starting an attack).
-- Activate Priest and choose an opponent hand target.
-- If revealed card matches your active suit, you convert/steal it; otherwise it is returned.
+1. First establish current attack suit by starting an attack.
+2. Activate Priest and target an opponent hand card.
+3. If revealed card matches your active attack suit, convert/keep it; otherwise return it.
 
-Important rules:
-- Priest has limited attempts per turn.
-- Timing matters: Priest is only strong after suit has been fixed for your turn.
-
-Best use:
-- Use right after setting a suit where opponents are likely to hold many cards.
+Limits and details:
+- Usually up to 2 conversion attempts per turn.
+- Priest is only selectable after attack suit is set.
 
 ### Dark Heroes
 
@@ -207,105 +213,94 @@ Best use:
 ![Reservists](images/reservists.png)
 
 How to use:
-- Reservists passively reinforce king defense.
-- During attack/plunder resolution, spend reservists for +1 attack each when needed.
+1. Keep reservists for passive king-defense boost.
+2. Spend reservists during attack/plunder for +1 each when needed.
 
-Important rules:
-- Units are finite and recover over turns.
-- Spending too many reduces your king safety.
-
-Best use:
-- Keep a defensive baseline, spend only the minimum needed to secure key wins.
+Limits and details:
+- Spending improves offense but weakens defense buffer.
+- Units recover over turns.
 
 #### Banneret
 
 ![Banneret](images/lieutenant.png)
 
 How to use:
-- Banneret allows broader attack composition (paired suits / mixed pattern, depending on your table rules).
-- It also enables attack lines that include your own defense cards.
+1. Use Banneret to broaden legal attack composition.
+2. In supported contexts, include own defense cards in attack builds.
 
-Important rules:
-- Confirm your active suit pattern before committing cards.
-- You trade board security for offensive burst when using own defense cards.
-
-Best use:
-- Convert a stable defense into a sudden high-value finishing attack.
+Limits and details:
+- Use carefully: converting defense into attack can open your board.
+- Confirm suit-combination legality before committing cards.
 
 #### Saboteurs
 
 ![Saboteurs](images/saboteurs.png)
 
 How to use:
-- During your turn, place a saboteur on an enemy defense slot.
-- That slot becomes blocked for defense management until cleared.
+1. Place saboteur on enemy defense slot.
+2. Block that slot from normal defense management.
 
-Important rules:
-- Saboteurs are limited units with recovery time after destruction.
-- Opponents can remove them by resolving the slot through combat/sacrifice rules.
-
-Best use:
-- Lock high-value slots to prevent enemy repositioning before your next attack.
+Limits and details:
+- Saboteurs are limited units with destruction/repair/recovery states.
+- Defender can clear sabotage through legal removal/sacrifice/combat outcomes.
 
 #### Fortified Tower
 
 ![Fortified Tower](images/fortifiedtower.png)
 
 How to use:
-- Select Fortified Tower and choose one of your existing defense slots.
-- Place an extra face-down top defense card onto that slot.
+1. Choose one of your defense slots.
+2. Add a face-down top defense card.
+3. Defender value becomes combined stack value.
 
-Important rules:
-- Attacker must beat the combined defense value to capture it.
-- Usually limited number of tower uses per turn.
-
-Best use:
-- Protect key slot(s) right before passing turn.
+Limits and details:
+- Usually 1 stack action per turn.
+- Attackers must beat combined strength to capture.
 
 #### Magician
 
 ![Magician](images/mage.png)
 
 How to use:
-- During your turn, target an existing defense slot (yours or enemy, depending on table rules).
-- Replace the slot card(s) with fresh draw(s) from the main deck.
+1. Target a defense slot (enemy or own, depending on format).
+2. Replace card(s) with fresh draw(s) from deck.
+3. Old card(s) go to cemetery.
 
-Important rules:
-- Replaced cards go to cemetery.
-- Usually one spell use per turn.
-
-Best use:
-- Reset strong revealed enemy defenses into unknown or weaker values.
+Limits and details:
+- Usually 1 spell per turn.
+- Powerful for disrupting known strong defenses.
 
 #### Warlord
 
 ![Warlord](images/warlord.png)
 
 How to use:
-- Warlord unlocks aggressive king-based attack options.
-- You can launch special king attacks and use king-swap tactics.
+1. Activate Warlord to unlock special king-based attack line.
+2. Optionally perform king swap (variant/implementation-specific) for tactical setup.
 
-Important rules:
-- King-based attacks are high risk: failed commits can expose your own king.
-- Respect one-use/charge limits per turn where applicable.
+Limits and details:
+- King-based aggression is high risk.
+- Failed king-committed attacks can cause self-elimination.
 
-Best use:
-- Use after reducing enemy defense to convert initiative into elimination pressure.
+## 10. Optional Rules
 
-## Optional Rules
+- Fixed clockwise turn order (no dice each round).
+- Faster mode: shorter timer / fewer planning pauses.
 
-- Turn order variant: fixed clockwise order (no dice roll each round).
-- Recommended for faster games and simpler onboarding.
+## 11. Win Condition
 
-## Win Condition
+Last non-eliminated player wins.
 
-The last non-eliminated player wins.
+## 12. Quick Beginner Guide
 
-## New Player Tips
+1. Keep at least one strong hidden defense.
+2. Use plunder to stabilize weak hands.
+3. Do not commit king assaults unless odds are clearly favorable.
+4. Use heroes for timing advantage, not just raw value.
+5. Track enemy resources (charges, units, per-turn uses).
 
-1. Keep at least one strong hidden defense while building offense.
-2. Plunder early if your hand is weak.
-3. Avoid king assault unless odds are clearly good.
-4. Use jokers when a hero can immediately impact your turn.
-5. Track enemy hero resources before committing attacks.
+## 13. Notes on Offline vs Online
 
+- Offline and online use the same core mechanics.
+- Online UI may automate checks and reveal states.
+- If a table rule conflicts with this page, agree house rules before game start.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,13 @@ Shared board:
 - cemetery (discard pile)
 - 2 center picking decks for plunder
 
-At round start, players roll dice to determine turn order.
+## Turn Order
+
+Default rule:
+- At round start, players roll dice to determine turn order.
+
+Optional rule:
+- Skip dice and use fixed clockwise order from a chosen starting player.
 
 ## Turn Flow
 
@@ -99,20 +105,86 @@ Draw mapping:
 | Black Ace | Choose a black hero (8-K) |
 | Joker | Free choice of any hero |
 
-Hero quick summary:
+### White Heroes
 
-- Mercenaries: spend units for temporary attack boosts.
-- Marshal: stronger take/put economy per turn.
-- Spy: reveal hidden enemy defense cards.
-- Battery Tower: deny one incoming attack and lock attacker cards.
-- Merchant: discard one card to draw one card.
-- Priest: convert matching-suit enemy hand cards after attack setup.
-- Reservists: boost king defense and optionally boost attack.
-- Banneret: allows mixed-color attack behavior and own-defense attack support.
-- Saboteurs: block enemy defense slots.
-- Fortified Tower: add a top defense card to stack defense values.
-- Magician: replace defense cards with fresh draws.
-- Warlord: special king-driven attack options and king swap utility.
+#### Mercenaries
+
+![Mercenaries](images/mercenaries.png)
+
+You can spend mercenary units to add temporary attack power. Units regenerate over time, so this hero is best for creating short, explosive attack turns.
+
+#### Marshal
+
+![Marshal](images/general.png)
+
+Improves defense management economy. You can perform more efficient take/put sequencing each turn, which helps stabilize your board while still preparing attacks.
+
+#### Spy
+
+![Spy](images/spy.png)
+
+Reveals hidden enemy defense cards. With extra cost, Spy can reveal additional cards. This turns uncertainty into information and enables stronger attack planning.
+
+#### Battery Tower
+
+![Battery Tower](images/batterytower.png)
+
+Can deny one incoming attack (when charged), causing the attacker to lose access to the committed attack cards for that turn. Excellent defensive tempo tool.
+
+#### Merchant
+
+![Merchant](images/merchant.png)
+
+Trade one card for a fresh draw. Useful for filtering weak cards out of hand and improving attack or defense consistency.
+
+#### Priest
+
+![Priest](images/priest.png)
+
+After attack setup, can attempt to convert enemy hand cards matching the current attack suit. Strong when timed around suit control.
+
+### Dark Heroes
+
+#### Reservists
+
+![Reservists](images/reservists.png)
+
+Provide passive king-defense value and can also be spent as temporary attack boosts. Flexible hero for both defense and finishing power.
+
+#### Banneret
+
+![Banneret](images/lieutenant.png)
+
+Expands attack composition and supports using own defense cards in attack scenarios. High tactical depth hero for advanced turns.
+
+#### Saboteurs
+
+![Saboteurs](images/saboteurs.png)
+
+Can block enemy defense slots, limiting opponent defense management options until the saboteur is removed.
+
+#### Fortified Tower
+
+![Fortified Tower](images/fortifiedtower.png)
+
+Allows stacking a top defense card onto an existing slot. Attackers must beat the combined defense strength.
+
+#### Magician
+
+![Magician](images/mage.png)
+
+Can replace defense cards with fresh cards from the deck. Useful for disruption or for forcing uncertainty onto key enemy slots.
+
+#### Warlord
+
+![Warlord](images/warlord.png)
+
+Enables special king-driven attack options and king swap utility, allowing aggressive tactical lines that are not available to other heroes.
+
+## Optional Rules
+
+- Turn order variant: fixed clockwise order (no dice roll each round).
+- Recommended for faster games and simpler onboarding.
 
 ## Win Condition
 


### PR DESCRIPTION
Closes #95

## Context
The rules page is hosted at https://perahrens.github.io/baisch/ and published from branch docs, folder /docs.

## What changed
- Rewrote docs/index.md into a concise, structured, and current player rulebook.
- Updated outdated naming/mechanics text to match current gameplay terminology.
- Included goal, setup, turn flow, core actions, king assault, prey cards, hero mapping, hero summaries, and beginner tips.