### PR TITLE
fix: eliminate memory leaks causing browser RAM spike and mobile crashes

### DIFF
--- a/android/src/com/mygdx/game/SocketIoClient.java
+++ b/android/src/com/mygdx/game/SocketIoClient.java
@@ -58,6 +58,11 @@ public class SocketIoClient implements SocketClient {
   }
 
   @Override
+  public void off(String event) {
+    socket.off(event);
+  }
+
+  @Override
   public String getSocketId() {
     String id = socket.id();
     return id != null ? id : "";

--- a/core/src/com/mygdx/game/Dice.java
+++ b/core/src/com/mygdx/game/Dice.java
@@ -7,7 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.Actor;
 
 public class Dice extends Actor {
   Sprite sprite;
-  TextureAtlas atlas = new TextureAtlas("data/skins/dice.atlas");
+  private static final TextureAtlas atlas = new TextureAtlas("data/skins/dice.atlas");
 
   private int number;
 

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -4539,9 +4539,36 @@ public class GameScreen extends ScreenAdapter {
 
   @Override
   public void dispose() {
+    screenDisposed = true;
+    // Remove all GameScreen-exclusive socket listeners so this instance can be GC'd.
+    // (Events also used by MenuScreen — "gameState", "returnToLobby" — are guarded
+    //  by the screenDisposed flag in their call() bodies instead.)
+    socket.off("stateUpdate");
+    socket.off("heroAcquired");
+    socket.off("heroLost");
+    socket.off("saboteurDestroyed");
+    socket.off("spyFlip");
+    socket.off("batteryDefenseCheck");
+    socket.off("batteryAllowAttack");
+    socket.off("batteryDenyAttack");
+    socket.off("mercDefBoost");
+    socket.off("reservistsKingBoost");
     gameStage.dispose();
     handStage.dispose();
-
+    overlayStage.dispose();
+    texMercenary.dispose();
+    texSabotaged.dispose();
+    texHearts.dispose();
+    texHeartsRed.dispose();
+    texDiamonds.dispose();
+    texDiamondsRed.dispose();
+    texClubs.dispose();
+    texSpades.dispose();
+    texSomeSymbol.dispose();
+    texSword.dispose();
+    texCrone.dispose();
+    texShieldCheck.dispose();
+    texArrowDownShield.dispose();
   }
 
 }

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -1064,8 +1064,8 @@ public class MenuScreen extends AbstractScreen {
 
   @Override
   public void dispose() {
-    // TODO Auto-generated method stub
-
+    menuStage.dispose();
+    logoTexture.dispose();
   }
 
   public void configSocketEvents(final SocketClient socket) {

--- a/core/src/com/mygdx/game/heroes/Hero.java
+++ b/core/src/com/mygdx/game/heroes/Hero.java
@@ -11,7 +11,7 @@ public class Hero extends Actor {
   protected String heroName = "Hero";
   protected String heroID = "H.";
   protected Sprite sprite;
-  protected TextureAtlas atlas = new TextureAtlas("data/skins/pieces.atlas");
+  protected static final TextureAtlas atlas = new TextureAtlas("data/skins/pieces.atlas");
 
   protected boolean isSelectable = false;
   protected boolean isSelected;

--- a/core/src/com/mygdx/game/net/SocketClient.java
+++ b/core/src/com/mygdx/game/net/SocketClient.java
@@ -7,6 +7,8 @@ package com.mygdx.game.net;
  */
 public interface SocketClient {
   void on(String event, SocketListener listener);
+  /** Remove all listeners for the given event. Safe to call from dispose(). */
+  void off(String event);
   void emit(String event, Object data);
   void connect();
   /** Cleanly disconnect and prevent auto-reconnect. */

--- a/desktop/src/com/mygdx/game/desktop/SocketIoClient.java
+++ b/desktop/src/com/mygdx/game/desktop/SocketIoClient.java
@@ -57,6 +57,11 @@ public class SocketIoClient implements SocketClient {
   }
 
   @Override
+  public void off(String event) {
+    socket.off(event);
+  }
+
+  @Override
   public String getSocketId() {
     String id = socket.id();
     return id != null ? id : "";

--- a/html/src/com/mygdx/game/client/WebSocketClient.java
+++ b/html/src/com/mygdx/game/client/WebSocketClient.java
@@ -59,6 +59,15 @@ public class WebSocketClient implements SocketClient {
   }
 
   @Override
+  public void off(String event) {
+    nativeOff(jsSocket, event);
+  }
+
+  private native void nativeOff(JavaScriptObject sock, String event) /*-{
+    sock.off(event);
+  }-*/;
+
+  @Override
   public void emit(String event, Object data) {
     String jsonStr = (data != null) ? data.toString() : "null";
     nativeEmit(jsSocket, event, jsonStr);

--- a/ios/src/com/mygdx/game/IOSSocketClient.java
+++ b/ios/src/com/mygdx/game/IOSSocketClient.java
@@ -59,6 +59,11 @@ public class IOSSocketClient implements SocketClient {
     }
 
     @Override
+    public void off(String event) {
+        socket.off(event);
+    }
+
+    @Override
     public String getSocketId() {
         String id = socket.id();
         return id != null ? id : "";

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -191,6 +191,7 @@ class GameState {
 
   pushLog(text, success, neutral = false) {
     this.log.push({ text, success, neutral });
+    if (this.log.length > 5) this.log.shift();
   }
 
   cardStrength(cardId) {


### PR DESCRIPTION
Closes #147

## Changes

### Server (`server/gameState.js`)
- **Cap `this.log` to 5 entries** in `pushLog()`. Previously the log array grew without bound and was serialized into every `stateUpdate` broadcast. With 3 bots at 1.5s intervals, this caused WebSocket message sizes to balloon continuously — the primary driver of browser RAM growth.

### Core (`core/`)
- **`GameScreen.dispose()`**: Now properly disposes all 13 `Texture` objects (`texMercenary`, `texSabotaged`, `texHearts`, etc.) and `overlayStage`. These were leaking GPU memory on every game restart.
- **`GameScreen.dispose()`**: Sets `screenDisposed = true` and calls `socket.off()` for all 10 GameScreen-exclusive events (`stateUpdate`, `heroAcquired`, `heroLost`, `saboteurDestroyed`, `spyFlip`, `batteryDefenseCheck`, `batteryAllowAttack`, `batteryDenyAttack`, `mercDefBoost`, `reservistsKingBoost`). Each game restart previously added another full set of listeners without removing the old ones.
- **`SocketClient` interface**: Added `off(String event)` method.
- **`Dice.java`**: Atlas is now `static final` — one load shared across all instances instead of one per player.
- **`Hero.java`**: Atlas is now `static final` — one load shared across all hero instances instead of one per hero.
- **`MenuScreen.dispose()`**: Implemented (was a stub) — now frees `menuStage` and `logoTexture`.

### Platform implementations (`html/`, `desktop/`, `android/`, `ios/`)
- Added `off(String event)` to all four `SocketClient` implementations (`WebSocketClient`, `SocketIoClient` ×2, `IOSSocketClient`).
