### PR TITLE
fix: Game is cut off on tablets in browser (bottom of screen not visible)

### DIFF
--- a/.github/instructions/github-issue-workflow.instructions.md
+++ b/.github/instructions/github-issue-workflow.instructions.md
@@ -1,0 +1,76 @@
+---
+description: "Use when given a GitHub issue to work on. Covers improving issue titles and descriptions, implementing changes, creating branches and PRs, and deploying to Fly.io after each code change."
+---
+# GitHub Issue Workflow
+
+## When Given a GitHub Issue
+
+### 1. Improve the Issue
+
+Before starting implementation, update the issue on GitHub:
+- Rewrite the title to be clear and action-oriented
+- Improve the description: add reproduction steps, acceptance criteria, and technical context
+- Use `mcp_github_issue_write` to update the issue
+
+### 2. Create a Branch
+
+Create a branch named `feat/<topic>-issue-<number>` (e.g., `feat/bot-overlays-issue-47`):
+- Use `mcp_github_create_branch` or run `git checkout -b feat/<topic>-issue-<number>` in the WSL terminal
+
+### 3. Implement the Change
+
+Make all code changes using VS Code file editing tools (not terminal text manipulation like `sed`/`awk`):
+- Use `read_file`, `replace_string_in_file`, `multi_replace_string_in_file`, `create_file`
+- Read files before modifying them
+- Understand existing code before suggesting changes
+
+### 4. Deploy After Every Code Change
+
+After **each** change to the code, deploy to Fly.io immediately:
+
+```bash
+wsl git -C /home/per-ahrens/source/repos/baisch add -A
+wsl git -C /home/per-ahrens/source/repos/baisch commit -m "<type>: <description>"
+wsl git -C /home/per-ahrens/source/repos/baisch push origin <branch-name>
+wsl bash -c "cd /home/per-ahrens/source/repos/baisch && ~/.fly/bin/fly deploy"
+```
+
+Wait for deploy to complete and confirm both machines reach "good state" before proceeding.
+
+### 5. Create a Pull Request
+
+Once the feature is complete and deployed:
+- Use `mcp_github_create_pull_request` to open a PR against the main branch
+- Reference the issue in the PR body (e.g., "Closes #47")
+- Title should match the improved issue title
+- Only add changes related to the issue in the PR
+
+## Key Constraints
+
+- **Always use WSL commands** for git and deployment (prefix with `wsl git ...` or `wsl bash -c "..."`)
+- **Never use destructive git commands** (no `--force`, no `reset --hard`) without confirmation
+- **Deploy app name**: `baisch-game` (from `fly.toml` in repo root)
+- **Fly CLI path**: `~/.fly/bin/fly` (within WSL)
+- **Repository path in WSL**: `/home/per-ahrens/source/repos/baisch`
+
+## Target Environments — Test Every Change Against All of Them
+
+This codebase runs on multiple platforms. Any change to core game logic, UI layout, input
+handling, or audio **must be verified not to break any of these environments**:
+
+| Environment | Entry point | Notes |
+|---|---|---|
+| **Web — mobile phone (Chrome/Safari)** | `html/webapp/mobile.html` | Touch forwarding, `width=device-width` viewport, letterbox |
+| **Web — desktop browser** | `html/webapp/index.html` | Mouse input, wide/landscape screens, letterbox |
+| **Android app** | `android/` | `AndroidLauncher`, `AndroidPlayerStorage`, `AndroidManifest.xml` |
+| **Future: iOS app** | `ios/` (stubbed) | Will use same core; avoid platform assumptions |
+| **Desktop (dev/testing)** | `desktop/` | Uses `PlayerStorage.NOOP` — no persistence |
+
+### Platform-Specific Anti-Patterns to Avoid
+
+- **Never use Java `==`/`!=` for String comparison** — strings from JSON parsing are non-interned on Android and will not compare equal by reference to literals.
+- **Never use `PlayerStorage.NOOP` in production launchers** — it silently discards all preferences. Create a platform implementation (`AndroidPlayerStorage`, `BrowserPlayerStorage`).
+- **Never hard-code physical pixel sizes** — use `MyGdxGame.WIDTH` / `MyGdxGame.HEIGHT` (logical coordinates) everywhere. `Gdx.graphics.getWidth/Height()` returns physical pixels.
+- **Never assume a fixed viewport width in HTML** — tablets and desktops have varying viewport sizes. The Java letterbox (`FitViewport` + `GameScreen` scale/offset) handles aspect ratio; the HTML only needs to give the canvas the actual viewport dimensions.
+- **`Gdx.net.openURI()` on Android 11+** requires a `<queries>` block in `AndroidManifest.xml` for the target URL scheme (`https`), or the call is silently ignored.
+- **Browser autoplay guards** (e.g., `musicStarted` flag) must not be applied to Android — they prevent the music toggle from working. Keep audio unlock logic inside `HtmlLauncher` / `BrowserPlayerStorage` only.

