### PR TITLE
fix: enforce Priest conversion limit server-side (#112)

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -1138,9 +1138,10 @@ public class GameScreen extends ScreenAdapter {
           break;
         }
 
-        // Only add info listener to other players' heroes here.
-        // The current player's heroes get it via heroLabel in showHandStage.
-        if (players.get(i) != currentPlayer) {
+        // Add info listener for all non-active board heroes.
+        // Active player's detailed hero info is still handled via heroLabel in showHandStage.
+        boolean shouldShowBoardHeroInfo = players.get(i) != gameState.getCurrentPlayer();
+        if (shouldShowBoardHeroInfo) {
           playerHeroes.get(j).removeAllListeners();
           final String heroInfoName_gs = playerHeroes.get(j).getHeroName();
           playerHeroes.get(j).addListener(new ClickListener() {

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -409,6 +409,8 @@ public class GameScreen extends ScreenAdapter {
                     previewData.put("mercenaryBonus", pt.getPendingAttackMercenaryBonus());
                     previewData.put("reservistBonus", pt.getReservistAttackBonus());
                     previewData.put("success", pt.isAttackSuccess());
+                    previewData.put("attackingSymbol", pt.getAttackingSymbol()[0]);
+                    previewData.put("attackingSymbol2", pt.getAttackingSymbol()[1]);
                     theSocket.emit("attackPreview", previewData);
                   } catch (JSONException ex) { ex.printStackTrace(); }
                 }
@@ -1766,6 +1768,8 @@ public class GameScreen extends ScreenAdapter {
                       resPreview.put("mercenaryBonus", apt.getPendingAttackMercenaryBonus());
                       resPreview.put("reservistBonus", apt.getReservistAttackBonus());
                       resPreview.put("success", newSuccess);
+                      resPreview.put("attackingSymbol", apt.getAttackingSymbol()[0]);
+                      resPreview.put("attackingSymbol2", apt.getAttackingSymbol()[1]);
                       socket.emit("attackPreview", resPreview);
                     } catch (JSONException ex) { ex.printStackTrace(); }
                   }
@@ -3334,6 +3338,14 @@ public class GameScreen extends ScreenAdapter {
         }
         p.getPlayerTurn().setPreyCardIds(newPreyIds);
         p.getPlayerTurn().setAttackCounter(pj.optInt("attackCount", 0));
+
+        // Restore per-turn client counters from server-authoritative state so they survive page refresh
+        if (p == currentPlayer) {
+          p.getPlayerTurn().setPickingDeckAttacks(pj.optInt("pickingDeckAttacks", 1));
+          p.getPlayerTurn().setAttackingSymbolDirect(
+              pj.optString("attackingSymbol", "none"),
+              pj.optString("attackingSymbol2", "none"));
+        }
       }
 
       // Sync heroes from server-authoritative state so missed relay events do not desync views.
@@ -3453,11 +3465,13 @@ public class GameScreen extends ScreenAdapter {
     // Game/hand stages are added only when it is this client's active turn.
     if (menuOpen) {
       Gdx.input.setInputProcessor(overlayStage);
-    } else if (!isSpectator && (gameState.getCurrentPlayer() == currentPlayer || pendingBatteryDefCheck != null || pendingBatteryResultCards != null || pendingExposeCard)) {
-      // Active turn: overlay (menu btn) + game + hand
+    } else if (!isSpectator) {
+      // Active turn OR waiting: include game+hand stages so hero info overlays work when not your turn.
+      // Game-action listeners (EnemyDefCardListener etc.) require selected cards/heroes which are
+      // never set during a non-active turn, so enabling these stages is safe.
       Gdx.input.setInputProcessor(menuAndGameMulti);
     } else {
-      // Waiting or spectator: only overlay/menu input; block gameplay interactions
+      // Spectator: only overlay/menu input
       Gdx.input.setInputProcessor(overlayStage);
     }
 

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -2298,8 +2298,9 @@ public class GameScreen extends ScreenAdapter {
                   gameState.setPriestTargetPlayerIdx(-1);
                   gameState.setPriestRevealedCardId(-1);
                 } else {
-                  // Miss — reveal it
+                  // Miss — reveal it and notify server to decrement the counter
                   gameState.setPriestRevealedCardId(tc.getCardId());
+                  emitPriestAttemptFailed();
                 }
                 gameState.setUpdateState(true);
               }
@@ -3130,6 +3131,15 @@ public class GameScreen extends ScreenAdapter {
     } catch (JSONException e) { e.printStackTrace(); }
   }
 
+  private void emitPriestAttemptFailed() {
+    if (socket == null) return;
+    try {
+      JSONObject data = new JSONObject();
+      data.put("attackerIdx", playerIndex);
+      socket.emit("priestAttemptFailed", data);
+    } catch (JSONException e) { e.printStackTrace(); }
+  }
+
   private void emitReservistsKingBoost(int count) {
     if (socket == null) return;
     try {
@@ -3353,9 +3363,33 @@ public class GameScreen extends ScreenAdapter {
         pendingAttackBroadcast = null;
       }
 
-      // Sync plunder preview for the watcher overlay
+      // Sync plunder preview — restore overlay for attacker on reconnect, watcher overlay for others
       JSONObject serverPendingPlunder = state.optJSONObject("pendingPlunder");
-      if (serverPendingPlunder != null && serverPendingPlunder.optInt("attackerIdx", -1) != playerIndex) {
+      if (serverPendingPlunder != null
+          && serverPendingPlunder.optInt("attackerIdx", -1) == playerIndex
+          && !currentPlayer.getPlayerTurn().isPlunderPending()) {
+        // Restore the plunder confirmation overlay so it reappears after a page refresh
+        PlayerTurn rpt = currentPlayer.getPlayerTurn();
+        rpt.setPlunderPending(true);
+        rpt.setPendingPickingDeckIndex(serverPendingPlunder.optInt("deckIndex", 0));
+        rpt.setPlunderSuccess(serverPendingPlunder.optBoolean("success", false));
+        rpt.setKingUsed(serverPendingPlunder.optBoolean("kingUsed", false));
+        rpt.setPendingPlunderAttackSum(serverPendingPlunder.optInt("attackSum", 0));
+        rpt.setPendingPlunderDefStrength(serverPendingPlunder.optInt("defStrength", 0));
+        ArrayList<Card> rptAtkCards = new ArrayList<Card>();
+        JSONArray rptAtkIds = serverPendingPlunder.optJSONArray("attackCardIds");
+        if (rptAtkIds != null) {
+          for (int rai = 0; rai < rptAtkIds.length(); rai++) rptAtkCards.add(Card.fromCardId(rptAtkIds.getInt(rai)));
+        }
+        rpt.setPendingAttackCards(rptAtkCards);
+        ArrayList<Card> rptOwnDefCards = new ArrayList<Card>();
+        JSONArray rptOwnDefIds = serverPendingPlunder.optJSONArray("ownDefCardIds");
+        if (rptOwnDefIds != null) {
+          for (int rai = 0; rai < rptOwnDefIds.length(); rai++) rptOwnDefCards.add(Card.fromCardId(rptOwnDefIds.getInt(rai)));
+        }
+        rpt.setPendingAttackOwnDefCards(rptOwnDefCards);
+        pendingPlunderBroadcast = null;
+      } else if (serverPendingPlunder != null && serverPendingPlunder.optInt("attackerIdx", -1) != playerIndex) {
         pendingPlunderBroadcast = serverPendingPlunder;
       } else {
         pendingPlunderBroadcast = null;

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -1138,20 +1138,18 @@ public class GameScreen extends ScreenAdapter {
           break;
         }
 
-        // Add info listener for all non-active board heroes.
-        // Active player's detailed hero info is still handled via heroLabel in showHandStage.
-        boolean shouldShowBoardHeroInfo = players.get(i) != gameState.getCurrentPlayer();
-        if (shouldShowBoardHeroInfo) {
-          playerHeroes.get(j).removeAllListeners();
-          final String heroInfoName_gs = playerHeroes.get(j).getHeroName();
-          playerHeroes.get(j).addListener(new ClickListener() {
-            @Override
-            public void clicked(InputEvent event, float x, float y) {
-              showHeroInfoOverlay(heroInfoName_gs);
-              event.stop();
-            }
-          });
-        }
+        // All board heroes get an info overlay click listener.
+        // (Local player's own heroes are moved to handStage by showHandStage, so the
+        //  listener added here gets replaced there — no conflict.)
+        playerHeroes.get(j).removeAllListeners();
+        final String heroInfoName_gs = playerHeroes.get(j).getHeroName();
+        playerHeroes.get(j).addListener(new ClickListener() {
+          @Override
+          public void clicked(InputEvent event, float x, float y) {
+            showHeroInfoOverlay(heroInfoName_gs);
+            event.stop();
+          }
+        });
         gameStage.addActor(playerHeroes.get(j));
       }
 

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -2525,12 +2525,23 @@ public class GameScreen extends ScreenAdapter {
       }
 
       hero.removeAllListeners();
-      ownHeroListener = new OwnHeroListener(hero, gameState.getCurrentPlayer(), gameState);
-      hero.addListener(ownHeroListener);
+      final String heroInfoName = hero.getHeroName();
+      if (currentPlayer == gameState.getCurrentPlayer()) {
+        ownHeroListener = new OwnHeroListener(hero, gameState.getCurrentPlayer(), gameState);
+        hero.addListener(ownHeroListener);
+      } else {
+        // Not our turn — hero is not usable; clicking the image shows info instead.
+        hero.addListener(new ClickListener() {
+          @Override
+          public void clicked(InputEvent event, float x, float y) {
+            showHeroInfoOverlay(heroInfoName);
+            event.stop();
+          }
+        });
+      }
 
       Label heroLabel = new Label(hero.getHeroID(), MyGdxGame.skin);
       heroLabel.setPosition(j * hero.getWidth() + (hero.getWidth() - heroLabel.getWidth()) / 2, hero.getHeight());
-      final String heroInfoName = hero.getHeroName();
       heroLabel.addListener(new ClickListener() {
         @Override
         public void clicked(InputEvent event, float x, float y) {

--- a/core/src/com/mygdx/game/GameState.java
+++ b/core/src/com/mygdx/game/GameState.java
@@ -402,12 +402,26 @@ public class GameState {
 
   /**
    * Rebuild all heroes from a server-authoritative players JSON array.
-   * This resets the hero pool and player hero lists first, then reapplies
-   * ownership by player index to keep all clients deterministic.
+   *
+   * <p>Existing hero instances are reused for heroes the same player already owns. This
+   * preserves all per-turn counters through routine stateUpdate syncs so heroes cannot be
+   * exploited by triggering a server event to reset their counters.
+   *
+   * <p>Server-authoritative per-turn counters are ALWAYS applied so the client never runs
+   * ahead of what the server permits.
    */
+  @SuppressWarnings("unchecked")
   public void rebuildHeroesFromState(JSONArray playersJson) throws JSONException {
-    heroesSquare = new HeroesSquare();
+    // Save current hero instances keyed by playerIdx -> heroName.
+    java.util.Map<String, Hero>[] savedHeroes = new java.util.Map[players.size()];
+    for (int i = 0; i < players.size(); i++) {
+      savedHeroes[i] = new java.util.HashMap<String, Hero>();
+      for (Hero h : players.get(i).getHeroes()) {
+        savedHeroes[i].put(h.getHeroName(), h);
+      }
+    }
 
+    heroesSquare = new HeroesSquare();
     for (int i = 0; i < players.size(); i++) {
       players.get(i).getHeroes().clear();
     }
@@ -419,7 +433,40 @@ public class GameState {
       if (heroesJson == null) continue;
 
       for (int h = 0; h < heroesJson.length(); h++) {
-        applyHeroAcquired(idx, heroesJson.getString(h));
+        String heroName = heroesJson.getString(h);
+        Hero existing = (savedHeroes[idx] != null) ? savedHeroes[idx].get(heroName) : null;
+        if (existing != null) {
+          // Reuse existing instance -- preserves mid-turn state.
+          heroesSquare.consumeHeroByName(heroName);
+          players.get(idx).addHero(existing);
+        } else {
+          // New acquisition or reconnect: get a fresh hero from the pool.
+          applyHeroAcquired(idx, heroName);
+        }
+        // Always apply server-authoritative per-turn counters.
+        ArrayList<Hero> heroList = players.get(idx).getHeroes();
+        Hero syncedHero = heroList.get(heroList.size() - 1);
+        if (syncedHero instanceof com.mygdx.game.heroes.Priest) {
+          int serverAttempts = pj.optInt("priestConversionAttempts", 2);
+          ((com.mygdx.game.heroes.Priest) syncedHero).setConversionAttempts(serverAttempts);
+        } else if (syncedHero instanceof com.mygdx.game.heroes.Magician) {
+          int serverSpells = pj.optInt("magicianSpells", 1);
+          ((com.mygdx.game.heroes.Magician) syncedHero).setSpells(serverSpells);
+        } else if (syncedHero instanceof com.mygdx.game.heroes.Merchant) {
+          int serverTrades = pj.optInt("merchantTrades", 1);
+          ((com.mygdx.game.heroes.Merchant) syncedHero).setTrades(serverTrades);
+        } else if (syncedHero instanceof com.mygdx.game.heroes.Warlord) {
+          int serverAttacks = pj.optInt("warlordAttacks", 1);
+          ((com.mygdx.game.heroes.Warlord) syncedHero).setAttacks(serverAttacks);
+        } else if (syncedHero instanceof com.mygdx.game.heroes.Spy) {
+          int serverSpyAttacks = pj.optInt("spyAttacks", 1);
+          int serverSpyMaxAttacks = pj.optInt("spyMaxAttacks", 1);
+          int serverSpyExtends = pj.optInt("spyExtends", 1);
+          com.mygdx.game.heroes.Spy spy = (com.mygdx.game.heroes.Spy) syncedHero;
+          spy.setSpyAttacks(serverSpyAttacks);
+          spy.setSpyMaxAttacks(serverSpyMaxAttacks);
+          spy.setSpyExtends(serverSpyExtends);
+        }
       }
     }
   }

--- a/core/src/com/mygdx/game/PlayerTurn.java
+++ b/core/src/com/mygdx/game/PlayerTurn.java
@@ -21,6 +21,10 @@ public class PlayerTurn {
     pickingDeckAttacks -= 1;
   }
 
+  public void setPickingDeckAttacks(int v) {
+    pickingDeckAttacks = v;
+  }
+
   public int getPickingDeckAttacks() {
     return pickingDeckAttacks;
   }
@@ -64,6 +68,12 @@ public class PlayerTurn {
         if (symbol == "clubs") attackingSymbol[1] = "spades";
       }
     }
+  }
+
+  // Directly restore both symbol slots from server state (used by applyStateUpdate on page refresh).
+  public void setAttackingSymbolDirect(String sym1, String sym2) {
+    attackingSymbol[0] = sym1;
+    attackingSymbol[1] = sym2;
   }
 
   public String[] getAttackingSymbol() {

--- a/core/src/com/mygdx/game/heroes/Magician.java
+++ b/core/src/com/mygdx/game/heroes/Magician.java
@@ -34,4 +34,14 @@ public class Magician extends Hero {
     return spells;
   }
 
+  public void setSpells(int spells) {
+    this.spells = Math.max(0, spells);
+    if (this.spells > 0) {
+      isSelectable = true;
+    } else {
+      isSelectable = false;
+      isSelected = false;
+    }
+  }
+
 }

--- a/core/src/com/mygdx/game/heroes/Merchant.java
+++ b/core/src/com/mygdx/game/heroes/Merchant.java
@@ -34,6 +34,16 @@ public class Merchant extends Hero {
     return trades;
   }
 
+  public void setTrades(int trades) {
+    this.trades = Math.max(0, trades);
+    if (this.trades > 0) {
+      isSelectable = true;
+    } else {
+      isSelectable = false;
+      isSelected = false;
+    }
+  }
+
   @Override
   public void recover() {
     trades = 1;

--- a/core/src/com/mygdx/game/heroes/Priest.java
+++ b/core/src/com/mygdx/game/heroes/Priest.java
@@ -34,6 +34,11 @@ public class Priest extends Hero {
     return conversionAttempts;
   }
 
+  public void setConversionAttempts(int n) {
+    conversionAttempts = n;
+    isSelectable = (n > 0);
+  }
+
   public void conversion() {
     conversionAttempts = 0;
   }

--- a/core/src/com/mygdx/game/heroes/Spy.java
+++ b/core/src/com/mygdx/game/heroes/Spy.java
@@ -41,6 +41,24 @@ public class Spy extends Hero {
     return spyExtends;
   }
 
+  public void setSpyAttacks(int spyAttacks) {
+    this.spyAttacks = Math.max(0, spyAttacks);
+  }
+
+  public void setSpyMaxAttacks(int spyMaxAttacks) {
+    this.spyMaxAttacks = Math.max(1, spyMaxAttacks);
+  }
+
+  public void setSpyExtends(int spyExtends) {
+    this.spyExtends = Math.max(0, spyExtends);
+    if (this.spyAttacks <= 0 && this.spyExtends <= 0) {
+      isReady = false;
+      isSelected = false;
+    } else {
+      isReady = true;
+    }
+  }
+
   public void spyExtend() {
     // sacrifice a card: spend the extend charge, gain +2 actions
     spyExtends--;

--- a/core/src/com/mygdx/game/heroes/Warlord.java
+++ b/core/src/com/mygdx/game/heroes/Warlord.java
@@ -32,6 +32,16 @@ public class Warlord extends Hero {
 
   public int getAttacks() { return attacks; }
 
+  public void setAttacks(int attacks) {
+    this.attacks = Math.max(0, attacks);
+    if (this.attacks > 0) {
+      isSelectable = true;
+    } else {
+      isSelectable = false;
+      isSelected = false;
+    }
+  }
+
   public boolean isAttackAvailable() { return attacks > 0; }
 
   /** Spend the Warlord's attack charge for this turn. */

--- a/core/src/com/mygdx/game/listeners/EnemyDefCardListener.java
+++ b/core/src/com/mygdx/game/listeners/EnemyDefCardListener.java
@@ -302,6 +302,13 @@ public class EnemyDefCardListener extends ClickListener {
     // Consume Warlord charge after attack is committed
     if (warlordAttack && warlord != null) {
       warlord.useAttack();
+      if (socket != null) {
+        try {
+          JSONObject warlordData = new JSONObject();
+          warlordData.put("playerIdx", playerIdx);
+          socket.emit("warlordDirectAttack", warlordData);
+        } catch (JSONException e) { e.printStackTrace(); }
+      }
     }
 
     // Only trigger the Battery Tower intercept flow when the defender actually has one with charges.

--- a/core/src/com/mygdx/game/listeners/EnemyDefCardListener.java
+++ b/core/src/com/mygdx/game/listeners/EnemyDefCardListener.java
@@ -422,6 +422,8 @@ public class EnemyDefCardListener extends ClickListener {
       data.put("mercenaryBonus", player.getPlayerTurn().getPendingAttackMercenaryBonus());
       data.put("reservistBonus", player.getPlayerTurn().getReservistAttackBonus());
       data.put("success", success);
+      data.put("attackingSymbol", player.getPlayerTurn().getAttackingSymbol()[0]);
+      data.put("attackingSymbol2", player.getPlayerTurn().getAttackingSymbol()[1]);
       socket.emit("attackPreview", data);
     } catch (JSONException e) { e.printStackTrace(); }
   }

--- a/core/src/com/mygdx/game/listeners/EnemyKingCardListener.java
+++ b/core/src/com/mygdx/game/listeners/EnemyKingCardListener.java
@@ -191,6 +191,13 @@ public class EnemyKingCardListener extends ClickListener {
     // Consume Warlord charge after attack is committed
     if (warlordAttack && warlord != null) {
       warlord.useAttack();
+      if (socket != null) {
+        try {
+          JSONObject warlordData = new JSONObject();
+          warlordData.put("playerIdx", playerIdx);
+          socket.emit("warlordDirectAttack", warlordData);
+        } catch (JSONException e) { e.printStackTrace(); }
+      }
     }
 
     // Only trigger the Battery Tower intercept flow when the defender actually has one with charges.

--- a/core/src/com/mygdx/game/listeners/OwnDefCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnDefCardListener.java
@@ -106,7 +106,15 @@ public class OwnDefCardListener extends ClickListener {
               } else {
                 defCards.remove(posId);
               }
+              final int sacrificedCardId = selectedCard.getCardId();
               spy.spyExtend();
+              if (socket != null) {
+                try {
+                  JSONObject extendData = new JSONObject();
+                  extendData.put("cardId", sacrificedCardId);
+                  socket.emit("spyExtend", extendData);
+                } catch (JSONException e) { e.printStackTrace(); }
+              }
               gameState.setUpdateState(true);
             }
           } else if (player.getHeroes().get(i).getHeroName() == "Merchant"

--- a/core/src/com/mygdx/game/listeners/OwnHandCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnHandCardListener.java
@@ -110,7 +110,15 @@ public class OwnHandCardListener extends ClickListener {
             System.out.println("Spy sacrifice handcard " + handCard.getStrength());
             cemeteryDeck.addCard(handCard);
             player.getHandCards().remove(handCard);
+            final int sacrificedCardId = handCard.getCardId();
             spy.spyExtend();
+            if (socket != null) {
+              try {
+                JSONObject extendData = new JSONObject();
+                extendData.put("cardId", sacrificedCardId);
+                socket.emit("spyExtend", extendData);
+              } catch (JSONException e) { e.printStackTrace(); }
+            }
             if (gameState != null) gameState.setUpdateState(true);
           }
           return;

--- a/core/src/com/mygdx/game/listeners/PickingDeckListener.java
+++ b/core/src/com/mygdx/game/listeners/PickingDeckListener.java
@@ -145,6 +145,8 @@ public class PickingDeckListener extends ClickListener {
             JSONArray ownDefIds = new JSONArray();
             for (Card c : ownDefSnapshot) ownDefIds.put(c.getCardId());
             preview.put("ownDefCardIds", ownDefIds);
+            preview.put("attackingSymbol", pt.getAttackingSymbol()[0]);
+            preview.put("attackingSymbol2", pt.getAttackingSymbol()[1]);
             gameState.getSocket().emit("plunderPreview", preview);
           } catch (JSONException e) { e.printStackTrace(); }
         }

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -558,6 +558,17 @@ class GameState {
     this.pendingHeroSelection = null;
   }
 
+  warlordDirectAttack(playerIdx) {
+    const p = this.players[playerIdx];
+    if ((p.warlordAttacks || 0) <= 0) {
+      console.log(`warlordDirectAttack: rejected — player ${playerIdx} has no attacks remaining`);
+      return false;
+    }
+    p.warlordAttacks--;
+    this.pushLog(`${this.pname(playerIdx)} used Warlord direct attack`, true, true);
+    return true;
+  }
+
   warlordKingSwap(playerIdx, oldKingCardId, newKingCardId) {
     const p = this.players[playerIdx];
     if ((p.warlordAttacks || 0) <= 0) {

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -59,6 +59,12 @@ class GameState {
       p.sabotaged = {}; // { slotId: attackerPlayerIdx } — tracks which slots have a saboteur
       p.attackCount = 0; // number of enemy attacks this turn (reset on finishTurn)
       p.priestConversionAttempts = 2; // Priest hero: attempts remaining this turn
+      p.magicianSpells = 1; // Magician hero: spells remaining this turn
+      p.merchantTrades = 1; // Merchant hero: trades remaining this turn
+      p.warlordAttacks = 1; // Warlord hero: king swap/attack uses remaining this turn
+      p.spyAttacks = 1; // Spy hero: flips remaining this turn
+      p.spyMaxAttacks = 1; // Spy hero: max flips displayed this turn
+      p.spyExtends = 1; // Spy hero: extends remaining this turn
     }
   }
 
@@ -233,6 +239,12 @@ class GameState {
   }
 
   magicianSwap(playerIdx, targetPlayerIdx, positionId, newBottomCardId, bottomCovered, newTopCardId, topCovered) {
+    const attacker = this.players[playerIdx];
+    if ((attacker.magicianSpells || 0) <= 0) {
+      console.log(`magicianSwap: rejected — player ${playerIdx} has no spells remaining`);
+      return;
+    }
+
     const target = this.players[targetPlayerIdx];
     // Discard old bottom card
     const oldBottom = target.defCards[positionId];
@@ -254,7 +266,55 @@ class GameState {
       if (!target.topDefCardsCovered) target.topDefCardsCovered = {};
       target.topDefCardsCovered[positionId] = topCovered;
     }
+    attacker.magicianSpells--;
     this.pushLog(`${this.pname(playerIdx)} cast Magician on ${this.pname(targetPlayerIdx)}'s shield [${positionId}]`, true);
+  }
+
+  spyFlip(playerIdx) {
+    const p = this.players[playerIdx];
+    if (!p) return false;
+    if ((p.spyAttacks || 0) <= 0) {
+      console.log(`spyFlip: rejected attack — player ${playerIdx} has no spy attacks remaining`);
+      return false;
+    }
+    p.spyAttacks--;
+    return true;
+  }
+
+  spyExtend(playerIdx, cardId) {
+    const p = this.players[playerIdx];
+    if (!p) return false;
+    if ((p.spyExtends || 0) <= 0) {
+      console.log(`spyExtend: rejected — player ${playerIdx} has no extends remaining`);
+      return false;
+    }
+    // Remove the sacrificed card from hand, defCards, or topDefCards
+    if (cardId !== undefined && cardId !== null) {
+      const handIdx = p.hand.indexOf(cardId);
+      if (handIdx !== -1) {
+        p.hand.splice(handIdx, 1);
+      } else {
+        for (const key of Object.keys(p.defCards || {})) {
+          if (p.defCards[key] === cardId) {
+            delete p.defCards[key];
+            if (p.defCardsCovered) delete p.defCardsCovered[key];
+            break;
+          }
+        }
+        for (const key of Object.keys(p.topDefCards || {})) {
+          if (p.topDefCards[key] === cardId) {
+            delete p.topDefCards[key];
+            if (p.topDefCardsCovered) delete p.topDefCardsCovered[key];
+            break;
+          }
+        }
+      }
+      this.cemetery.push(cardId);
+    }
+    p.spyExtends--;
+    p.spyAttacks = Math.min((p.spyAttacks || 0) + 2, 3);
+    p.spyMaxAttacks = Math.min((p.spyMaxAttacks || 1) + 2, 3);
+    return true;
   }
 
   addToCemetery(playerIdx, cardIds, drawFromDeck) {
@@ -388,6 +448,12 @@ class GameState {
       this.players[currentPlayerIndex].preyCards = [];
       this.players[currentPlayerIndex].attackCount = 0; // reset for next turn
       this.players[currentPlayerIndex].priestConversionAttempts = 2; // reset Priest uses for next turn
+      this.players[currentPlayerIndex].magicianSpells = 1;
+      this.players[currentPlayerIndex].merchantTrades = 1;
+      this.players[currentPlayerIndex].warlordAttacks = 1;
+      this.players[currentPlayerIndex].spyAttacks = 1;
+      this.players[currentPlayerIndex].spyMaxAttacks = 1;
+      this.players[currentPlayerIndex].spyExtends = 1;
     }
     // Advance to the next non-eliminated player (server is authoritative)
     const n = this.players.length;
@@ -494,17 +560,26 @@ class GameState {
 
   warlordKingSwap(playerIdx, oldKingCardId, newKingCardId) {
     const p = this.players[playerIdx];
+    if ((p.warlordAttacks || 0) <= 0) {
+      console.log(`warlordKingSwap: rejected — player ${playerIdx} has no attacks remaining`);
+      return;
+    }
     const handIdx = p.hand.indexOf(newKingCardId);
     if (handIdx === -1) return;
     p.hand.splice(handIdx, 1);
     p.hand.push(oldKingCardId);
     p.kingCard = newKingCardId;
     p.kingCovered = true; // new king is always placed face-down
+    p.warlordAttacks--;
     this.pushLog(`${this.pname(playerIdx)} swapped king (Warlord)`, true, true);
   }
 
   merchantTrade(playerIdx, discardedCardId, drawnCardId) {
     const p = this.players[playerIdx];
+    if ((p.merchantTrades || 0) <= 0) {
+      console.log(`merchantTrade: rejected — player ${playerIdx} has no trades remaining`);
+      return;
+    }
     this.lastMerchantReveal = null;
     // Remove discarded card from hand, defCards, or topDefCards
     const handIdx = p.hand.indexOf(discardedCardId);
@@ -523,6 +598,7 @@ class GameState {
     const deckIdx = this.deck.indexOf(drawnCardId);
     if (deckIdx !== -1) this.deck.splice(deckIdx, 1);
     p.hand.push(drawnCardId);
+    p.merchantTrades--;
     this.pushLog(`${this.pname(playerIdx)} used Merchant trade`, true, true);
   }
 
@@ -595,6 +671,12 @@ class GameState {
         preyCards: [...(p.preyCards || [])],
         attackCount: p.attackCount || 0,
         priestConversionAttempts: p.priestConversionAttempts !== undefined ? p.priestConversionAttempts : 2,
+        magicianSpells: p.magicianSpells !== undefined ? p.magicianSpells : 1,
+        merchantTrades: p.merchantTrades !== undefined ? p.merchantTrades : 1,
+        warlordAttacks: p.warlordAttacks !== undefined ? p.warlordAttacks : 1,
+        spyAttacks: p.spyAttacks !== undefined ? p.spyAttacks : 1,
+        spyMaxAttacks: p.spyMaxAttacks !== undefined ? p.spyMaxAttacks : 1,
+        spyExtends: p.spyExtends !== undefined ? p.spyExtends : 1,
       })),
       pickingDecks: this.pickingDecks.map(d => d.map(c => ({ id: c.id, covered: c.covered }))),
       winnerIndex: this.checkWinner(),

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -73,7 +73,17 @@ class GameState {
   }
 
   setPlunderPreview(data) {
-    this.pendingPlunder = data;
+    // Immediately remove committed hand-based attack cards from attacker's hand.
+    // This prevents them reappearing in hand if the player refreshes before confirming the overlay.
+    const p = data.attackerIdx !== undefined ? this.players[data.attackerIdx] : null;
+    const lockedHandCards = [];
+    if (p && data.attackCardIds) {
+      for (const cardId of data.attackCardIds) {
+        const i = p.hand.indexOf(cardId);
+        if (i !== -1) { p.hand.splice(i, 1); lockedHandCards.push(cardId); }
+      }
+    }
+    this.pendingPlunder = Object.assign({}, data, { _lockedHandCards: lockedHandCards });
   }
 
   setAttackPreview(data) {
@@ -142,6 +152,13 @@ class GameState {
     return this.deck.pop();
   }
 
+  priestAttemptFailed(attackerIdx) {
+    const attacker = this.players[attackerIdx];
+    if ((attacker.priestConversionAttempts || 0) <= 0) return;
+    attacker.priestConversionAttempts--;
+    this.pushLog(`${this.pname(attackerIdx)} (Priest) missed — no match`, false);
+  }
+
   priestConvert(attackerIdx, targetPlayerIdx, cardId) {
     const attacker = this.players[attackerIdx];
     // Enforce server-authoritative attempt limit (2 per turn).
@@ -155,7 +172,7 @@ class GameState {
       target.hand.splice(idx, 1);
       attacker.hand.push(cardId);
     }
-    attacker.priestConversionAttempts--;
+    attacker.priestConversionAttempts = 0; // success burns all remaining attempts
     this.pushLog(`${this.pname(attackerIdx)} (Priest) took card from ${this.pname(targetPlayerIdx)}`, true);
   }
 
@@ -348,11 +365,14 @@ class GameState {
   }
 
   plunderResolved(attackerIdx, deckIdx, success, attackCardIds, kingUsed, attackerOwnDefCardIds) {
+    // Use cards pre-locked in setPlunderPreview if available (prevents reappearance on refresh)
+    const lockedHandCards = this.pendingPlunder ? (this.pendingPlunder._lockedHandCards || []) : [];
     this.pendingPlunder = null;
     const attacker = this.players[attackerIdx];
-    for (const cardId of attackCardIds) {
+    const handCardsToProcess = lockedHandCards.length > 0 ? lockedHandCards : attackCardIds;
+    for (const cardId of handCardsToProcess) {
       const i = attacker.hand.indexOf(cardId);
-      if (i !== -1) attacker.hand.splice(i, 1);
+      if (i !== -1) attacker.hand.splice(i, 1); // already removed from hand if locking was used
       this.cemetery.push(cardId);
     }
     // Banneret: own def cards used as attackers go to cemetery

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -65,6 +65,9 @@ class GameState {
       p.spyAttacks = 1; // Spy hero: flips remaining this turn
       p.spyMaxAttacks = 1; // Spy hero: max flips displayed this turn
       p.spyExtends = 1; // Spy hero: extends remaining this turn
+      p.pickingDeckAttacks = 1; // plunder attempts remaining this turn
+      p.attackingSymbol = 'none'; // first attack symbol this turn (locked after first attack)
+      p.attackingSymbol2 = 'none'; // Banneret extended symbol
     }
   }
 
@@ -76,6 +79,10 @@ class GameState {
     // Immediately remove committed hand-based attack cards from attacker's hand.
     // This prevents them reappearing in hand if the player refreshes before confirming the overlay.
     const p = data.attackerIdx !== undefined ? this.players[data.attackerIdx] : null;
+    if (p) {
+      if (p.pickingDeckAttacks > 0) p.pickingDeckAttacks--;
+      if (data.attackingSymbol) { p.attackingSymbol = data.attackingSymbol; p.attackingSymbol2 = data.attackingSymbol2 || 'none'; }
+    }
     const lockedHandCards = [];
     if (p && data.attackCardIds) {
       for (const cardId of data.attackCardIds) {
@@ -87,6 +94,11 @@ class GameState {
   }
 
   setAttackPreview(data) {
+    // Track attacking symbol so the client can restore it on page refresh
+    if (data.attackerIdx !== undefined && data.attackingSymbol) {
+      const atk = this.players[data.attackerIdx];
+      if (atk) { atk.attackingSymbol = data.attackingSymbol; atk.attackingSymbol2 = data.attackingSymbol2 || 'none'; }
+    }
     this.pendingAttack = data;
     // Mark targeted defense card(s) as face-up so the defender sees the reveal immediately
     const { defenderIdx, positionId, level } = data;
@@ -474,6 +486,9 @@ class GameState {
       this.players[currentPlayerIndex].spyAttacks = 1;
       this.players[currentPlayerIndex].spyMaxAttacks = 1;
       this.players[currentPlayerIndex].spyExtends = 1;
+      this.players[currentPlayerIndex].pickingDeckAttacks = 1;
+      this.players[currentPlayerIndex].attackingSymbol = 'none';
+      this.players[currentPlayerIndex].attackingSymbol2 = 'none';
     }
     // Advance to the next non-eliminated player (server is authoritative)
     const n = this.players.length;
@@ -708,6 +723,9 @@ class GameState {
         spyAttacks: p.spyAttacks !== undefined ? p.spyAttacks : 1,
         spyMaxAttacks: p.spyMaxAttacks !== undefined ? p.spyMaxAttacks : 1,
         spyExtends: p.spyExtends !== undefined ? p.spyExtends : 1,
+        pickingDeckAttacks: p.pickingDeckAttacks !== undefined ? p.pickingDeckAttacks : 1,
+        attackingSymbol: p.attackingSymbol || 'none',
+        attackingSymbol2: p.attackingSymbol2 || 'none',
       })),
       pickingDecks: this.pickingDecks.map(d => d.map(c => ({ id: c.id, covered: c.covered }))),
       winnerIndex: this.checkWinner(),

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -58,6 +58,7 @@ class GameState {
       p.topDefCardsCovered = {};
       p.sabotaged = {}; // { slotId: attackerPlayerIdx } — tracks which slots have a saboteur
       p.attackCount = 0; // number of enemy attacks this turn (reset on finishTurn)
+      p.priestConversionAttempts = 2; // Priest hero: attempts remaining this turn
     }
   }
 
@@ -136,13 +137,19 @@ class GameState {
   }
 
   priestConvert(attackerIdx, targetPlayerIdx, cardId) {
-    const target = this.players[targetPlayerIdx];
     const attacker = this.players[attackerIdx];
+    // Enforce server-authoritative attempt limit (2 per turn).
+    if ((attacker.priestConversionAttempts || 0) <= 0) {
+      console.log(`priestConvert: rejected — player ${attackerIdx} has no attempts remaining`);
+      return;
+    }
+    const target = this.players[targetPlayerIdx];
     const idx = target.hand.indexOf(cardId);
     if (idx !== -1) {
       target.hand.splice(idx, 1);
       attacker.hand.push(cardId);
     }
+    attacker.priestConversionAttempts--;
     this.pushLog(`${this.pname(attackerIdx)} (Priest) took card from ${this.pname(targetPlayerIdx)}`, true);
   }
 
@@ -380,6 +387,7 @@ class GameState {
     if (this.players[currentPlayerIndex]) {
       this.players[currentPlayerIndex].preyCards = [];
       this.players[currentPlayerIndex].attackCount = 0; // reset for next turn
+      this.players[currentPlayerIndex].priestConversionAttempts = 2; // reset Priest uses for next turn
     }
     // Advance to the next non-eliminated player (server is authoritative)
     const n = this.players.length;
@@ -586,6 +594,7 @@ class GameState {
         heroes: [...(p.heroes || [])],
         preyCards: [...(p.preyCards || [])],
         attackCount: p.attackCount || 0,
+        priestConversionAttempts: p.priestConversionAttempts !== undefined ? p.priestConversionAttempts : 2,
       })),
       pickingDecks: this.pickingDecks.map(d => d.map(c => ({ id: c.id, covered: c.covered }))),
       winnerIndex: this.checkWinner(),

--- a/server/index.js
+++ b/server/index.js
@@ -739,6 +739,13 @@ io.on('connection', function(socket) {
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
+  socket.on('priestAttemptFailed', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
+    sess.gameState.priestAttemptFailed(data.attackerIdx);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+  });
+
   socket.on('sabotage', function(data) {
     var sess = getSession(socket.id);
     if (!sess || !sess.gameState) return;

--- a/server/index.js
+++ b/server/index.js
@@ -651,6 +651,13 @@ io.on('connection', function(socket) {
     socket.to(sess.id).emit('reservistsKingBoost', data);
   });
 
+  socket.on('warlordDirectAttack', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
+    sess.gameState.warlordDirectAttack(data.playerIdx);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+  });
+
   socket.on('warlordKingSwap', function(data) {
     var sess = getSession(socket.id);
     if (!sess || !sess.gameState) return;

--- a/server/index.js
+++ b/server/index.js
@@ -689,8 +689,21 @@ io.on('connection', function(socket) {
 
   socket.on('spyFlip', function(data) {
     var sess = getSession(socket.id);
-    if (!sess) return;
+    if (!sess || !sess.gameState) return;
+    var userIdx = sess.users.findIndex(function(u) { return u.id === socket.id; });
+    if (userIdx === -1) return;
+    if (!sess.gameState.spyFlip(userIdx)) return;
     socket.to(sess.id).emit('spyFlip', data);
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+  });
+
+  socket.on('spyExtend', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
+    var userIdx = sess.users.findIndex(function(u) { return u.id === socket.id; });
+    if (userIdx === -1) return;
+    if (!sess.gameState.spyExtend(userIdx, data.cardId)) return;
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
   socket.on('batteryDefenseCheck', function(data) {


### PR DESCRIPTION
Closes #112

## Root cause

The Priest hero's 2-conversion-per-turn limit was enforced **only on the client**. On every `stateUpdate` event, `rebuildHeroesFromState` created a fresh `Priest` object — resetting the counter to 2 mid-turn. This meant a player could spam conversions indefinitely by relying on the server broadcast to reset the counter between each attempt.

## Changes

### `server/gameState.js`
- Added `priestConversionAttempts = 2` to each player's state on initialisation
- `priestConvert()` now **rejects** calls when `priestConversionAttempts <= 0` (server-authoritative enforcement)
- `priestConversionAttempts` is decremented on each successful conversion
- Reset to 2 in `finishTurn()` for the active player
- Serialised into every `gameState` snapshot via the existing `serialize()` method so reconnecting players receive the correct remaining count

### `core/src/com/mygdx/game/heroes/Priest.java`
- Added `setConversionAttempts(int n)` — used during reconnect to restore the server-authoritative value

### `core/src/com/mygdx/game/GameState.java` *(already committed in #109)*
- `rebuildHeroesFromState` now **reuses existing hero instances** instead of creating new ones, preserving all mid-turn state for every hero
- For newly-acquired heroes (including reconnects), the Priest's `conversionAttempts` is set from the server-sent `priestConversionAttempts` field