### PR TITLE
Players can get stuck in a game — add Give Up & Stay and Leave options to in-game menu

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -3296,17 +3296,7 @@ public class GameScreen extends ScreenAdapter {
     });
     table.add(musicBtn).width(300).height(60).padBottom(14).row();
 
-    if (!isSpectator) {
-      TextButton giveUpBtn = new TextButton("Give Up", MyGdxGame.skin);
-      giveUpBtn.addListener(new ClickListener() {
-        @Override
-        public void clicked(InputEvent event, float x, float y) {
-          closeMenu();
-          emitGiveUp();
-        }
-      });
-      table.add(giveUpBtn).width(300).height(60).padBottom(14).row();
-    } else {
+    if (isSpectator || (currentPlayer != null && currentPlayer.isOut())) {
       TextButton leaveBtn = new TextButton("Leave Game", MyGdxGame.skin);
       leaveBtn.addListener(new ClickListener() {
         @Override
@@ -3316,6 +3306,26 @@ public class GameScreen extends ScreenAdapter {
         }
       });
       table.add(leaveBtn).width(300).height(60).row();
+    } else {
+      TextButton giveUpStayBtn = new TextButton("Give Up & Stay", MyGdxGame.skin);
+      giveUpStayBtn.addListener(new ClickListener() {
+        @Override
+        public void clicked(InputEvent event, float x, float y) {
+          closeMenu();
+          emitGiveUp();
+        }
+      });
+      table.add(giveUpStayBtn).width(300).height(60).padBottom(14).row();
+
+      TextButton giveUpLeaveBtn = new TextButton("Give Up & Leave", MyGdxGame.skin);
+      giveUpLeaveBtn.addListener(new ClickListener() {
+        @Override
+        public void clicked(InputEvent event, float x, float y) {
+          closeMenu();
+          emitGiveUpAndLeave();
+        }
+      });
+      table.add(giveUpLeaveBtn).width(300).height(60).row();
     }
 
     overlayStage.addActor(table);
@@ -3529,6 +3539,16 @@ public class GameScreen extends ScreenAdapter {
       data.put("playerIndex", playerIndex);
       socket.emit("giveUp", data);
     } catch (JSONException e) { e.printStackTrace(); }
+  }
+
+  private void emitGiveUpAndLeave() {
+    if (socket == null) return;
+    try {
+      JSONObject data = new JSONObject();
+      data.put("playerIndex", playerIndex);
+      socket.emit("giveUpAndLeave", data);
+    } catch (JSONException e) { e.printStackTrace(); }
+    navigateToLobby();
   }
 
   private void navigateToLobby() {

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -120,6 +120,8 @@ public class GameScreen extends ScreenAdapter {
 
   private int playerIndex;
   private boolean isSpectator = false;
+  // Set to true when navigating away; prevents stale socket listeners from acting.
+  private boolean screenDisposed = false;
   private JSONObject centralizedState;
   private SocketClient socket;
   private Game game;
@@ -196,6 +198,7 @@ public class GameScreen extends ScreenAdapter {
     socket.on("stateUpdate", new SocketListener() {
       @Override
       public void call(Object... args) {
+        if (screenDisposed) return;
         final JSONObject data = (JSONObject) args[0];
         // Fire turn notification here, NOT inside applyStateUpdate/postRunnable.
         // postRunnable runs on the render thread which is paused when the tab is hidden
@@ -229,6 +232,7 @@ public class GameScreen extends ScreenAdapter {
     socket.on("gameState", new SocketListener() {
       @Override
       public void call(Object... args) {
+        if (screenDisposed) return;
         final JSONObject data = (JSONObject) args[0];
         Gdx.app.postRunnable(new Runnable() {
           @Override
@@ -3552,6 +3556,7 @@ public class GameScreen extends ScreenAdapter {
   }
 
   private void navigateToLobby() {
+    screenDisposed = true;
     MyGdxGame.playerStorage.clearSessionId();
     Gdx.app.postRunnable(new Runnable() {
       @Override

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -3552,6 +3552,7 @@ public class GameScreen extends ScreenAdapter {
   }
 
   private void navigateToLobby() {
+    MyGdxGame.playerStorage.clearSessionId();
     Gdx.app.postRunnable(new Runnable() {
       @Override
       public void run() {

--- a/core/src/com/mygdx/game/GameState.java
+++ b/core/src/com/mygdx/game/GameState.java
@@ -175,6 +175,9 @@ public class GameState {
           }
         }
 
+        // Sync out flag so the initial render correctly skips eliminated players
+        if (pj.optBoolean("isOut", false)) p.setOut(true);
+
         players.add(p);
       }
       roundOrder = new ArrayList<Player>(players);

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -124,6 +124,13 @@ public class MenuScreen extends AbstractScreen {
     menuState = new MenuState();
     configSocketEvents(socket);
 
+    // If the socket is already connected (e.g. returning from GameScreen), grab the
+    // socket ID immediately so the lobby is functional without waiting for socketID.
+    String existingSocketId = socket.getSocketId();
+    if (existingSocketId != null && !existingSocketId.isEmpty()) {
+      menuState.setMyUserID(existingSocketId);
+    }
+
     // Pre-populate name and UI state from local storage so returning players skip the name-entry screen.
     String savedName = MyGdxGame.playerStorage.getSavedName();
     if (!savedName.isEmpty()) {

--- a/core/src/com/mygdx/game/net/SocketClient.java
+++ b/core/src/com/mygdx/game/net/SocketClient.java
@@ -11,4 +11,6 @@ public interface SocketClient {
   void connect();
   /** Cleanly disconnect and prevent auto-reconnect. */
   void disconnect();
+  /** Returns the current socket ID, or an empty string if not yet connected. */
+  String getSocketId();
 }

--- a/desktop/src/com/mygdx/game/desktop/SocketIoClient.java
+++ b/desktop/src/com/mygdx/game/desktop/SocketIoClient.java
@@ -57,6 +57,12 @@ public class SocketIoClient implements SocketClient {
   }
 
   @Override
+  public String getSocketId() {
+    String id = socket.id();
+    return id != null ? id : "";
+  }
+
+  @Override
   public void emit(String event, Object data) {
     if (data instanceof JSONObject) {
       try {

--- a/html/src/com/mygdx/game/client/WebSocketClient.java
+++ b/html/src/com/mygdx/game/client/WebSocketClient.java
@@ -93,4 +93,14 @@ public class WebSocketClient implements SocketClient {
     // Calling sock.disconnect() on the client stops auto-reconnect in socket.io v2.
     sock.disconnect();
   }-*/;
+
+  @Override
+  public String getSocketId() {
+    return nativeGetSocketId(jsSocket);
+  }
+
+  private native String nativeGetSocketId(JavaScriptObject sock) /*-{
+    var id = sock.id;
+    return (id != null && id !== undefined) ? id : "";
+  }-*/;
 }

--- a/server/index.js
+++ b/server/index.js
@@ -1437,12 +1437,23 @@ io.on('connection', function(socket) {
     if (!player.isOut) {
       console.log("Player " + playerIdx + " (" + player.name + ") gave up & left session " + sess.id);
       player.isOut = true;
-      if (sess.gameState.currentPlayerIndex === playerIdx) {
+      var wasCurrentPlayer = sess.gameState.currentPlayerIndex === playerIdx;
+      if (wasCurrentPlayer) {
         sess.gameState.finishTurn();
       }
       io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
       checkAndHandleWinner(sess);
-      bot.playBotTurnIfNeeded(sess);
+      // Only restart bot chain if we advanced the turn — if it's already a bot's turn,
+      // the existing bot chain is still running and must not be double-scheduled.
+      if (wasCurrentPlayer) {
+        bot.playBotTurnIfNeeded(sess);
+      }
+    }
+    // Clear token map so a page-refresh does not ghost-reconnect the player.
+    var token = findTokenBySocketId(socket.id);
+    if (token && tokenMap[token]) {
+      delete tokenMap[token].sessionId;
+      delete tokenMap[token].playerIdx;
     }
     leaveCurrentSession(socket);
   });

--- a/server/index.js
+++ b/server/index.js
@@ -1425,5 +1425,25 @@ io.on('connection', function(socket) {
     }
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
     checkAndHandleWinner(sess);
+    bot.playBotTurnIfNeeded(sess);
+  });
+
+  socket.on('giveUpAndLeave', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
+    var playerIdx = data.playerIndex;
+    if (playerIdx < 0 || playerIdx >= sess.gameState.players.length) return;
+    var player = sess.gameState.players[playerIdx];
+    if (!player.isOut) {
+      console.log("Player " + playerIdx + " (" + player.name + ") gave up & left session " + sess.id);
+      player.isOut = true;
+      if (sess.gameState.currentPlayerIndex === playerIdx) {
+        sess.gameState.finishTurn();
+      }
+      io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+      checkAndHandleWinner(sess);
+      bot.playBotTurnIfNeeded(sess);
+    }
+    leaveCurrentSession(socket);
   });
 });


### PR DESCRIPTION
Closes #129

## Changes

### Server (`server/index.js`)
- **New `giveUpAndLeave` socket event handler**: marks the player as out, finishes their turn if it's their current turn, broadcasts `stateUpdate`, checks for a winner, triggers bot turn if needed, then removes the player from the session via `leaveCurrentSession`.
- **`giveUp` handler**: added missing `bot.playBotTurnIfNeeded(sess)` call so bots resume after a human player gives up.

### Client (`core/src/com/mygdx/game/GameScreen.java`)
- **Menu overlay** now shows different buttons based on player state:
  - **Spectators and eliminated players** (`isSpectator || currentPlayer.isOut()`): "Leave Game" button (navigates to lobby)
  - **Active players**: "Give Up & Stay" (existing behaviour — marks out, stays in session to spectate) and "Give Up & Leave" (new — marks out and immediately returns to lobby)
- **New `emitGiveUpAndLeave()` method**: emits the `giveUpAndLeave` socket event with the player index, then navigates to the lobby.