### PR TITLE
feat: add interactive step-by-step tutorial for new players

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -137,6 +137,9 @@ public class GameScreen extends ScreenAdapter {
   private JSONArray pendingBatteryResultCards = null;
   // Set when the current player ended their turn without attacking -- they must expose a defense card.
   private boolean pendingExposeCard = false;
+  // Tutorial mode: guided overlay steps for new players
+  private boolean isTutorial = false;
+  private int tutorialStep = 0;
   private JSONArray activityLog = new JSONArray();
   // Emit Reservists count to other clients once on first render (before any stateUpdate fires)
   private boolean initialReservistsBroadcastDone = false;
@@ -186,6 +189,7 @@ public class GameScreen extends ScreenAdapter {
     gameState.setSocket(socket);
     players = gameState.getPlayers();
     currentPlayer = players.get(this.playerIndex);
+    this.isTutorial = centralizedState.optBoolean("isTutorial", false);
 
     // Single stateUpdate listener — replaces all specific sync events
     final int notifyPlayerIdx = this.playerIndex; // capture field before parameter shadows it
@@ -646,6 +650,9 @@ public class GameScreen extends ScreenAdapter {
       buildMenuOverlay();
     } else {
       addMenuButtonToOverlay();
+      if (isTutorial && tutorialStep >= 0) {
+        buildTutorialOverlay();
+      }
     }
   }
 
@@ -3393,6 +3400,126 @@ public class GameScreen extends ScreenAdapter {
     overlayStage.clear();
     addMenuButtonToOverlay();
     // render() will set the correct input processor next frame
+  }
+
+  // ── Tutorial overlay ────────────────────────────────────────────────────────
+  private static final String[] TUTORIAL_TITLES = {
+    "Welcome to Baisch!",
+    "Your Hand Cards",
+    "Plundering",
+    "Defense Cards",
+    "Attacking",
+    "Goal of the Game",
+    "Tutorial Complete!"
+  };
+  private static final String[] TUTORIAL_TEXTS = {
+    "This tutorial will teach you the core mechanics.\n\n"
+      + "You are playing against a bot opponent.\n"
+      + "The board shows your cards at the bottom, harvest decks in the center, "
+      + "and your king card with shield slots on the left.",
+    "The cards at the bottom of the screen are your hand cards.\n\n"
+      + "Tap a card to select it (it will highlight).\n"
+      + "You use hand cards to plunder harvest decks, attack enemies, "
+      + "or place them as defense shields.",
+    "To plunder, select one or more hand cards, then tap a harvest deck "
+      + "(the tilted card stacks in the center).\n\n"
+      + "Your attack strength must exceed the top card's defense. "
+      + "If you succeed, you take all cards from that deck!",
+    "To protect your king, place defense cards in your 3 shield slots.\n\n"
+      + "Tap a hand card to select it, then tap an empty shield slot "
+      + "(the dotted outlines near your king).\n"
+      + "Each slot holds up to 2 stacked cards.",
+    "To attack another player, select hand cards and tap one of their defense slots.\n\n"
+      + "If your attack strength exceeds the defense card, you destroy it. "
+      + "Once all 3 shields are gone, their king is exposed!",
+    "The goal is to be the last player with a covered king card.\n\n"
+      + "If your king gets exposed and attacked, you are eliminated. "
+      + "Use your turns wisely: plunder for cards, build defenses, and attack enemies!",
+    "You now know the basics!\n\n"
+      + "Feel free to keep playing this tutorial game, "
+      + "or press the button below to return to the main menu."
+  };
+
+  private void buildTutorialOverlay() {
+    if (tutorialStep < 0 || tutorialStep >= TUTORIAL_TITLES.length) return;
+
+    // Semi-transparent backdrop
+    Image bg = new Image(MyGdxGame.skin, "white");
+    bg.setFillParent(true);
+    bg.setColor(0f, 0f, 0f, 0.75f);
+    overlayStage.addActor(bg);
+
+    Table outer = new Table();
+    outer.setFillParent(true);
+    outer.center();
+
+    // Step counter
+    Label stepLabel = new Label("Step " + (tutorialStep + 1) + " / " + TUTORIAL_TITLES.length,
+        MyGdxGame.skin);
+    stepLabel.setColor(1f, 1f, 1f, 0.5f);
+    outer.add(stepLabel).padBottom(6).row();
+
+    // Title
+    Label titleLabel = new Label(TUTORIAL_TITLES[tutorialStep], MyGdxGame.skin);
+    titleLabel.setColor(Color.GOLD);
+    outer.add(titleLabel).padBottom(14).row();
+
+    // Body text
+    Label bodyLabel = new Label(TUTORIAL_TEXTS[tutorialStep], MyGdxGame.skin);
+    bodyLabel.setWrap(true);
+    outer.add(bodyLabel).width(380f).padBottom(20).row();
+
+    // Buttons
+    final boolean isLastStep = (tutorialStep == TUTORIAL_TITLES.length - 1);
+    if (isLastStep) {
+      TextButton exitBtn = new TextButton("Back to Menu", MyGdxGame.skin);
+      exitBtn.addListener(new ClickListener() {
+        @Override
+        public void clicked(InputEvent event, float x, float y) {
+          tutorialStep = -1;
+          emitGiveUp();
+        }
+      });
+      outer.add(exitBtn).width(300).height(50).padBottom(10).row();
+
+      TextButton keepBtn = new TextButton("Keep Playing", MyGdxGame.skin);
+      keepBtn.addListener(new ClickListener() {
+        @Override
+        public void clicked(InputEvent event, float x, float y) {
+          tutorialStep = -1;
+          overlayStage.clear();
+          addMenuButtonToOverlay();
+          gameState.setUpdateState(true);
+        }
+      });
+      outer.add(keepBtn).width(300).height(50).row();
+    } else {
+      TextButton nextBtn = new TextButton("Next", MyGdxGame.skin);
+      nextBtn.addListener(new ClickListener() {
+        @Override
+        public void clicked(InputEvent event, float x, float y) {
+          tutorialStep++;
+          overlayStage.clear();
+          addMenuButtonToOverlay();
+          buildTutorialOverlay();
+        }
+      });
+      outer.add(nextBtn).width(300).height(50).padBottom(10).row();
+
+      TextButton skipBtn = new TextButton("Skip Tutorial", MyGdxGame.skin);
+      skipBtn.addListener(new ClickListener() {
+        @Override
+        public void clicked(InputEvent event, float x, float y) {
+          tutorialStep = -1;
+          overlayStage.clear();
+          addMenuButtonToOverlay();
+          gameState.setUpdateState(true);
+        }
+      });
+      outer.add(skipBtn).width(300).height(50).row();
+    }
+
+    overlayStage.addActor(outer);
   }
 
   private void emitGiveUp() {

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -457,9 +457,20 @@ public class MenuScreen extends AbstractScreen {
       sessTable.setPosition(Math.round(cx - sessTable.getWidth() / 2f), Math.round(0.45f * MyGdxGame.HEIGHT));
       menuStage.addActor(sessTable);
 
+      TextButton tutorialBtn = new TextButton("Tutorial", MyGdxGame.skin);
+      tutorialBtn.setSize(button.getWidth(), button.getHeight());
+      tutorialBtn.setPosition(cx - tutorialBtn.getWidth() / 2f, 0.08f * MyGdxGame.HEIGHT);
+      tutorialBtn.addListener(new ClickListener() {
+        @Override
+        public void clicked(InputEvent event, float x, float y) {
+          socket.emit("createTutorial", new JSONObject());
+        }
+      });
+      menuStage.addActor(tutorialBtn);
+
       TextButton createBtn = new TextButton("Create game", MyGdxGame.skin);
-      createBtn.setSize(button.getWidth() * 1.5f, button.getHeight());
-      createBtn.setPosition(cx - createBtn.getWidth() / 2f, 0.08f * MyGdxGame.HEIGHT);
+      createBtn.setSize(button.getWidth(), button.getHeight());
+      createBtn.setPosition(MyGdxGame.WIDTH - createBtn.getWidth() - 20f, 0.08f * MyGdxGame.HEIGHT);
       createBtn.addListener(new ClickListener() {
         @Override
         public void clicked(InputEvent event, float x, float y) {

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -815,6 +815,7 @@ class GameState {
       pendingAttack: this.pendingAttack || null,
       pendingPlunder: this.pendingPlunder || null,
       pendingHeroSelection: this.pendingHeroSelection || null,
+      isTutorial: this.isTutorial || false,
     };
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -269,6 +269,20 @@ server.listen(PORT, function() {
   console.log("Server is now running on port " + PORT);
 });
 
+function autoFinishBotTurnIfNeeded(sess) {
+  if (!sess || !sess.gameState || !sess.isTutorial) return;
+  var currentIdx = sess.gameState.currentPlayerIndex;
+  var currentPlayer = sess.gameState.players[currentIdx];
+  if (currentPlayer && currentPlayer.id.indexOf('bot_') === 0) {
+    setTimeout(function() {
+      if (!sess.gameState) return;
+      sess.gameState.finishTurn();
+      io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+      autoFinishBotTurnIfNeeded(sess);
+    }, 1500);
+  }
+}
+
 io.on('connection', function(socket) {
   console.log("User Connected: " + socket.id);
   connectedPlayers[socket.id] = { id: socket.id, name: '' };
@@ -532,6 +546,7 @@ io.on('connection', function(socket) {
     }
     sess.gameState.finishTurn();
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+    if (sess.isTutorial) autoFinishBotTurnIfNeeded(sess);
   });
 
   socket.on('putDefCard', function(data) {
@@ -815,6 +830,30 @@ io.on('connection', function(socket) {
       io.to(sess.users[attackerIdx].id).emit('saboteurDestroyed', { attackerIdx: attackerIdx });
     }
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+  });
+
+  socket.on('createTutorial', function() {
+    leaveCurrentSession(socket);
+    var sess = createSession('Tutorial', false, 6, false);
+    sess.isTutorial = true;
+    var player = connectedPlayers[socket.id];
+    var userName = player ? player.name : 'Player';
+    var botId = 'bot_' + sess.id;
+    sess.users = [
+      makeUser(socket.id, userName),
+      makeUser(botId, 'Tutorial Bot')
+    ];
+    socket.join(sess.id);
+    socketToSession[socket.id] = sess.id;
+    sess.gameState = new GameState(sess.users, { startingCards: 8 });
+    sess.gameState.isTutorial = true;
+    io.to(socket.id).emit('gameState', {
+      playerIndex: 0,
+      gameState: sess.gameState.serialize()
+    });
+    broadcastSessionList();
+    broadcastPlayerList();
+    autoFinishBotTurnIfNeeded(sess);
   });
 
   socket.on('giveUp', function(data) {


### PR DESCRIPTION
Closes #46

## Summary
Adds an interactive step-by-step tutorial that teaches new players the core mechanics by playing against a bot opponent.

## Changes

### Server (`server/index.js`, `server/gameState.js`)
- **`createTutorial` socket handler**: Creates a 1v1 tutorial session (player + bot), starts the game immediately, and emits the initial game state
- **`autoFinishBotTurnIfNeeded(sess)`**: Automatically finishes the bot's turn after 1.5s delay in tutorial sessions, so the player doesn't have to wait
- **`isTutorial` in `serialize()`**: Passes the tutorial flag to the client via game state

### Client (`MenuScreen.java`)
- **Tutorial button** added to the lobby screen between "Rules" and "Create game"
- Emits `createTutorial` to the server on click

### Client (`GameScreen.java`)
- **`isTutorial` / `tutorialStep` fields**: Track tutorial state on the client
- **`buildTutorialOverlay()` method**: Renders a 7-step tutorial overlay with:
  - Step 0: Welcome + board overview
  - Step 1: Hand cards explanation
  - Step 2: Plundering mechanics
  - Step 3: Defense cards / shield slots
  - Step 4: Attacking other players
  - Step 5: Goal of the game
  - Step 6: Tutorial complete — "Back to Menu" or "Keep Playing"
- Each step has "Next" / "Skip Tutorial" buttons; final step offers "Back to Menu" (gives up) or "Keep Playing" (dismisses overlay)

## Testing
- GWT compiles successfully
- Tutorial overlay follows existing overlay patterns (`showHeroInfoOverlay` style)