--- a/html/src/com/mygdx/game/client/HtmlLauncher.java
+++ b/html/src/com/mygdx/game/client/HtmlLauncher.java
@@ -3,13 +3,19 @@ package com.mygdx.game.client;
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.backends.gwt.GwtApplication;
 import com.badlogic.gdx.backends.gwt.GwtApplicationConfiguration;
+import com.google.gwt.user.client.Window;
 import com.mygdx.game.MyGdxGame;
 
 public class HtmlLauncher extends GwtApplication {
 
     @Override
     public GwtApplicationConfiguration getConfig() {
-        return new GwtApplicationConfiguration(450, 800);
+        // Use the actual viewport dimensions so the canvas fills the screen on all
+        // devices (phones, tablets, desktops). The Java FitViewport / letterbox in
+        // GameScreen handles aspect-ratio centering with black bars.
+        return new GwtApplicationConfiguration(
+                Window.getClientWidth(),
+                Window.getClientHeight());
     }
 
     @Override

--- a/html/webapp/index.html
+++ b/html/webapp/index.html
@@ -3,9 +3,10 @@
        <head>
               <title>Baisch-v1</title>
               <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-              <!-- Viewport meta: same settings as mobile.html so this page also works
-                   correctly on mobile when accessed directly. -->
-              <meta name="viewport" content="width=450, user-scalable=no, viewport-fit=cover, shrink-to-fit=no">
+              <!-- width=device-width: browser uses its natural CSS viewport width so
+                   tablets and desktops get their actual dimensions. The Java FitViewport
+                   letterbox centres the 450×800 logical game area with black bars. -->
+              <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover, shrink-to-fit=no">
               <meta name="apple-mobile-web-app-capable" content="yes">
               <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
               <meta name="mobile-web-app-capable" content="yes">

--- a/html/webapp/mobile.html
+++ b/html/webapp/mobile.html
@@ -3,11 +3,12 @@
   <head>
     <title>Baisch</title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <!-- viewport width=450: browser scales the 450px-wide page to fit the screen
-         and maps touch coordinates into the same 450px space automatically.
+    <!-- width=device-width: browser uses its natural CSS viewport width so tablets
+         and desktops get their actual dimensions. The Java FitViewport letterbox
+         centres the 450×800 logical game area with black bars on any aspect ratio.
          viewport-fit=cover: extend into iPhone X notch / home-indicator area.
          shrink-to-fit=no:   prevent iOS 9 auto-shrinking. -->
-    <meta name="viewport" content="width=450, user-scalable=no, viewport-fit=cover, shrink-to-fit=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover, shrink-to-fit=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
Closes #139

## Problem

With `<meta name="viewport" content="width=450">`, a tablet 768 CSS px wide scales the page by 768/450 = 1.71×. The 800px canvas appears 1368px on-screen, but the viewport is only ~600 CSS px tall — the bottom ~200px of the game is cut off.

## Changes

**`html/webapp/mobile.html` & `html/webapp/index.html`**
- Viewport meta changed from `width=450` to `width=device-width, initial-scale=1` so every device uses its natural CSS viewport width.

**`html/src/.../HtmlLauncher.java`**
- `getConfig()` now uses `Window.getClientWidth()` / `Window.getClientHeight()` instead of hard-coded `450 × 800`, so the canvas matches the actual viewport.

**No Java game-logic changes needed** — `GameScreen` already letterboxes via `scale = min(screenW/450, screenH/800)` and `FitViewport`. Wide/landscape screens get black side bars; portrait phones get small top/bottom bars.

**`.github/instructions/github-issue-workflow.instructions.md`**
- Added a Target Environments table and a list of platform-specific anti-patterns to avoid in future changes.

## Tested

- Deployed to https://baisch-game.fly.dev/
- Android APK unaffected (separate code path)