### PR TITLE
Add manual setup phase and configurable starting card count (#108)

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -54,6 +54,7 @@ import com.mygdx.game.listeners.OwnDefCardListener;
 import com.mygdx.game.listeners.EnemyPlaceholderListener;
 import com.mygdx.game.listeners.OwnHandCardListener;
 import com.mygdx.game.listeners.OwnHeroListener;
+import com.mygdx.game.listeners.PickingDeckListener;
 import com.mygdx.game.listeners.OwnKingCardListener;
 import com.mygdx.game.listeners.OwnPlaceholderListener;
 import com.mygdx.game.listeners.SabotagedImageListener;
@@ -139,6 +140,15 @@ public class GameScreen extends ScreenAdapter {
   private JSONArray activityLog = new JSONArray();
   // Emit Reservists count to other clients once on first render (before any stateUpdate fires)
   private boolean initialReservistsBroadcastDone = false;
+
+  // ── Manual setup phase ────────────────────────────────────────────────────
+  // -1 = not yet selected; >= 1 = card ID of the chosen king
+  private int setupSelectedKingId = -1;
+  // IDs of the 3 selected defense cards (-1 = not yet selected)
+  private final int[] setupSelectedDefIds = { -1, -1, -1 };
+  // True after the player has clicked Confirm (waiting for others to finish)
+  private boolean setupSubmitted = false;
+  private final ArrayList<Integer> setupDiscardIds = new ArrayList<Integer>();
 
   // Textures cached once to avoid leaking a new Texture on every show() call
   private Texture texMercenary;
@@ -556,6 +566,7 @@ public class GameScreen extends ScreenAdapter {
     handBck.addListener(new ClickListener() {
       @Override
       public void clicked(InputEvent event, float x, float y) {
+        if (gameState.isSetupPhase()) return;
         Map<Integer, Card> defs = currentPlayer.getDefCards();
         Map<Integer, Card> topDefs = currentPlayer.getTopDefCards();
         for (int jj = 1; jj <= 3; jj++) {
@@ -594,8 +605,6 @@ public class GameScreen extends ScreenAdapter {
   @Override
   public void show() {
     MyGdxGame.setMusicTrack(null); // no music during the game
-    Gdx.app.log("Java Heap", String.valueOf(Gdx.app.getJavaHeap()));
-    Gdx.app.log("Native Heap", String.valueOf(Gdx.app.getNativeHeap()));
 
     players = gameState.getPlayers();
     // Spectators always follow the player whose turn it currently is.
@@ -603,7 +612,20 @@ public class GameScreen extends ScreenAdapter {
       currentPlayer = gameState.getCurrentPlayer();
     }
 
-    // On first render, broadcast Reservists count so enemies see the indicator immediately.
+    gameStage.clear();
+    handStage.clear();
+    overlayStage.clear();
+
+    gameStage.addActor(gameBck);
+    handStage.addActor(handBck);
+
+    // Manual setup phase: show card-selection UI instead of the normal game board
+    if (gameState.isSetupPhase()) {
+      showSetupPhaseScreen();
+      return;
+    }
+
+    // On first render after setup phase (or on first normal game render), broadcast Reservists.
     if (!initialReservistsBroadcastDone) {
       initialReservistsBroadcastDone = true;
       for (Hero h : currentPlayer.getHeroes()) {
@@ -614,13 +636,6 @@ public class GameScreen extends ScreenAdapter {
       }
     }
 
-    gameStage.clear();
-    handStage.clear();
-    overlayStage.clear();
-
-    gameStage.addActor(gameBck);
-    handStage.addActor(handBck);
-
     showGameStage(players, currentPlayer);
     showHandStage(players, currentPlayer);
     if (menuOpen) {
@@ -628,6 +643,243 @@ public class GameScreen extends ScreenAdapter {
     } else {
       addMenuButtonToOverlay();
     }
+  }
+
+  /**
+   * Shows the interactive manual setup phase UI.
+   *
+   * Phase 1: player taps a card to designate it as king (highlighted in gold).
+   * Phase 2: player taps up to 3 more cards as defense cards (highlighted in green).
+   * Phase 3: a Confirm button appears once all 4 cards are chosen.
+   * After Confirm: show "Waiting for other players…" until setup completes for everyone.
+   */
+  private void showSetupPhaseScreen() {
+    float cx = MyGdxGame.WIDTH / 2f;
+    float gameH = Gdx.graphics.getWidth();   // gameStage is square
+    float handH = Gdx.graphics.getHeight() - Gdx.graphics.getWidth();
+
+    Card infoCard = new Card();
+    final float cardW = infoCard.getDefWidth() * 1.6f;
+    final float cardH = infoCard.getDefHeight() * 1.6f;
+
+    // ── Status label ────────────────────────────────────────────────────────
+    int _defCount = 0;
+    for (int id : setupSelectedDefIds) if (id != -1) _defCount++;
+    final int allHandSize = currentPlayer.getHandCards().size();
+    // requiredDiscards = hand - king(1) - def(3) - keep(2)  =  hand - 6
+    final int requiredDiscards = Math.max(0, allHandSize - 6);
+    final boolean inDiscardPhase = (setupSelectedKingId != -1 && _defCount == 3 && requiredDiscards > 0);
+    String statusText;
+    if (setupSubmitted) {
+      statusText = "Waiting for other players...";
+    } else if (setupSelectedKingId == -1) {
+      statusText = "Select your king card";
+    } else if (_defCount < 3) {
+      statusText = "Select defense card " + (_defCount + 1) + " of 3";
+    } else if (inDiscardPhase) {
+      int stillNeeded = requiredDiscards - setupDiscardIds.size();
+      if (stillNeeded > 0) {
+        statusText = "Discard " + stillNeeded + " more card" + (stillNeeded > 1 ? "s" : "");
+      } else {
+        statusText = "Tap Confirm to start";
+      }
+    } else {
+      statusText = "Tap Confirm to start";
+    }
+    Label statusLabel = new Label(statusText, MyGdxGame.skin);
+    statusLabel.setColor(Color.WHITE);
+    statusLabel.pack();
+    statusLabel.setPosition(cx - statusLabel.getPrefWidth() / 2f, gameH - statusLabel.getHeight() - 20);
+    gameStage.addActor(statusLabel);
+
+    // ── Hand cards layout ────────────────────────────────────────────────────
+    if (!setupSubmitted) {
+      ArrayList<Card> handCards = new ArrayList<Card>(currentPlayer.getHandCards());
+      int count = handCards.size();
+      float maxW = Gdx.graphics.getWidth() - 10f;
+      final float step = count <= 1 ? cardW : Math.min(cardW, (maxW - cardW) / (count - 1));
+      float totalW = cardW + (count > 1 ? (count - 1) * step : 0);
+      float startX = cx - totalW / 2f;
+      final float handY = (handH - cardH) / 2f;
+
+      for (int i = 0; i < count; i++) {
+        final Card c = handCards.get(i);
+        final int cardId = c.getCardId();
+
+        // Determine highlight color
+        boolean isKing = (cardId == setupSelectedKingId);
+        boolean isDef = false;
+        for (int id : setupSelectedDefIds) if (id == cardId) { isDef = true; break; }
+
+        c.setCovered(false);
+        c.setWidth(cardW);
+        c.setHeight(cardH);
+        c.setX(startX + i * step);
+        c.setY(handY);
+
+        if (isKing) {
+          c.setColor(Color.GOLD);
+        } else if (isDef) {
+          c.setColor(new Color(0.4f, 1f, 0.4f, 1f));
+        } else if (inDiscardPhase && setupDiscardIds.contains(cardId)) {
+          c.setColor(new Color(0.45f, 0.45f, 0.45f, 1f)); // grayed = marked for discard
+        } else {
+          c.setColor(Color.WHITE);
+        }
+
+        final boolean cardIsKing = (cardId == setupSelectedKingId);
+        boolean cardIsDef = false;
+        for (int id : setupSelectedDefIds) if (id == cardId) { cardIsDef = true; break; }
+        final boolean cardIsKeepSelected = cardIsKing || cardIsDef;
+        final boolean cardIsDiscard = inDiscardPhase && setupDiscardIds.contains(cardId);
+
+        c.removeAllListeners();
+        if (inDiscardPhase && !cardIsKeepSelected) {
+          // In discard phase: tap non-king/non-def cards to toggle discard
+          c.addListener(new ClickListener() {
+            @Override
+            public void clicked(InputEvent event, float x, float y) {
+              if (setupDiscardIds.contains(cardId)) {
+                setupDiscardIds.remove((Integer) cardId);
+              } else {
+                setupDiscardIds.add(cardId);
+              }
+              gameState.setUpdateState(true);
+            }
+          });
+        } else if (!inDiscardPhase) {
+          // In king/def selection phase
+          c.addListener(new ClickListener() {
+            @Override
+            public void clicked(InputEvent event, float x, float y) {
+              // Deselect king
+              if (cardId == setupSelectedKingId) {
+                setupSelectedKingId = -1;
+                setupDiscardIds.clear();
+                gameState.setUpdateState(true);
+                return;
+              }
+              // Deselect def
+              for (int slot = 0; slot < 3; slot++) {
+                if (setupSelectedDefIds[slot] == cardId) {
+                  setupSelectedDefIds[slot] = -1;
+                  for (int s = slot; s < 2; s++) setupSelectedDefIds[s] = setupSelectedDefIds[s + 1];
+                  setupSelectedDefIds[2] = -1;
+                  setupDiscardIds.clear();
+                  gameState.setUpdateState(true);
+                  return;
+                }
+              }
+              // Select as king
+              if (setupSelectedKingId == -1) {
+                setupSelectedKingId = cardId;
+                setupDiscardIds.clear();
+                gameState.setUpdateState(true);
+                return;
+              }
+              // Select as def (up to 3)
+              for (int slot = 0; slot < 3; slot++) {
+                if (setupSelectedDefIds[slot] == -1) {
+                  setupSelectedDefIds[slot] = cardId;
+                  setupDiscardIds.clear();
+                  gameState.setUpdateState(true);
+                  return;
+                }
+              }
+            }
+          });
+        }
+        handStage.addActor(c);
+      }
+
+      // ── King label ───────────────────────────────────────────────────────
+      if (setupSelectedKingId != -1) {
+        Label kingLabel = new Label("KING", MyGdxGame.skin);
+        kingLabel.setColor(Color.GOLD);
+        // Find king card x
+        for (int i = 0; i < count; i++) {
+          if (handCards.get(i).getCardId() == setupSelectedKingId) {
+            kingLabel.pack();
+            kingLabel.setPosition(handCards.get(i).getX() + cardW / 2f - kingLabel.getWidth() / 2f,
+                handY + cardH + 4f);
+            handStage.addActor(kingLabel);
+            break;
+          }
+        }
+      }
+
+      // ── Defense labels ───────────────────────────────────────────────────
+      for (int slot = 0; slot < 3; slot++) {
+        final int defId = setupSelectedDefIds[slot];
+        if (defId == -1) continue;
+        for (int i = 0; i < count; i++) {
+          if (handCards.get(i).getCardId() == defId) {
+            Label defLabel = new Label("DEF " + (slot + 1), MyGdxGame.skin);
+            defLabel.setColor(new Color(0.4f, 1f, 0.4f, 1f));
+            defLabel.pack();
+            defLabel.setPosition(handCards.get(i).getX() + cardW / 2f - defLabel.getWidth() / 2f,
+                handY - defLabel.getHeight() - 4f);
+            handStage.addActor(defLabel);
+            break;
+          }
+        }
+      }
+
+      // ── Discard labels (when in discard phase) ───────────────────────────
+      if (inDiscardPhase) {
+        for (int i = 0; i < count; i++) {
+          final Card c2 = handCards.get(i);
+          final int cid = c2.getCardId();
+          if (cid == setupSelectedKingId) continue;
+          boolean isd = false; for (int id : setupSelectedDefIds) if (id == cid) { isd = true; break; }
+          if (isd) continue;
+          // Show DISCARD / KEEP label below the card
+          boolean markedDiscard = setupDiscardIds.contains(cid);
+          Label discardLabel = new Label(markedDiscard ? "DISCARD" : "KEEP", MyGdxGame.skin);
+          discardLabel.setColor(markedDiscard ? Color.RED : new Color(0.7f, 0.7f, 0.7f, 1f));
+          discardLabel.pack();
+          discardLabel.setPosition(c2.getX() + cardW / 2f - discardLabel.getWidth() / 2f,
+              handY - discardLabel.getHeight() - 4f);
+          handStage.addActor(discardLabel);
+        }
+      }
+
+      // ── Confirm button (shown when king + 3 def chose AND discards done) ─
+      int defCount = 0;
+      for (int id : setupSelectedDefIds) if (id != -1) defCount++;
+      boolean discardsReady = (requiredDiscards == 0) || (setupDiscardIds.size() == requiredDiscards);
+      if (setupSelectedKingId != -1 && defCount == 3 && discardsReady) {
+        final ArrayList<Integer> frozenDiscards = new ArrayList<Integer>(setupDiscardIds);
+        TextButton confirmBtn = new TextButton("Confirm", MyGdxGame.skin);
+        confirmBtn.pack();
+        confirmBtn.setSize(confirmBtn.getPrefWidth() + 20, confirmBtn.getPrefHeight() + 10);
+        confirmBtn.setPosition(cx - confirmBtn.getWidth() / 2f, 0.06f * MyGdxGame.HEIGHT);
+        confirmBtn.addListener(new ClickListener() {
+          @Override
+          public void clicked(InputEvent event, float x, float y) {
+            if (setupSubmitted) return;
+            setupSubmitted = true;
+            try {
+              JSONObject data = new JSONObject();
+              data.put("kingCardId", setupSelectedKingId);
+              JSONArray defIds = new JSONArray();
+              defIds.put(setupSelectedDefIds[0]);
+              defIds.put(setupSelectedDefIds[1]);
+              defIds.put(setupSelectedDefIds[2]);
+              data.put("defCardIds", defIds);
+              JSONArray discardIds = new JSONArray();
+              for (int id : frozenDiscards) discardIds.put(id);
+              data.put("discardCardIds", discardIds);
+              socket.emit("submitSetup", data);
+            } catch (JSONException ex) { ex.printStackTrace(); }
+            gameState.setUpdateState(true);
+          }
+        });
+        overlayStage.addActor(confirmBtn);
+      }
+    }
+
+    Gdx.input.setInputProcessor(menuAndGameMulti);
   }
 
   public void showGameStage(final ArrayList<Player> players, final Player currentPlayer) {
@@ -3328,9 +3580,19 @@ public class GameScreen extends ScreenAdapter {
           if (bc != null && bc.getCardId() == e.getValue()[0]) bc.addBoosted(e.getValue()[1]);
         }
 
-        // Apply king card covered state and out flag
+        // Sync king card from server (may transition null→card after setup phase)
+        int serverKingId = pj.optInt("kingCard", 0);
+        if (serverKingId > 0) {
+          if (p.getKingCard() == null || p.getKingCard().getCardId() != serverKingId) {
+            p.setKingCard(Card.fromCardId(serverKingId));
+          }
+          p.getKingCard().setCovered(pj.optBoolean("kingCovered", true));
+        } else {
+          p.setKingCard(null);
+        }
+
+        // Apply out flag
         p.setOut(pj.optBoolean("isOut", false));
-        if (p.getKingCard() != null) p.getKingCard().setCovered(pj.optBoolean("kingCovered", true));
 
         // Sync slot sabotage state from server-authoritative state
         for (int sl = 1; sl <= 3; sl++) p.clearSlotSabotaged(sl);
@@ -3451,6 +3713,18 @@ public class GameScreen extends ScreenAdapter {
       // 6. Winner index
       gameState.setWinnerIndex(state.optInt("winnerIndex", -1));
 
+      // 6b. Setup phase flag (manual setup)
+      boolean prevSetupPhase = gameState.isSetupPhase();
+      boolean newSetupPhase = state.optBoolean("setupPhase", false);
+      gameState.setSetupPhase(newSetupPhase);
+      // When setup phase just ended, attach picking deck listeners (deferred from deserialization)
+      if (prevSetupPhase && !newSetupPhase && gameState.getPickingDecks().size() >= 2) {
+        PickingDeckListener pdl0 = new PickingDeckListener(gameState, gameState.getPickingDecks().get(0), gameState.getPickingDecks().get(1), 0);
+        gameState.getPickingDecks().get(0).addListener(pdl0);
+        PickingDeckListener pdl1 = new PickingDeckListener(gameState, gameState.getPickingDecks().get(1), gameState.getPickingDecks().get(0), 1);
+        gameState.getPickingDecks().get(1).addListener(pdl1);
+      }
+
       // 7. Activity log
       JSONArray logJson = state.optJSONArray("log");
       if (logJson != null) activityLog = logJson;
@@ -3496,12 +3770,12 @@ public class GameScreen extends ScreenAdapter {
 
     // Highlight hand area when own defense card is selected or being dragged
     boolean anyOwnDefSelected = isDraggingDefCard;
-    if (!anyOwnDefSelected) {
+    if (!anyOwnDefSelected && !gameState.isSetupPhase()) {
       for (Card c : currentPlayer.getDefCards().values()) {
         if (c.isSelected()) { anyOwnDefSelected = true; break; }
       }
     }
-    if (!anyOwnDefSelected) {
+    if (!anyOwnDefSelected && !gameState.isSetupPhase()) {
       for (Card c : currentPlayer.getTopDefCards().values()) {
         if (c.isSelected()) { anyOwnDefSelected = true; break; }
       }

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -621,12 +621,7 @@ public class GameScreen extends ScreenAdapter {
 
     // Manual setup phase: show card-selection UI instead of the normal game board
     if (gameState.isSetupPhase()) {
-      try {
-        showSetupPhaseScreen();
-      } catch (Exception e) {
-        Gdx.app.error("showSetupPhaseScreen", "Exception: " + e.getClass().getName() + ": " + e.getMessage());
-        e.printStackTrace();
-      }
+      showSetupPhaseScreen();
       return;
     }
 
@@ -3744,10 +3739,7 @@ public class GameScreen extends ScreenAdapter {
         merchantRevealPlayerIdx = -1;
       }
 
-    } catch (Exception e) {
-      Gdx.app.error("applyStateUpdate", "Exception in applyStateUpdate: " + e.getClass().getName() + ": " + e.getMessage());
-      e.printStackTrace();
-    }
+    } catch (JSONException e) { e.printStackTrace(); }
   }
 
   @Override

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -621,7 +621,12 @@ public class GameScreen extends ScreenAdapter {
 
     // Manual setup phase: show card-selection UI instead of the normal game board
     if (gameState.isSetupPhase()) {
-      showSetupPhaseScreen();
+      try {
+        showSetupPhaseScreen();
+      } catch (Exception e) {
+        Gdx.app.error("showSetupPhaseScreen", "Exception: " + e.getClass().getName() + ": " + e.getMessage());
+        e.printStackTrace();
+      }
       return;
     }
 
@@ -3739,7 +3744,8 @@ public class GameScreen extends ScreenAdapter {
         merchantRevealPlayerIdx = -1;
       }
 
-    } catch (JSONException e) {
+    } catch (Exception e) {
+      Gdx.app.error("applyStateUpdate", "Exception in applyStateUpdate: " + e.getClass().getName() + ": " + e.getMessage());
       e.printStackTrace();
     }
   }

--- a/core/src/com/mygdx/game/GameState.java
+++ b/core/src/com/mygdx/game/GameState.java
@@ -5,11 +5,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.mygdx.game.util.JSONArray;
+import com.mygdx.game.util.JSONException;
+import com.mygdx.game.util.JSONObject;
 
-import io.socket.client.Socket;
+import com.mygdx.game.net.SocketClient;
 
 import com.mygdx.game.heroes.Hero;
 import com.mygdx.game.listeners.CemeteryDeckListener;
@@ -30,12 +30,7 @@ public class GameState {
 
   private boolean updateState;
 
-  // True while the manual setup phase is in progress (server uses setupPhase flag).
-  private boolean setupPhase = false;
-  public boolean isSetupPhase() { return setupPhase; }
-  public void setSetupPhase(boolean v) { setupPhase = v; }
-
-  private Socket socket;
+  private SocketClient socket;
 
   private int winnerIndex = -1;
   public int getWinnerIndex() { return winnerIndex; }
@@ -55,7 +50,7 @@ public class GameState {
   private CemeteryDeckListener cemeteryDeckListener;
 
   public SocketClient getSocket() { return socket; }
-  public void setSocket(Socket socket) { this.socket = socket; }
+  public void setSocket(SocketClient socket) { this.socket = socket; }
 
   // Constructor for centralized (server-driven) game state.
   // Players already have their hand cards from the server.
@@ -159,8 +154,7 @@ public class GameState {
           p.topDefCards.put(Integer.parseInt(key), tdc);
         }
 
-        int kingId = pj.optInt("kingCard", 0);
-        if (kingId > 0) p.setKingCard(Card.fromCardId(kingId));
+        p.setKingCard(Card.fromCardId(pj.getInt("kingCard")));
 
         // Saboteurs slot state
         JSONObject sabotagedJson = pj.optJSONObject("sabotaged");
@@ -207,25 +201,18 @@ public class GameState {
       int cpIdx = fullState.getInt("currentPlayerIndex");
       currentPlayerIt = roundOrder.iterator();
       for (int i = 0; i < cpIdx; i++) currentPlayerIt.next();
-        currentPlayer = roundOrder.get(cpIdx);
-      // 6. Listeners (only if picking decks are initialised — not true during setup phase)
-      if (pickingDecks.size() >= 2) {
-        pickingDeckListenerOne = new PickingDeckListener(this, pickingDecks.get(0), pickingDecks.get(1), 0);
-        pickingDecks.get(0).addListener(pickingDeckListenerOne);
-        pickingDeckListenerTwo = new PickingDeckListener(this, pickingDecks.get(1), pickingDecks.get(0), 1);
-        pickingDecks.get(1).addListener(pickingDeckListenerTwo);
-      } else {
-        // Ensure we always have two (possibly empty) picking deck slots
-        while (pickingDecks.size() < 2) pickingDecks.add(new PickingDeck());
-      }
+      currentPlayer = currentPlayerIt.next();
+
+      // 6. Listeners
+      pickingDeckListenerOne = new PickingDeckListener(this, pickingDecks.get(0), pickingDecks.get(1), 0);
+      pickingDecks.get(0).addListener(pickingDeckListenerOne);
+      pickingDeckListenerTwo = new PickingDeckListener(this, pickingDecks.get(1), pickingDecks.get(0), 1);
+      pickingDecks.get(1).addListener(pickingDeckListenerTwo);
       cemeteryDeckListener = new CemeteryDeckListener(this);
       cemeteryDeck.addListener(cemeteryDeckListener);
 
       // 7. Heroes from server-authoritative state
       rebuildHeroesFromState(playersJson);
-
-      // 8. Setup phase flag
-      setupPhase = fullState.optBoolean("setupPhase", false);
 
     } catch (JSONException e) {
       e.printStackTrace();
@@ -417,17 +404,15 @@ public class GameState {
    * Rebuild all heroes from a server-authoritative players JSON array.
    *
    * <p>Existing hero instances are reused for heroes the same player already owns. This
-   * preserves all per-turn counters (Priest conversionAttempts, Merchant trades, Marshal
-   * mobilizations, etc.) through routine stateUpdate syncs so heroes cannot be exploited by
-   * triggering a server event to "reload" their counters.
+   * preserves all per-turn counters through routine stateUpdate syncs so heroes cannot be
+   * exploited by triggering a server event to reset their counters.
    *
-   * <p>When a hero instance is newly created (first acquisition or reconnect), the server-
-   * serialized counter is applied — e.g. {@code priestConversionAttempts} — so that a
-   * reconnecting player cannot use more attempts than the server permits.
+   * <p>Server-authoritative per-turn counters are ALWAYS applied so the client never runs
+   * ahead of what the server permits.
    */
+  @SuppressWarnings("unchecked")
   public void rebuildHeroesFromState(JSONArray playersJson) throws JSONException {
-    // Save current hero instances keyed by playerIdx → heroName.
-    @SuppressWarnings("unchecked")
+    // Save current hero instances keyed by playerIdx -> heroName.
     java.util.Map<String, Hero>[] savedHeroes = new java.util.Map[players.size()];
     for (int i = 0; i < players.size(); i++) {
       savedHeroes[i] = new java.util.HashMap<String, Hero>();
@@ -450,20 +435,17 @@ public class GameState {
       for (int h = 0; h < heroesJson.length(); h++) {
         String heroName = heroesJson.getString(h);
         Hero existing = (savedHeroes[idx] != null) ? savedHeroes[idx].get(heroName) : null;
-        Hero syncedHero;
         if (existing != null) {
-          // Reuse existing instance — preserves mid-turn state for all heroes.
-          heroesSquare.consumeHeroByName(heroName); // remove from pool to keep it consistent
+          // Reuse existing instance -- preserves mid-turn state.
+          heroesSquare.consumeHeroByName(heroName);
           players.get(idx).addHero(existing);
-          syncedHero = existing;
         } else {
           // New acquisition or reconnect: get a fresh hero from the pool.
           applyHeroAcquired(idx, heroName);
-          ArrayList<Hero> heroList = players.get(idx).getHeroes();
-          syncedHero = heroList.get(heroList.size() - 1);
         }
-
-        // Apply server-authoritative hero counters so reconnects cannot refresh turn-limited actions.
+        // Always apply server-authoritative per-turn counters.
+        ArrayList<Hero> heroList = players.get(idx).getHeroes();
+        Hero syncedHero = heroList.get(heroList.size() - 1);
         if (syncedHero instanceof com.mygdx.game.heroes.Priest) {
           int serverAttempts = pj.optInt("priestConversionAttempts", 2);
           ((com.mygdx.game.heroes.Priest) syncedHero).setConversionAttempts(serverAttempts);
@@ -507,7 +489,6 @@ public class GameState {
       players.get(playerIdx).addHero(hero);
     }
   }
-
   /**
    * Find the index of the player who currently owns a hero with the given name.
    * Returns -1 if no player owns that hero.

--- a/core/src/com/mygdx/game/GameState.java
+++ b/core/src/com/mygdx/game/GameState.java
@@ -5,11 +5,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 
-import com.mygdx.game.util.JSONArray;
-import com.mygdx.game.util.JSONException;
-import com.mygdx.game.util.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
-import com.mygdx.game.net.SocketClient;
+import io.socket.client.Socket;
 
 import com.mygdx.game.heroes.Hero;
 import com.mygdx.game.listeners.CemeteryDeckListener;
@@ -30,7 +30,12 @@ public class GameState {
 
   private boolean updateState;
 
-  private SocketClient socket;
+  // True while the manual setup phase is in progress (server uses setupPhase flag).
+  private boolean setupPhase = false;
+  public boolean isSetupPhase() { return setupPhase; }
+  public void setSetupPhase(boolean v) { setupPhase = v; }
+
+  private Socket socket;
 
   private int winnerIndex = -1;
   public int getWinnerIndex() { return winnerIndex; }
@@ -50,7 +55,7 @@ public class GameState {
   private CemeteryDeckListener cemeteryDeckListener;
 
   public SocketClient getSocket() { return socket; }
-  public void setSocket(SocketClient socket) { this.socket = socket; }
+  public void setSocket(Socket socket) { this.socket = socket; }
 
   // Constructor for centralized (server-driven) game state.
   // Players already have their hand cards from the server.
@@ -154,7 +159,8 @@ public class GameState {
           p.topDefCards.put(Integer.parseInt(key), tdc);
         }
 
-        p.setKingCard(Card.fromCardId(pj.getInt("kingCard")));
+        int kingId = pj.optInt("kingCard", 0);
+        if (kingId > 0) p.setKingCard(Card.fromCardId(kingId));
 
         // Saboteurs slot state
         JSONObject sabotagedJson = pj.optJSONObject("sabotaged");
@@ -201,18 +207,25 @@ public class GameState {
       int cpIdx = fullState.getInt("currentPlayerIndex");
       currentPlayerIt = roundOrder.iterator();
       for (int i = 0; i < cpIdx; i++) currentPlayerIt.next();
-      currentPlayer = currentPlayerIt.next();
-
-      // 6. Listeners
-      pickingDeckListenerOne = new PickingDeckListener(this, pickingDecks.get(0), pickingDecks.get(1), 0);
-      pickingDecks.get(0).addListener(pickingDeckListenerOne);
-      pickingDeckListenerTwo = new PickingDeckListener(this, pickingDecks.get(1), pickingDecks.get(0), 1);
-      pickingDecks.get(1).addListener(pickingDeckListenerTwo);
+        currentPlayer = roundOrder.get(cpIdx);
+      // 6. Listeners (only if picking decks are initialised — not true during setup phase)
+      if (pickingDecks.size() >= 2) {
+        pickingDeckListenerOne = new PickingDeckListener(this, pickingDecks.get(0), pickingDecks.get(1), 0);
+        pickingDecks.get(0).addListener(pickingDeckListenerOne);
+        pickingDeckListenerTwo = new PickingDeckListener(this, pickingDecks.get(1), pickingDecks.get(0), 1);
+        pickingDecks.get(1).addListener(pickingDeckListenerTwo);
+      } else {
+        // Ensure we always have two (possibly empty) picking deck slots
+        while (pickingDecks.size() < 2) pickingDecks.add(new PickingDeck());
+      }
       cemeteryDeckListener = new CemeteryDeckListener(this);
       cemeteryDeck.addListener(cemeteryDeckListener);
 
       // 7. Heroes from server-authoritative state
       rebuildHeroesFromState(playersJson);
+
+      // 8. Setup phase flag
+      setupPhase = fullState.optBoolean("setupPhase", false);
 
     } catch (JSONException e) {
       e.printStackTrace();
@@ -404,15 +417,17 @@ public class GameState {
    * Rebuild all heroes from a server-authoritative players JSON array.
    *
    * <p>Existing hero instances are reused for heroes the same player already owns. This
-   * preserves all per-turn counters through routine stateUpdate syncs so heroes cannot be
-   * exploited by triggering a server event to reset their counters.
+   * preserves all per-turn counters (Priest conversionAttempts, Merchant trades, Marshal
+   * mobilizations, etc.) through routine stateUpdate syncs so heroes cannot be exploited by
+   * triggering a server event to "reload" their counters.
    *
-   * <p>Server-authoritative per-turn counters are ALWAYS applied so the client never runs
-   * ahead of what the server permits.
+   * <p>When a hero instance is newly created (first acquisition or reconnect), the server-
+   * serialized counter is applied — e.g. {@code priestConversionAttempts} — so that a
+   * reconnecting player cannot use more attempts than the server permits.
    */
-  @SuppressWarnings("unchecked")
   public void rebuildHeroesFromState(JSONArray playersJson) throws JSONException {
-    // Save current hero instances keyed by playerIdx -> heroName.
+    // Save current hero instances keyed by playerIdx → heroName.
+    @SuppressWarnings("unchecked")
     java.util.Map<String, Hero>[] savedHeroes = new java.util.Map[players.size()];
     for (int i = 0; i < players.size(); i++) {
       savedHeroes[i] = new java.util.HashMap<String, Hero>();
@@ -435,17 +450,20 @@ public class GameState {
       for (int h = 0; h < heroesJson.length(); h++) {
         String heroName = heroesJson.getString(h);
         Hero existing = (savedHeroes[idx] != null) ? savedHeroes[idx].get(heroName) : null;
+        Hero syncedHero;
         if (existing != null) {
-          // Reuse existing instance -- preserves mid-turn state.
-          heroesSquare.consumeHeroByName(heroName);
+          // Reuse existing instance — preserves mid-turn state for all heroes.
+          heroesSquare.consumeHeroByName(heroName); // remove from pool to keep it consistent
           players.get(idx).addHero(existing);
+          syncedHero = existing;
         } else {
           // New acquisition or reconnect: get a fresh hero from the pool.
           applyHeroAcquired(idx, heroName);
+          ArrayList<Hero> heroList = players.get(idx).getHeroes();
+          syncedHero = heroList.get(heroList.size() - 1);
         }
-        // Always apply server-authoritative per-turn counters.
-        ArrayList<Hero> heroList = players.get(idx).getHeroes();
-        Hero syncedHero = heroList.get(heroList.size() - 1);
+
+        // Apply server-authoritative hero counters so reconnects cannot refresh turn-limited actions.
         if (syncedHero instanceof com.mygdx.game.heroes.Priest) {
           int serverAttempts = pj.optInt("priestConversionAttempts", 2);
           ((com.mygdx.game.heroes.Priest) syncedHero).setConversionAttempts(serverAttempts);
@@ -489,6 +507,7 @@ public class GameState {
       players.get(playerIdx).addHero(hero);
     }
   }
+
   /**
    * Find the index of the player who currently owns a hero with the given name.
    * Returns -1 if no player owns that hero.

--- a/core/src/com/mygdx/game/GameState.java
+++ b/core/src/com/mygdx/game/GameState.java
@@ -128,16 +128,15 @@ public class GameState {
     updateState = false;
 
     try {
+      // 0. Setup phase flag (read first so it is available for step 6)
+      setupPhase = fullState.optBoolean("setupPhase", false);
+
       // 1. Build players (hand, defCards, topDefCards, kingCard)
       JSONArray playersJson = fullState.getJSONArray("players");
-      com.badlogic.gdx.Gdx.app.log("DBG_GS", "parsing " + playersJson.length() + " players");
       for (int i = 0; i < playersJson.length(); i++) {
         JSONObject pj = playersJson.getJSONObject(i);
         int idx = pj.getInt("index");
         String name = pj.optString("name", "Player " + idx);
-        com.badlogic.gdx.Gdx.app.log("DBG_GS", "player[" + i + "] name=" + name
-            + " kingCard=" + pj.optInt("kingCard", -1)
-            + " hand=" + pj.getJSONArray("hand").length());
         Player p = new Player(name);
 
         JSONArray handJson = pj.getJSONArray("hand");
@@ -181,7 +180,6 @@ public class GameState {
       roundOrder = new ArrayList<Player>(players);
 
       // 2. Deck
-      com.badlogic.gdx.Gdx.app.log("DBG_GS", "parsing deck");
       cardDeck = new CardDeck(true);
       JSONArray deckJson = fullState.getJSONArray("deck");
       for (int i = 0; i < deckJson.length(); i++) {
@@ -189,14 +187,12 @@ public class GameState {
       }
 
       // 3. Cemetery
-      com.badlogic.gdx.Gdx.app.log("DBG_GS", "parsing cemetery");
       JSONArray cemJson = fullState.getJSONArray("cemetery");
       for (int i = 0; i < cemJson.length(); i++) {
         cemeteryDeck.getCards().add(Card.fromCardId(cemJson.getInt(i)));
       }
 
       // 4. Picking decks
-      com.badlogic.gdx.Gdx.app.log("DBG_GS", "parsing pickingDecks");
       JSONArray pickJson = fullState.getJSONArray("pickingDecks");
       for (int i = 0; i < pickJson.length(); i++) {
         PickingDeck pd = new PickingDeck();
@@ -211,13 +207,12 @@ public class GameState {
       }
 
       // 5. Current player (sequential order, start from server's currentPlayerIndex)
-      com.badlogic.gdx.Gdx.app.log("DBG_GS", "parsing currentPlayer");
       int cpIdx = fullState.getInt("currentPlayerIndex");
       currentPlayerIt = roundOrder.iterator();
       for (int i = 0; i < cpIdx; i++) currentPlayerIt.next();
         currentPlayer = roundOrder.get(cpIdx);
-      // 6. Listeners (only if picking decks are initialised — not true during setup phase)
-      if (pickingDecks.size() >= 2) {
+      // 6. Listeners (only when picking decks have cards — skipped during manual setup phase)
+      if (!setupPhase && pickingDecks.size() >= 2) {
         pickingDeckListenerOne = new PickingDeckListener(this, pickingDecks.get(0), pickingDecks.get(1), 0);
         pickingDecks.get(0).addListener(pickingDeckListenerOne);
         pickingDeckListenerTwo = new PickingDeckListener(this, pickingDecks.get(1), pickingDecks.get(0), 1);
@@ -230,12 +225,7 @@ public class GameState {
       cemeteryDeck.addListener(cemeteryDeckListener);
 
       // 7. Heroes from server-authoritative state
-      com.badlogic.gdx.Gdx.app.log("DBG_GS", "rebuilding heroes");
       rebuildHeroesFromState(playersJson);
-
-      // 8. Setup phase flag
-      com.badlogic.gdx.Gdx.app.log("DBG_GS", "done, setupPhase=" + setupPhase);
-      setupPhase = fullState.optBoolean("setupPhase", false);
 
     } catch (JSONException e) {
       e.printStackTrace();

--- a/core/src/com/mygdx/game/GameState.java
+++ b/core/src/com/mygdx/game/GameState.java
@@ -30,6 +30,11 @@ public class GameState {
 
   private boolean updateState;
 
+  // True while the manual setup phase is in progress (server uses setupPhase flag).
+  private boolean setupPhase = false;
+  public boolean isSetupPhase() { return setupPhase; }
+  public void setSetupPhase(boolean v) { setupPhase = v; }
+
   private SocketClient socket;
 
   private int winnerIndex = -1;
@@ -125,10 +130,14 @@ public class GameState {
     try {
       // 1. Build players (hand, defCards, topDefCards, kingCard)
       JSONArray playersJson = fullState.getJSONArray("players");
+      com.badlogic.gdx.Gdx.app.log("DBG_GS", "parsing " + playersJson.length() + " players");
       for (int i = 0; i < playersJson.length(); i++) {
         JSONObject pj = playersJson.getJSONObject(i);
         int idx = pj.getInt("index");
         String name = pj.optString("name", "Player " + idx);
+        com.badlogic.gdx.Gdx.app.log("DBG_GS", "player[" + i + "] name=" + name
+            + " kingCard=" + pj.optInt("kingCard", -1)
+            + " hand=" + pj.getJSONArray("hand").length());
         Player p = new Player(name);
 
         JSONArray handJson = pj.getJSONArray("hand");
@@ -154,7 +163,8 @@ public class GameState {
           p.topDefCards.put(Integer.parseInt(key), tdc);
         }
 
-        p.setKingCard(Card.fromCardId(pj.getInt("kingCard")));
+        int kingId = pj.optInt("kingCard", 0);
+        if (kingId > 0) p.setKingCard(Card.fromCardId(kingId));
 
         // Saboteurs slot state
         JSONObject sabotagedJson = pj.optJSONObject("sabotaged");
@@ -171,6 +181,7 @@ public class GameState {
       roundOrder = new ArrayList<Player>(players);
 
       // 2. Deck
+      com.badlogic.gdx.Gdx.app.log("DBG_GS", "parsing deck");
       cardDeck = new CardDeck(true);
       JSONArray deckJson = fullState.getJSONArray("deck");
       for (int i = 0; i < deckJson.length(); i++) {
@@ -178,12 +189,14 @@ public class GameState {
       }
 
       // 3. Cemetery
+      com.badlogic.gdx.Gdx.app.log("DBG_GS", "parsing cemetery");
       JSONArray cemJson = fullState.getJSONArray("cemetery");
       for (int i = 0; i < cemJson.length(); i++) {
         cemeteryDeck.getCards().add(Card.fromCardId(cemJson.getInt(i)));
       }
 
       // 4. Picking decks
+      com.badlogic.gdx.Gdx.app.log("DBG_GS", "parsing pickingDecks");
       JSONArray pickJson = fullState.getJSONArray("pickingDecks");
       for (int i = 0; i < pickJson.length(); i++) {
         PickingDeck pd = new PickingDeck();
@@ -198,21 +211,31 @@ public class GameState {
       }
 
       // 5. Current player (sequential order, start from server's currentPlayerIndex)
+      com.badlogic.gdx.Gdx.app.log("DBG_GS", "parsing currentPlayer");
       int cpIdx = fullState.getInt("currentPlayerIndex");
       currentPlayerIt = roundOrder.iterator();
       for (int i = 0; i < cpIdx; i++) currentPlayerIt.next();
-      currentPlayer = currentPlayerIt.next();
-
-      // 6. Listeners
-      pickingDeckListenerOne = new PickingDeckListener(this, pickingDecks.get(0), pickingDecks.get(1), 0);
-      pickingDecks.get(0).addListener(pickingDeckListenerOne);
-      pickingDeckListenerTwo = new PickingDeckListener(this, pickingDecks.get(1), pickingDecks.get(0), 1);
-      pickingDecks.get(1).addListener(pickingDeckListenerTwo);
+        currentPlayer = roundOrder.get(cpIdx);
+      // 6. Listeners (only if picking decks are initialised — not true during setup phase)
+      if (pickingDecks.size() >= 2) {
+        pickingDeckListenerOne = new PickingDeckListener(this, pickingDecks.get(0), pickingDecks.get(1), 0);
+        pickingDecks.get(0).addListener(pickingDeckListenerOne);
+        pickingDeckListenerTwo = new PickingDeckListener(this, pickingDecks.get(1), pickingDecks.get(0), 1);
+        pickingDecks.get(1).addListener(pickingDeckListenerTwo);
+      } else {
+        // Ensure we always have two (possibly empty) picking deck slots
+        while (pickingDecks.size() < 2) pickingDecks.add(new PickingDeck());
+      }
       cemeteryDeckListener = new CemeteryDeckListener(this);
       cemeteryDeck.addListener(cemeteryDeckListener);
 
       // 7. Heroes from server-authoritative state
+      com.badlogic.gdx.Gdx.app.log("DBG_GS", "rebuilding heroes");
       rebuildHeroesFromState(playersJson);
+
+      // 8. Setup phase flag
+      com.badlogic.gdx.Gdx.app.log("DBG_GS", "done, setupPhase=" + setupPhase);
+      setupPhase = fullState.optBoolean("setupPhase", false);
 
     } catch (JSONException e) {
       e.printStackTrace();
@@ -404,15 +427,17 @@ public class GameState {
    * Rebuild all heroes from a server-authoritative players JSON array.
    *
    * <p>Existing hero instances are reused for heroes the same player already owns. This
-   * preserves all per-turn counters through routine stateUpdate syncs so heroes cannot be
-   * exploited by triggering a server event to reset their counters.
+   * preserves all per-turn counters (Priest conversionAttempts, Merchant trades, Marshal
+   * mobilizations, etc.) through routine stateUpdate syncs so heroes cannot be exploited by
+   * triggering a server event to "reload" their counters.
    *
-   * <p>Server-authoritative per-turn counters are ALWAYS applied so the client never runs
-   * ahead of what the server permits.
+   * <p>When a hero instance is newly created (first acquisition or reconnect), the server-
+   * serialized counter is applied — e.g. {@code priestConversionAttempts} — so that a
+   * reconnecting player cannot use more attempts than the server permits.
    */
-  @SuppressWarnings("unchecked")
   public void rebuildHeroesFromState(JSONArray playersJson) throws JSONException {
-    // Save current hero instances keyed by playerIdx -> heroName.
+    // Save current hero instances keyed by playerIdx → heroName.
+    @SuppressWarnings("unchecked")
     java.util.Map<String, Hero>[] savedHeroes = new java.util.Map[players.size()];
     for (int i = 0; i < players.size(); i++) {
       savedHeroes[i] = new java.util.HashMap<String, Hero>();
@@ -435,17 +460,20 @@ public class GameState {
       for (int h = 0; h < heroesJson.length(); h++) {
         String heroName = heroesJson.getString(h);
         Hero existing = (savedHeroes[idx] != null) ? savedHeroes[idx].get(heroName) : null;
+        Hero syncedHero;
         if (existing != null) {
-          // Reuse existing instance -- preserves mid-turn state.
-          heroesSquare.consumeHeroByName(heroName);
+          // Reuse existing instance — preserves mid-turn state for all heroes.
+          heroesSquare.consumeHeroByName(heroName); // remove from pool to keep it consistent
           players.get(idx).addHero(existing);
+          syncedHero = existing;
         } else {
           // New acquisition or reconnect: get a fresh hero from the pool.
           applyHeroAcquired(idx, heroName);
+          ArrayList<Hero> heroList = players.get(idx).getHeroes();
+          syncedHero = heroList.get(heroList.size() - 1);
         }
-        // Always apply server-authoritative per-turn counters.
-        ArrayList<Hero> heroList = players.get(idx).getHeroes();
-        Hero syncedHero = heroList.get(heroList.size() - 1);
+
+        // Apply server-authoritative hero counters so reconnects cannot refresh turn-limited actions.
         if (syncedHero instanceof com.mygdx.game.heroes.Priest) {
           int serverAttempts = pj.optInt("priestConversionAttempts", 2);
           ((com.mygdx.game.heroes.Priest) syncedHero).setConversionAttempts(serverAttempts);
@@ -489,6 +517,7 @@ public class GameState {
       players.get(playerIdx).addHero(hero);
     }
   }
+
   /**
    * Find the index of the player who currently owns a hero with the given name.
    * Returns -1 if no player owns that hero.

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -1129,24 +1129,9 @@ public class MenuScreen extends AbstractScreen {
           final int playerIndex = data.getInt("playerIndex");
           final JSONObject gameState = data.getJSONObject("gameState");
           Gdx.app.log("SocketIO", "Received centralized game state, playerIndex: " + playerIndex);
-          Gdx.app.log("DBG_GAMESTATE", "setupPhase=" + gameState.optBoolean("setupPhase", false)
-              + " playerCount=" + gameState.optJSONArray("players").length()
-              + " pickingDecks=" + gameState.optJSONArray("pickingDecks").length());
-          // Log each player's key fields to find nulls
-          com.mygdx.game.util.JSONArray playerArr = gameState.optJSONArray("players");
-          for (int _i = 0; _i < playerArr.length(); _i++) {
-            com.mygdx.game.util.JSONObject _p = playerArr.getJSONObject(_i);
-            Gdx.app.log("DBG_PLAYER_" + _i,
-                "name=" + _p.optString("name", "?") +
-                " kingCard=" + _p.optInt("kingCard", -1) +
-                " hand=" + _p.optJSONArray("hand").length() +
-                " attackingSymbol=" + _p.optString("attackingSymbol", "?") +
-                " heroes=" + _p.optJSONArray("heroes").length());
-          }
           Gdx.app.postRunnable(new Runnable() {
             @Override
             public void run() {
-              Gdx.app.log("DBG_GAMESTATE", "Creating GameScreen...");
               game.setScreen(new GameScreen(game, gameState, playerIndex, socket, menuState.getStartingHero()));
             }
           });

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -67,6 +67,9 @@ public class MenuScreen extends AbstractScreen {
   private String pendingSessionName = "";
   // Whether hero selection is allowed in the current session
   private boolean sessionAllowHeroSelection = false;
+  // Pending create-screen settings
+  private boolean pendingManualSetup = false;
+  private int pendingMaxCards = 8;
 
   // The session list received from the server
   private java.util.List<SessionInfo> sessionList = new java.util.ArrayList<SessionInfo>();
@@ -535,17 +538,27 @@ public class MenuScreen extends AbstractScreen {
     MyGdxGame.setMusicTrack(MyGdxGame.musicShimmer);
     float cx = MyGdxGame.WIDTH / 2f;
 
-    // All elements must sit below the logo (logo bottom ≈ 0.9*H - logoHeight ≈ 449px on a
-    // 800px-high screen). Use the lower half of the display for all create-screen widgets.
-    Label title = new Label("New game", MyGdxGame.skin);
-    title.setPosition(cx - title.getWidth() / 2f, 0.50f * MyGdxGame.HEIGHT);
-    menuStage.addActor(title);
+    // ── Back button (top-left) ───────────────────────────────────────────────
+    TextButton backBtn = new TextButton("Back", MyGdxGame.skin);
+    backBtn.pack();
+    backBtn.setPosition(10, MyGdxGame.HEIGHT - backBtn.getHeight() - 10);
+    backBtn.addListener(new ClickListener() {
+      @Override
+      public void clicked(InputEvent event, float x, float y) {
+        inSessionCreate = false;
+        show();
+      }
+    });
+    menuStage.addActor(backBtn);
 
-    // Button that shows the current game name and opens a native dialog to edit it
+    // ── Title ────────────────────────────────────────────────────────────────
+    Label title = new Label("New game", MyGdxGame.skin);
+    title.setFontScale(1.3f);
+    title.pack();
+
+    // ── Game name button ─────────────────────────────────────────────────────
     final String nameDisplay = pendingSessionName.isEmpty() ? "Set name (optional)" : pendingSessionName;
     final TextButton gameNameBtn = new TextButton(nameDisplay, MyGdxGame.skin);
-    gameNameBtn.setSize(button.getWidth() * 2, button.getHeight());
-    gameNameBtn.setPosition(cx - gameNameBtn.getWidth() / 2f, 0.38f * MyGdxGame.HEIGHT);
     gameNameBtn.addListener(new ClickListener() {
       @Override
       public void clicked(InputEvent event, float x, float y) {
@@ -561,50 +574,77 @@ public class MenuScreen extends AbstractScreen {
         }, "New game", pendingSessionName, "Enter game name (optional)");
       }
     });
-    menuStage.addActor(gameNameBtn);
 
-    // Checkbox: allow starting hero selection
+    // ── Starting cards selector ──────────────────────────────────────────────
+    Label cardsLabel = new Label("Starting cards:", MyGdxGame.skin);
+    final SelectBox<String> cardsBox = new SelectBox<String>(MyGdxGame.skin);
+    Array<String> cardOptions = new Array<String>();
+    for (int n = 6; n <= 10; n++) cardOptions.add(String.valueOf(n));
+    cardsBox.setItems(cardOptions);
+    cardsBox.setSelected(String.valueOf(pendingMaxCards));
+
+    // ── Checkboxes ───────────────────────────────────────────────────────────
+    final CheckBox manualSetupCheckbox = new CheckBox(" Manual setup", MyGdxGame.skin);
+    manualSetupCheckbox.setChecked(pendingManualSetup);
+
     final CheckBox heroCheckbox = new CheckBox(" Allow starting hero", MyGdxGame.skin);
     heroCheckbox.setChecked(sessionAllowHeroSelection);
-    heroCheckbox.pack();
-    heroCheckbox.setPosition(cx - heroCheckbox.getWidth() / 2f, 0.26f * MyGdxGame.HEIGHT);
-    menuStage.addActor(heroCheckbox);
 
-    // Create button
-    TextButton confirmCreateBtn = new TextButton("Create", MyGdxGame.skin);
-    confirmCreateBtn.setSize(button.getWidth(), button.getHeight());
-    confirmCreateBtn.setPosition(cx - confirmCreateBtn.getWidth() / 2f, 0.14f * MyGdxGame.HEIGHT);
+    // ── Create button ────────────────────────────────────────────────────────
+    final TextButton confirmCreateBtn = new TextButton("Create", MyGdxGame.skin);
     confirmCreateBtn.addListener(new ClickListener() {
       @Override
       public void clicked(InputEvent event, float x, float y) {
         String sessionName = pendingSessionName.isEmpty()
             ? menuState.getMyName() + "'s game" : pendingSessionName;
         sessionAllowHeroSelection = heroCheckbox.isChecked();
+        pendingManualSetup = manualSetupCheckbox.isChecked();
+        try {
+          pendingMaxCards = Integer.parseInt(cardsBox.getSelected());
+        } catch (NumberFormatException ex) { pendingMaxCards = 8; }
         JSONObject data = new JSONObject();
         try {
           data.put("name", menuState.getMyName());
           data.put("sessionName", sessionName);
           data.put("allowHeroSelection", sessionAllowHeroSelection);
+          data.put("maxCards", pendingMaxCards);
+          data.put("manualSetup", pendingManualSetup);
           data.put("token", MyGdxGame.playerStorage.getToken());
         } catch (JSONException e) { /* ignore */ }
         socket.emit("createSession", data);
         pendingSessionName = "";
+        pendingManualSetup = false;
+        pendingMaxCards = 8;
         inSessionCreate = false;
       }
     });
-    menuStage.addActor(confirmCreateBtn);
 
-    // Back button
-    TextButton backBtn = new TextButton("Back", MyGdxGame.skin);
-    backBtn.setPosition(10, MyGdxGame.HEIGHT - backBtn.getHeight() - 10);
-    backBtn.addListener(new ClickListener() {
-      @Override
-      public void clicked(InputEvent event, float x, float y) {
-        inSessionCreate = false;
-        show();
-      }
-    });
-    menuStage.addActor(backBtn);
+    // ── Table layout (no overlap guaranteed) ────────────────────────────────
+    Table form = new Table(MyGdxGame.skin);
+    form.setBackground(MyGdxGame.skin.newDrawable("white", new Color(0f, 0f, 0f, 0.18f)));
+    form.pad(20f, 24f, 20f, 24f);
+    float colW = MyGdxGame.WIDTH * 0.72f;
+
+    form.add(title).colspan(2).center().padBottom(18f);
+    form.row();
+    form.add(gameNameBtn).colspan(2).fillX().padBottom(14f);
+    form.row();
+    form.add(cardsLabel).left().padRight(12f).padBottom(14f);
+    form.add(cardsBox).width(colW * 0.38f).left().padBottom(14f);
+    form.row();
+    form.add(manualSetupCheckbox).colspan(2).left().padBottom(10f);
+    form.row();
+    form.add(heroCheckbox).colspan(2).left().padBottom(18f);
+    form.row();
+    form.add(confirmCreateBtn).colspan(2).center();
+
+    form.pack();
+    // Centre the form vertically in the lower 55% of the screen (below the logo area)
+    float formTop = 0.82f * MyGdxGame.HEIGHT;
+    form.setPosition(
+        Math.round(cx - form.getWidth() / 2f),
+        Math.round(formTop - form.getHeight()));
+    menuStage.addActor(form);
 
     addMusicToggleButton(menuStage);
     addLogoutButton(menuStage);

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -1129,14 +1129,29 @@ public class MenuScreen extends AbstractScreen {
           final int playerIndex = data.getInt("playerIndex");
           final JSONObject gameState = data.getJSONObject("gameState");
           Gdx.app.log("SocketIO", "Received centralized game state, playerIndex: " + playerIndex);
+          Gdx.app.log("DBG_GAMESTATE", "setupPhase=" + gameState.optBoolean("setupPhase", false)
+              + " playerCount=" + gameState.optJSONArray("players").length()
+              + " pickingDecks=" + gameState.optJSONArray("pickingDecks").length());
+          // Log each player's key fields to find nulls
+          com.mygdx.game.util.JSONArray playerArr = gameState.optJSONArray("players");
+          for (int _i = 0; _i < playerArr.length(); _i++) {
+            com.mygdx.game.util.JSONObject _p = playerArr.getJSONObject(_i);
+            Gdx.app.log("DBG_PLAYER_" + _i,
+                "name=" + _p.optString("name", "?") +
+                " kingCard=" + _p.optInt("kingCard", -1) +
+                " hand=" + _p.optJSONArray("hand").length() +
+                " attackingSymbol=" + _p.optString("attackingSymbol", "?") +
+                " heroes=" + _p.optJSONArray("heroes").length());
+          }
           Gdx.app.postRunnable(new Runnable() {
             @Override
             public void run() {
+              Gdx.app.log("DBG_GAMESTATE", "Creating GameScreen...");
               game.setScreen(new GameScreen(game, gameState, playerIndex, socket, menuState.getStartingHero()));
             }
           });
         } catch (JSONException e) {
-          Gdx.app.log("SocketIO", "Error parsing centralized game state!");
+          Gdx.app.log("SocketIO", "Error parsing centralized game state: " + e.getMessage());
         }
       }
     });

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -40,7 +40,6 @@ public class MenuScreen extends AbstractScreen {
   private Stage menuStage;
   private MenuState menuState;
 
-  private Label loggedInCount;
   private TextButton button;
   private SelectBox<String> heroSelectBox;
 
@@ -69,7 +68,7 @@ public class MenuScreen extends AbstractScreen {
   private boolean sessionAllowHeroSelection = false;
   // Pending create-screen settings
   private boolean pendingManualSetup = false;
-  private int pendingMaxCards = 8;
+  private int pendingStartingCards = 8;
 
   // The session list received from the server
   private java.util.List<SessionInfo> sessionList = new java.util.ArrayList<SessionInfo>();
@@ -581,7 +580,7 @@ public class MenuScreen extends AbstractScreen {
     Array<String> cardOptions = new Array<String>();
     for (int n = 6; n <= 10; n++) cardOptions.add(String.valueOf(n));
     cardsBox.setItems(cardOptions);
-    cardsBox.setSelected(String.valueOf(pendingMaxCards));
+    cardsBox.setSelected(String.valueOf(pendingStartingCards));
 
     // ── Checkboxes ───────────────────────────────────────────────────────────
     final CheckBox manualSetupCheckbox = new CheckBox(" Manual setup", MyGdxGame.skin);
@@ -600,21 +599,21 @@ public class MenuScreen extends AbstractScreen {
         sessionAllowHeroSelection = heroCheckbox.isChecked();
         pendingManualSetup = manualSetupCheckbox.isChecked();
         try {
-          pendingMaxCards = Integer.parseInt(cardsBox.getSelected());
-        } catch (NumberFormatException ex) { pendingMaxCards = 8; }
+          pendingStartingCards = Integer.parseInt(cardsBox.getSelected());
+        } catch (NumberFormatException ex) { pendingStartingCards = 8; }
         JSONObject data = new JSONObject();
         try {
           data.put("name", menuState.getMyName());
           data.put("sessionName", sessionName);
           data.put("allowHeroSelection", sessionAllowHeroSelection);
-          data.put("maxCards", pendingMaxCards);
+          data.put("startingCards", pendingStartingCards);
           data.put("manualSetup", pendingManualSetup);
           data.put("token", MyGdxGame.playerStorage.getToken());
         } catch (JSONException e) { /* ignore */ }
         socket.emit("createSession", data);
         pendingSessionName = "";
         pendingManualSetup = false;
-        pendingMaxCards = 8;
+        pendingStartingCards = 8;
         inSessionCreate = false;
       }
     });
@@ -779,10 +778,6 @@ public class MenuScreen extends AbstractScreen {
     lobbyTitle.setColor(1f, 1f, 1f, 0.98f);
     lobbyTitle.setPosition(Math.round(cx - lobbyTitle.getPrefWidth() / 2f), Math.round(0.835f * MyGdxGame.HEIGHT));
 
-    // logged in count
-    loggedInCount = new Label("Players in lobby: " + currentUsersCount, MyGdxGame.skin);
-    loggedInCount.setPosition(0.05f * MyGdxGame.WIDTH, 0.055f * MyGdxGame.HEIGHT);
-
     // table with all logged in users
     Table loggedInUserTable = new Table(MyGdxGame.skin);
     loggedInUserTable.setBackground(MyGdxGame.skin.newDrawable("white", new Color(0f, 0f, 0f, 0.14f)));
@@ -864,12 +859,18 @@ public class MenuScreen extends AbstractScreen {
         }
       });
       menuStage.addActor(watchButton);
-    } else {
-      // No game running — host can start once enough players are ready.
-      int readyCount = 0;
-      for (int i = 0; i < loggedInUsers.size(); i++) {
-        if (loggedInUsers.get(i).isReady()) readyCount++;
-      }
+    }
+
+    // Ready player count — always visible
+    int readyCount = 0;
+    for (int i = 0; i < loggedInUsers.size(); i++) {
+      if (loggedInUsers.get(i).isReady()) readyCount++;
+    }
+    Label lobbyStatus = new Label("Ready players: " + readyCount + " / " + loggedInUsers.size(), MyGdxGame.skin);
+    lobbyStatus.setPosition(0.05f * MyGdxGame.WIDTH, 0.055f * MyGdxGame.HEIGHT);
+    menuStage.addActor(lobbyStatus);
+
+    if (!gameRunning) {
       boolean amReady = false;
       for (int i = 0; i < loggedInUsers.size(); i++) {
         if (loggedInUsers.get(i).getUserID().equals(menuState.getMyUserID())) {
@@ -880,11 +881,6 @@ public class MenuScreen extends AbstractScreen {
       boolean isHost = !loggedInUsers.isEmpty()
           && loggedInUsers.get(0).getUserID().equals(menuState.getMyUserID());
       boolean canHostStart = isHost && amReady && readyCount >= 2 && !timerStarted;
-
-      Label lobbyStatus = new Label("Ready players: " + readyCount + " / " + loggedInUsers.size(), MyGdxGame.skin);
-      lobbyStatus.setPosition(MyGdxGame.WIDTH - lobbyStatus.getWidth() - 0.05f * MyGdxGame.WIDTH,
-          0.055f * MyGdxGame.HEIGHT);
-      menuStage.addActor(lobbyStatus);
 
       if (isHost) {
         TextButton startGameButton = new TextButton("Start game", MyGdxGame.skin);
@@ -941,7 +937,6 @@ public class MenuScreen extends AbstractScreen {
     menuStage.addActor(actionBar);
     menuStage.addActor(lobbyTitle);
     menuStage.addActor(loggedInUserTable);
-    menuStage.addActor(loggedInCount);
 
     // Leave session — returns to session list
     TextButton leaveBtn = new TextButton("Leave", MyGdxGame.skin);

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -867,7 +867,7 @@ public class MenuScreen extends AbstractScreen {
       if (loggedInUsers.get(i).isReady()) readyCount++;
     }
     Label lobbyStatus = new Label("Ready players: " + readyCount + " / " + loggedInUsers.size(), MyGdxGame.skin);
-    lobbyStatus.setPosition(0.05f * MyGdxGame.WIDTH, 0.055f * MyGdxGame.HEIGHT);
+    lobbyStatus.setPosition(0.05f * MyGdxGame.WIDTH, 0.01f * MyGdxGame.HEIGHT);
     menuStage.addActor(lobbyStatus);
 
     if (!gameRunning) {

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -781,7 +781,7 @@ public class MenuScreen extends AbstractScreen {
 
     // logged in count
     loggedInCount = new Label("Players in lobby: " + currentUsersCount, MyGdxGame.skin);
-    loggedInCount.setPosition(0.05f * MyGdxGame.WIDTH, 0.01f * MyGdxGame.HEIGHT);
+    loggedInCount.setPosition(0.05f * MyGdxGame.WIDTH, 0.055f * MyGdxGame.HEIGHT);
 
     // table with all logged in users
     Table loggedInUserTable = new Table(MyGdxGame.skin);
@@ -882,8 +882,8 @@ public class MenuScreen extends AbstractScreen {
       boolean canHostStart = isHost && amReady && readyCount >= 2 && !timerStarted;
 
       Label lobbyStatus = new Label("Ready players: " + readyCount + " / " + loggedInUsers.size(), MyGdxGame.skin);
-        lobbyStatus.setPosition(MyGdxGame.WIDTH - lobbyStatus.getWidth() - 0.05f * MyGdxGame.WIDTH,
-          0.01f * MyGdxGame.HEIGHT);
+      lobbyStatus.setPosition(MyGdxGame.WIDTH - lobbyStatus.getWidth() - 0.05f * MyGdxGame.WIDTH,
+          0.055f * MyGdxGame.HEIGHT);
       menuStage.addActor(lobbyStatus);
 
       if (isHost) {

--- a/core/src/com/mygdx/game/Player.java
+++ b/core/src/com/mygdx/game/Player.java
@@ -387,38 +387,25 @@ public class Player {
   }
 
   public void sortHandCards() {
-    // Unusable cards (prey + battery-denied) go to the end.
-    ArrayList<Integer> unusableIds = new ArrayList<Integer>();
-    unusableIds.addAll(playerTurn.getPreyCardIds());
-    unusableIds.addAll(playerTurn.getBatteryDeniedAttackCardIds());
-
     ArrayList<Card> hearts = new ArrayList<Card>();
     ArrayList<Card> diamonds = new ArrayList<Card>();
     ArrayList<Card> spades = new ArrayList<Card>();
     ArrayList<Card> clubs = new ArrayList<Card>();
     ArrayList<Card> jokers = new ArrayList<Card>();
-    ArrayList<Card> unusable = new ArrayList<Card>();
 
-    // sort by symbol; unusable cards go into their own bucket
+    // sort by symbol
     for (int i = 0; i < handCards.size(); i++) {
-      Card c = handCards.get(i);
-      if (unusableIds.contains(c.getCardId())) {
-        unusable.add(c);
-        continue;
-      }
-      String symbol = c.getSymbol();
+      String symbol = handCards.get(i).getSymbol();
       if (symbol == "hearts")
-        hearts.add(c);
+        hearts.add(handCards.get(i));
       else if (symbol == "diamonds")
-        diamonds.add(c);
+        diamonds.add(handCards.get(i));
       else if (symbol == "spades")
-        spades.add(c);
+        spades.add(handCards.get(i));
       else if (symbol == "clubs")
-        clubs.add(c);
+        clubs.add(handCards.get(i));
       else if (symbol == "joker")
-        jokers.add(c);
-      else
-        unusable.add(c); // unknown symbol treated as unusable
+        jokers.add(handCards.get(i));
     }
 
     // sort each symbol by strength
@@ -451,7 +438,7 @@ public class Player {
       }
     }
 
-    // refill handCards sorted; unusable cards at the end
+    // refill handCards sorted
     handCards = new ArrayList<Card>();
     for (int i = 0; i < hearts.size(); i++)
       handCards.add(hearts.get(i));
@@ -463,8 +450,6 @@ public class Player {
       handCards.add(clubs.get(i));
     for (int i = 0; i < jokers.size(); i++)
       handCards.add(jokers.get(i));
-    for (int i = 0; i < unusable.size(); i++)
-      handCards.add(unusable.get(i));
 
   }
 
@@ -489,6 +474,10 @@ public class Player {
   }
 
   public void setKingCard(Card kingCard) {
+    if (kingCard == null) {
+      this.kingCard = null;
+      return;
+    }
 
     kingCard.setSelected(false);
 

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -1,7 +1,9 @@
 // Server-authoritative game state
 
 class GameState {
-  constructor(users) {
+  constructor(users, opts) {
+    const maxCards = (opts && opts.maxCards) ? Math.min(10, Math.max(6, parseInt(opts.maxCards, 10))) : 8;
+    const manualSetup = !!(opts && opts.manualSetup);
     this.deck = this.generateCards();
     this.cemetery = [];
     this.players = users.map((user, idx) => ({
@@ -21,9 +23,90 @@ class GameState {
     this.lastMerchantReveal = null; // set during 2nd-try, cleared on finishTurn
     this.pendingAttack = null; // current attack preview broadcast, cleared on defAttackResolved
     this.pendingPlunder = null; // current plunder preview broadcast, cleared on plunderResolved
-    this.dealCards(8);
-    this.doSetup();
-    this.initPickingDecks();
+    this.setupPhase = manualSetup;
+    this.setupSubmitted = {}; // { playerIdx: true } — tracks who confirmed during manual setup
+    this.dealCards(maxCards);
+    if (manualSetup) {
+      this.initPlayerStats(); // init combat counters without placing king/def/cemetery
+    } else {
+      this.doSetup();
+      this.initPickingDecks();
+    }
+  }
+
+  /** Initialise per-player combat counters (shared by auto and manual setup). */
+  initPlayerStats() {
+    for (const p of this.players) {
+      p.kingCovered = true;
+      p.isOut = false;
+      p.defCardsCovered = { 1: true, 2: true, 3: true };
+      p.topDefCardsCovered = {};
+      p.sabotaged = {};
+      p.attackCount = 0;
+      p.priestConversionAttempts = 2;
+      p.magicianSpells = 1;
+      p.merchantTrades = 1;
+      p.warlordAttacks = 1;
+      p.spyAttacks = 1;
+      p.spyMaxAttacks = 1;
+      p.spyExtends = 1;
+      p.pickingDeckAttacks = 1;
+      p.attackingSymbol = 'none';
+      p.attackingSymbol2 = 'none';
+    }
+  }
+
+  /**
+   * Apply a manual setup submission for one player.
+   * kingCardId and defCardIds (array of 3) must all be in the player's current hand.
+   * Returns true on success, false if validation fails.
+   */
+  applyManualSetup(playerIdx, kingCardId, defCardIds, discardCardIds) {
+    const p = this.players[playerIdx];
+    if (!p) return false;
+    if (this.setupSubmitted[playerIdx]) return false; // already submitted
+
+    const ids = [kingCardId, ...defCardIds];
+    if (ids.length !== 4) return false;
+
+    // All cards must be in hand and no duplicates
+    const seen = new Set();
+    for (const id of ids) {
+      if (p.hand.indexOf(id) === -1) return false;
+      if (seen.has(id)) return false;
+      seen.add(id);
+    }
+
+    // Remove from hand and place
+    for (const id of ids) {
+      const i = p.hand.indexOf(id);
+      p.hand.splice(i, 1);
+    }
+    p.kingCard = kingCardId;
+    p.defCards = { 1: defCardIds[0], 2: defCardIds[1], 3: defCardIds[2] };
+
+    // Remove discarded cards from hand (must not be king or def; anything else is fair game)
+    if (Array.isArray(discardCardIds)) {
+      const keepSet = new Set([kingCardId, ...defCardIds]);
+      for (const id of discardCardIds) {
+        if (keepSet.has(id)) continue; // ignore invalid discard of selected cards
+        const i = p.hand.indexOf(id);
+        if (i !== -1) p.hand.splice(i, 1);
+      }
+    }
+
+    this.setupSubmitted[playerIdx] = true;
+
+    // If all players have submitted, finalise setup and start the game
+    let allDone = true;
+    for (let i = 0; i < this.players.length; i++) {
+      if (!this.setupSubmitted[i]) { allDone = false; break; }
+    }
+    if (allDone) {
+      this.setupPhase = false;
+      this.initPickingDecks();
+    }
+    return true;
   }
 
   generateCards() {
@@ -48,26 +131,11 @@ class GameState {
 
   // Mirrors Java doRandomSetup: king + 3 defCards + 2 cemetery per player
   doSetup() {
+    this.initPlayerStats();
     for (const p of this.players) {
       p.kingCard = p.hand.pop();
-      p.kingCovered = true;
-      p.isOut = false;
       for (let j = 1; j <= 3; j++) p.defCards[j] = p.hand.pop();
       for (let j = 0; j < 2; j++) this.cemetery.push(p.hand.pop());
-      p.defCardsCovered = { 1: true, 2: true, 3: true };
-      p.topDefCardsCovered = {};
-      p.sabotaged = {}; // { slotId: attackerPlayerIdx } — tracks which slots have a saboteur
-      p.attackCount = 0; // number of enemy attacks this turn (reset on finishTurn)
-      p.priestConversionAttempts = 2; // Priest hero: attempts remaining this turn
-      p.magicianSpells = 1; // Magician hero: spells remaining this turn
-      p.merchantTrades = 1; // Merchant hero: trades remaining this turn
-      p.warlordAttacks = 1; // Warlord hero: king swap/attack uses remaining this turn
-      p.spyAttacks = 1; // Spy hero: flips remaining this turn
-      p.spyMaxAttacks = 1; // Spy hero: max flips displayed this turn
-      p.spyExtends = 1; // Spy hero: extends remaining this turn
-      p.pickingDeckAttacks = 1; // plunder attempts remaining this turn
-      p.attackingSymbol = 'none'; // first attack symbol this turn (locked after first attack)
-      p.attackingSymbol2 = 'none'; // Banneret extended symbol
     }
   }
 
@@ -699,6 +767,8 @@ class GameState {
   serialize() {
     return {
       currentPlayerIndex: this.currentPlayerIndex,
+      setupPhase: this.setupPhase || false,
+      setupSubmitted: Object.assign({}, this.setupSubmitted || {}),
       deck: [...this.deck],
       cemetery: [...this.cemetery],
       players: this.players.map(p => ({

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -2,7 +2,7 @@
 
 class GameState {
   constructor(users, opts) {
-    const maxCards = (opts && opts.maxCards) ? Math.min(10, Math.max(6, parseInt(opts.maxCards, 10))) : 8;
+    const startingCards = (opts && opts.startingCards) ? Math.min(10, Math.max(6, parseInt(opts.startingCards, 10))) : 8;
     const manualSetup = !!(opts && opts.manualSetup);
     this.deck = this.generateCards();
     this.cemetery = [];
@@ -25,7 +25,7 @@ class GameState {
     this.pendingPlunder = null; // current plunder preview broadcast, cleared on plunderResolved
     this.setupPhase = manualSetup;
     this.setupSubmitted = {}; // { playerIdx: true } — tracks who confirmed during manual setup
-    this.dealCards(maxCards);
+    this.dealCards(startingCards);
     if (manualSetup) {
       this.initPlayerStats(); // init combat counters without placing king/def/cemetery
     } else {

--- a/server/index.js
+++ b/server/index.js
@@ -65,12 +65,14 @@ function broadcastPlayerList() {
   io.emit('playerList', list);
 }
 
-function createSession(name, allowHeroSelection) {
+function createSession(name, allowHeroSelection, maxCards, manualSetup) {
   var id = 's' + (_nextSessionId++);
   sessions[id] = {
     id: id,
     name: name,
     allowHeroSelection: allowHeroSelection !== false, // default true
+    maxCards: Math.min(10, Math.max(6, parseInt(maxCards, 10) || 8)),
+    manualSetup: !!manualSetup,
     users: [],
     spectators: [],
     gameState: null,
@@ -181,7 +183,7 @@ function startGameForSession(sess, requesterSocketId) {
 
   sess.users = readyUsers;
   sess.winnerHandled = false;
-  sess.gameState = new GameState(sess.users);
+  sess.gameState = new GameState(sess.users, { maxCards: sess.maxCards, manualSetup: sess.manualSetup });
 
   // Apply lobby starting hero selections before initial gameState broadcast.
   sess.users.forEach(function(u, idx) {
@@ -362,7 +364,9 @@ io.on('connection', function(socket) {
     if (connectedPlayers[socket.id]) connectedPlayers[socket.id].name = name;
     var sessionName = (data && data.sessionName) ? String(data.sessionName).slice(0, 50) : name + "'s game";
     var allowHeroSelection = (data && data.allowHeroSelection !== false);
-    var sess = createSession(sessionName, allowHeroSelection);
+    var maxCards = (data && data.maxCards) ? parseInt(data.maxCards, 10) : 8;
+    var manualSetup = !!(data && data.manualSetup);
+    var sess = createSession(sessionName, allowHeroSelection, maxCards, manualSetup);
     var cToken = (data && data.token) ? String(data.token).slice(0, 64) : null;
     sess.users.push(makeUser(socket.id, name, cToken));
     if (cToken) {
@@ -373,8 +377,8 @@ io.on('connection', function(socket) {
     }
     socketToSession[socket.id] = sess.id;
     socket.join(sess.id);
-    console.log("Session created: " + sess.id + " '" + sess.name + "' by " + name + " (heroes: " + allowHeroSelection + ")");
-    socket.emit('sessionJoined', { sessionId: sess.id, allowHeroSelection: sess.allowHeroSelection });
+    console.log("Session created: " + sess.id + " '" + sess.name + "' by " + name + " (heroes: " + allowHeroSelection + ", maxCards: " + sess.maxCards + ", manualSetup: " + manualSetup + ")");
+    socket.emit('sessionJoined', { sessionId: sess.id, allowHeroSelection: sess.allowHeroSelection, maxCards: sess.maxCards, manualSetup: sess.manualSetup });
     io.to(sess.id).emit('getUsers', sess.users);
     socket.emit('gameStatus', { running: false });
     broadcastSessionList();
@@ -409,7 +413,7 @@ io.on('connection', function(socket) {
         socket.emit('heroReserved', { heroName: h });
       }
     });
-    socket.emit('sessionJoined', { sessionId: sess.id, allowHeroSelection: sess.allowHeroSelection });
+    socket.emit('sessionJoined', { sessionId: sess.id, allowHeroSelection: sess.allowHeroSelection, maxCards: sess.maxCards, manualSetup: sess.manualSetup });
     io.to(sess.id).emit('getUsers', sess.users);
     socket.emit('gameStatus', { running: false });
     broadcastSessionList();
@@ -486,6 +490,35 @@ io.on('connection', function(socket) {
     var sess = getSession(socket.id);
     if (sess && sess.gameState) {
       socket.emit('stateUpdate', sess.gameState.serialize());
+    }
+  });
+
+  // Manual setup phase: player submits their king and defense card choices
+  socket.on('submitSetup', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState || !sess.gameState.setupPhase) return;
+    var playerIdx = sess.users.findIndex(function(u) { return u.id === socket.id; });
+    if (playerIdx === -1) return;
+    var kingCardId = data && data.kingCardId;
+    var defCardIds = data && Array.isArray(data.defCardIds) ? data.defCardIds : [];
+    if (defCardIds.length !== 3) return;
+    var discardCardIds = data && Array.isArray(data.discardCardIds) ? data.discardCardIds : [];
+    var ok = sess.gameState.applyManualSetup(playerIdx, kingCardId, defCardIds, discardCardIds);
+    if (!ok) {
+      console.log('submitSetup rejected for player ' + playerIdx + ' in session ' + sess.id);
+      return;
+    }
+    console.log('submitSetup accepted for player ' + playerIdx + ' in session ' + sess.id + (sess.gameState.setupPhase ? ' (waiting for others)' : ' (setup complete)'));
+    // Broadcast updated state to all players
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+    // Persist player indices once setup is complete
+    if (!sess.gameState.setupPhase) {
+      sess.users.forEach(function(u, idx) {
+        if (u.token && tokenMap[u.token]) {
+          tokenMap[u.token].playerIdx = idx;
+          tokenMap[u.token].sessionId = sess.id;
+        }
+      });
     }
   });
 

--- a/server/index.js
+++ b/server/index.js
@@ -65,13 +65,13 @@ function broadcastPlayerList() {
   io.emit('playerList', list);
 }
 
-function createSession(name, allowHeroSelection, maxCards, manualSetup) {
+function createSession(name, allowHeroSelection, startingCards, manualSetup) {
   var id = 's' + (_nextSessionId++);
   sessions[id] = {
     id: id,
     name: name,
     allowHeroSelection: allowHeroSelection !== false, // default true
-    maxCards: Math.min(10, Math.max(6, parseInt(maxCards, 10) || 8)),
+    startingCards: Math.min(10, Math.max(6, parseInt(startingCards, 10) || 8)),
     manualSetup: !!manualSetup,
     users: [],
     spectators: [],
@@ -183,7 +183,7 @@ function startGameForSession(sess, requesterSocketId) {
 
   sess.users = readyUsers;
   sess.winnerHandled = false;
-  sess.gameState = new GameState(sess.users, { maxCards: sess.maxCards, manualSetup: sess.manualSetup });
+  sess.gameState = new GameState(sess.users, { startingCards: sess.startingCards, manualSetup: sess.manualSetup });
 
   // Apply lobby starting hero selections before initial gameState broadcast.
   sess.users.forEach(function(u, idx) {
@@ -364,9 +364,9 @@ io.on('connection', function(socket) {
     if (connectedPlayers[socket.id]) connectedPlayers[socket.id].name = name;
     var sessionName = (data && data.sessionName) ? String(data.sessionName).slice(0, 50) : name + "'s game";
     var allowHeroSelection = (data && data.allowHeroSelection !== false);
-    var maxCards = (data && data.maxCards) ? parseInt(data.maxCards, 10) : 8;
+    var startingCards = (data && data.startingCards) ? parseInt(data.startingCards, 10) : 8;
     var manualSetup = !!(data && data.manualSetup);
-    var sess = createSession(sessionName, allowHeroSelection, maxCards, manualSetup);
+    var sess = createSession(sessionName, allowHeroSelection, startingCards, manualSetup);
     var cToken = (data && data.token) ? String(data.token).slice(0, 64) : null;
     sess.users.push(makeUser(socket.id, name, cToken));
     if (cToken) {
@@ -377,8 +377,8 @@ io.on('connection', function(socket) {
     }
     socketToSession[socket.id] = sess.id;
     socket.join(sess.id);
-    console.log("Session created: " + sess.id + " '" + sess.name + "' by " + name + " (heroes: " + allowHeroSelection + ", maxCards: " + sess.maxCards + ", manualSetup: " + manualSetup + ")");
-    socket.emit('sessionJoined', { sessionId: sess.id, allowHeroSelection: sess.allowHeroSelection, maxCards: sess.maxCards, manualSetup: sess.manualSetup });
+    console.log("Session created: " + sess.id + " '" + sess.name + "' by " + name + " (heroes: " + allowHeroSelection + ", startingCards: " + sess.startingCards + ", manualSetup: " + manualSetup + ")");
+    socket.emit('sessionJoined', { sessionId: sess.id, allowHeroSelection: sess.allowHeroSelection, startingCards: sess.startingCards, manualSetup: sess.manualSetup });
     io.to(sess.id).emit('getUsers', sess.users);
     socket.emit('gameStatus', { running: false });
     broadcastSessionList();
@@ -413,7 +413,7 @@ io.on('connection', function(socket) {
         socket.emit('heroReserved', { heroName: h });
       }
     });
-    socket.emit('sessionJoined', { sessionId: sess.id, allowHeroSelection: sess.allowHeroSelection, maxCards: sess.maxCards, manualSetup: sess.manualSetup });
+    socket.emit('sessionJoined', { sessionId: sess.id, allowHeroSelection: sess.allowHeroSelection, startingCards: sess.startingCards, manualSetup: sess.manualSetup });
     io.to(sess.id).emit('getUsers', sess.users);
     socket.emit('gameStatus', { running: false });
     broadcastSessionList();


### PR DESCRIPTION
Closes #108

## Changes

### Create game screen (MenuScreen)
- Replaced manually-positioned widgets with a `Table` layout — no element overlap
- Added **Starting cards** selector (6–10, default 8)
- Added **Manual setup** checkbox

### Setup phase UI (GameScreen)
- Phase 1: tap a card to designate it as king (gold highlight)
- Phase 2: tap 3 more cards as defense cards (green highlight)
- Phase 3 (discard): if `maxCards > 6`, remaining cards show KEEP/DISCARD labels; player taps to toggle; Confirm appears only when exactly the right number are marked for discard
- If `maxCards = 6` (king + 3 def + 2 keep = 6), discard phase is skipped
- `discardCardIds` is sent in the `submitSetup` socket event
- All players run setup in parallel; game starts when everyone confirms

### Server (gameState.js / index.js)
- `applyManualSetup` now accepts `discardCardIds` and removes those cards from the player's hand after placing king + def
- `submitSetup` handler passes `discardCardIds` through to `applyManualSetup`