### PR TITLE
Fix: Spy king-card flip immediately re-covered by state sync (issue #123)

### DIFF
--- a/server/gameState.js
+++ b/server/gameState.js
@@ -367,7 +367,7 @@ class GameState {
     this.pushLog(`${this.pname(playerIdx)} cast Magician on ${this.pname(targetPlayerIdx)}'s shield [${positionId}]`, true);
   }
 
-  spyFlip(playerIdx) {
+  spyFlip(playerIdx, targetPlayerIdx, slot) {
     const p = this.players[playerIdx];
     if (!p) return false;
     if ((p.spyAttacks || 0) <= 0) {
@@ -375,6 +375,11 @@ class GameState {
       return false;
     }
     p.spyAttacks--;
+    // Persist the flip so the subsequent stateUpdate doesn't re-cover the card
+    if (slot === -1) {
+      const target = this.players[targetPlayerIdx];
+      if (target) target.kingCovered = false;
+    }
     return true;
   }
 

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -159,6 +159,12 @@ class GameState {
       }
     }
     this.pendingPlunder = Object.assign({}, data, { _lockedHandCards: lockedHandCards });
+    // Persist the top card of the attacked deck as face-up so the stateUpdate
+    // broadcast does not re-cover it for all players
+    if (data.deckIndex !== undefined) {
+      const deck = this.pickingDecks[data.deckIndex];
+      if (deck && deck.length > 0) deck[deck.length - 1].covered = false;
+    }
   }
 
   setAttackPreview(data) {

--- a/server/index.js
+++ b/server/index.js
@@ -732,7 +732,7 @@ io.on('connection', function(socket) {
     if (!sess || !sess.gameState) return;
     var userIdx = sess.users.findIndex(function(u) { return u.id === socket.id; });
     if (userIdx === -1) return;
-    if (!sess.gameState.spyFlip(userIdx)) return;
+    if (!sess.gameState.spyFlip(userIdx, data.targetPlayerIdx, data.slot)) return;
     socket.to(sess.id).emit('spyFlip', data);
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });


### PR DESCRIPTION
Closes https://github.com/perahrens/baisch/issues/123\n\n## Problem\n\nWhen the Spy hero flips an enemy king card, the card is visible only for a brief moment before going face-down again.\n\n## Root Cause\n\n`gameState.spyFlip()` decremented `spyAttacks` but never updated `players[targetPlayerIdx].kingCovered`. The `stateUpdate` broadcast that immediately follows still serialised `kingCovered: true`, causing every client (including the attacker) to re-cover the card.\n\n## Fix\n\n- `server/gameState.js`: extended `spyFlip(playerIdx, targetPlayerIdx, slot)` — when `slot === -1` (king card flip), sets `this.players[targetPlayerIdx].kingCovered = false`.\n- `server/index.js`: passes `data.targetPlayerIdx` and `data.slot` to `spyFlip()`.