### PR TITLE
Add "Log out" button to menu screens (#119)

### DIFF
--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -527,6 +527,7 @@ public class MenuScreen extends AbstractScreen {
     menuStage.addActor(rulesBtn);
 
     addMusicToggleButton(menuStage);
+    addLogoutButton(menuStage);
     Gdx.input.setInputProcessor(menuStage);
   }
 
@@ -606,6 +607,7 @@ public class MenuScreen extends AbstractScreen {
     menuStage.addActor(backBtn);
 
     addMusicToggleButton(menuStage);
+    addLogoutButton(menuStage);
     Gdx.input.setInputProcessor(menuStage);
   }
 
@@ -617,6 +619,41 @@ public class MenuScreen extends AbstractScreen {
       data.put("token", MyGdxGame.playerStorage.getToken());
     } catch (JSONException e) { /* ignore */ }
     return data;
+  }
+
+  /** Logs the player out: clears saved name, leaves any session, returns to name-entry. */
+  private void logout() {
+    if (lobbyJoined) {
+      socket.emit("leaveSession", "");
+    }
+    MyGdxGame.playerStorage.clearName();
+    MyGdxGame.playerStorage.clearSessionId();
+    menuState.setMyName("");
+    nameConfirmed = false;
+    lobbyJoined = false;
+    timerStarted = false;
+    gameRunning = false;
+    inSessionCreate = false;
+    reconnecting = false;
+    pendingSessionName = "";
+    menuState.clearUsers();
+    reservedByOthers.clear();
+    show();
+  }
+
+  /** Adds a small "Log out" button to the bottom-right of the given stage. */
+  private void addLogoutButton(final Stage stage) {
+    TextButton logoutBtn = new TextButton("Log out", MyGdxGame.skin);
+    logoutBtn.pack();
+    logoutBtn.setSize(logoutBtn.getPrefWidth() + 10, logoutBtn.getPrefHeight() + 6);
+    logoutBtn.setPosition(MyGdxGame.WIDTH - logoutBtn.getWidth() - 10, 10);
+    logoutBtn.addListener(new ClickListener() {
+      @Override
+      public void clicked(InputEvent event, float x, float y) {
+        logout();
+      }
+    });
+    stage.addActor(logoutBtn);
   }
 
   /**
@@ -885,6 +922,7 @@ public class MenuScreen extends AbstractScreen {
     menuStage.addActor(leaveBtn);
 
     addMusicToggleButton(menuStage);
+    addLogoutButton(menuStage);
     Gdx.input.setInputProcessor(menuStage);
   }
 

--- a/core/src/com/mygdx/game/PlayerStorage.java
+++ b/core/src/com/mygdx/game/PlayerStorage.java
@@ -49,6 +49,9 @@ public interface PlayerStorage {
   /** Persists the music on/off preference. */
   void saveMusicEnabled(boolean enabled);
 
+  /** Clears the saved player name (logout). */
+  void clearName();
+
   /** No-op implementation used on desktop and as a safe default. */
   PlayerStorage NOOP = new PlayerStorage() {
     @Override public String  getToken()                          { return ""; }
@@ -61,5 +64,6 @@ public interface PlayerStorage {
     @Override public void    saveShowPlayersTab(boolean val)     { }
     @Override public boolean getMusicEnabled()                   { return true; }
     @Override public void    saveMusicEnabled(boolean enabled)   { }
+    @Override public void    clearName()                         { }
   };
 }

--- a/html/src/com/mygdx/game/client/BrowserPlayerStorage.java
+++ b/html/src/com/mygdx/game/client/BrowserPlayerStorage.java
@@ -73,4 +73,9 @@ public class BrowserPlayerStorage implements PlayerStorage {
   public native void saveMusicEnabled(boolean enabled) /*-{
     $wnd.localStorage.setItem('baisch_music_enabled', enabled ? '1' : '0');
   }-*/;
+
+  @Override
+  public native void clearName() /*-{
+    $wnd.localStorage.removeItem('baisch_player_name');
+  }-*/;
 }


### PR DESCRIPTION
Closes #119

## Changes

- **`PlayerStorage`** — added `clearName()` method to interface and NOOP implementation
- **`BrowserPlayerStorage`** — implemented `clearName()` via `localStorage.removeItem('baisch_player_name')`
- **`MenuScreen`** — added:
  - `logout()` — emits `leaveSession` if in a lobby, clears name + session from storage, resets all in-memory state, navigates to name-entry
  - `addLogoutButton(Stage)` — places a "Log out" button in the bottom-right corner
  - Button wired into `showSessionListScreen`, `showSessionCreateScreen`, and `showLobbyScreen`

## Screens with "Log out" button
| Screen | Button present |
|---|---|
| Name-entry | ❌ (not yet logged in) |
| Session list | ✅ |
| Session create | ✅ |
| Game lobby | ✅ |
| In-game | ❌ (covered by Give Up / return-to-lobby flow) |
