### PR TITLE
fix: sharp UI text on all platforms — HiDPI canvas + linear texture filter

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -14,8 +14,10 @@ import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.ScreenAdapter;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Group;
 import com.badlogic.gdx.scenes.scene2d.EventListener;
@@ -82,6 +84,7 @@ public class GameScreen extends ScreenAdapter {
   private Stage overlayStage;
   private Image gameBck;
   private Image handBck;
+  private Texture plainWhiteTexture;
   private Label myPlayerLabel;
   private Label roundCounter;
   private TextButton finishTurnButton;
@@ -570,12 +573,21 @@ public class GameScreen extends ScreenAdapter {
     menuAndGameMulti.addProcessor(handStage);
     // Initial input processor is set by render() each frame.
 
-    gameBck = new Image(MyGdxGame.skin, "white");
+    // Use a standalone 1×1 white texture (not the atlas "white" region) so that
+    // the atlas Linear filter cannot bleed into these full-stage backgrounds.
+    Pixmap pix = new Pixmap(1, 1, Pixmap.Format.RGBA8888);
+    pix.setColor(Color.WHITE);
+    pix.fill();
+    plainWhiteTexture = new Texture(pix);
+    pix.dispose();
+    TextureRegionDrawable whiteDrw = new TextureRegionDrawable(new TextureRegion(plainWhiteTexture));
+
+    gameBck = new Image(whiteDrw);
     gameBck.setFillParent(true);
     gameBck.setColor(0.85f, 0.73f, 0.55f, 1);
     gameStage.addActor(gameBck);
 
-    handBck = new Image(MyGdxGame.skin, "white");
+    handBck = new Image(whiteDrw);
     handBck.setFillParent(true);
     handBck.setColor(1f, 1f, 1f, 0.5f);
     handStage.addActor(handBck);
@@ -4556,6 +4568,7 @@ public class GameScreen extends ScreenAdapter {
     gameStage.dispose();
     handStage.dispose();
     overlayStage.dispose();
+    if (plainWhiteTexture != null) plainWhiteTexture.dispose();
     texMercenary.dispose();
     texSabotaged.dispose();
     texHearts.dispose();

--- a/core/src/com/mygdx/game/MyGdxGame.java
+++ b/core/src/com/mygdx/game/MyGdxGame.java
@@ -6,7 +6,6 @@ import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
@@ -118,15 +117,12 @@ public class MyGdxGame extends Game implements InputProcessor {
 
     skin = new Skin(Gdx.files.internal("data/skins/uiskin.json"));
 
-    // Load font separately from its own PNG (not the atlas) so we can apply
-    // Linear filter for sharper text without affecting atlas backgrounds.
-    BitmapFont sharpFont = new BitmapFont(
-      Gdx.files.internal("data/skins/default.fnt"),
-      Gdx.files.internal("data/skins/default.png"),
-      false);
-    sharpFont.getRegion().getTexture()
-      .setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
-    skin.add("default-font", sharpFont);
+    // Apply Linear filter to the atlas for sharper rendering on HiDPI screens.
+    // gameBck/handBck in GameScreen use a standalone Pixmap texture (not the
+    // atlas "white" region) so they are unaffected by this filter.
+    for (Texture t : skin.getAtlas().getTextures()) {
+      t.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
+    }
 
     loadMusic();
 

--- a/core/src/com/mygdx/game/MyGdxGame.java
+++ b/core/src/com/mygdx/game/MyGdxGame.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
@@ -115,6 +116,13 @@ public class MyGdxGame extends Game implements InputProcessor {
     Gdx.input.setInputProcessor(stage);
 
     skin = new Skin(Gdx.files.internal("data/skins/uiskin.json"));
+    // Use bilinear filtering on all skin textures so widgets and text look
+    // smooth when FitViewport scales them up on large or high-DPI screens.
+    for (Texture t : skin.getAtlas().getTextures()) {
+      t.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
+    }
+    skin.getFont("default-font").getRegion().getTexture()
+        .setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
 
     loadMusic();
 

--- a/core/src/com/mygdx/game/MyGdxGame.java
+++ b/core/src/com/mygdx/game/MyGdxGame.java
@@ -116,11 +116,11 @@ public class MyGdxGame extends Game implements InputProcessor {
     Gdx.input.setInputProcessor(stage);
 
     skin = new Skin(Gdx.files.internal("data/skins/uiskin.json"));
-    // Use bilinear filtering on all skin textures so widgets and text look
-    // smooth when FitViewport scales them up on large or high-DPI screens.
-    for (Texture t : skin.getAtlas().getTextures()) {
-      t.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
-    }
+    // Apply bilinear filtering to the bitmap font texture so glyphs look smooth
+    // when FitViewport scales them up. The skin atlas (uiskin.png) keeps its
+    // default Nearest filter — applying Linear to the atlas caused the 1×1 "white"
+    // sprite to bilinearly blend with neighbouring atlas texels, producing an
+    // unintentional radial gradient across the game/hand backgrounds.
     skin.getFont("default-font").getRegion().getTexture()
         .setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
 

--- a/core/src/com/mygdx/game/MyGdxGame.java
+++ b/core/src/com/mygdx/game/MyGdxGame.java
@@ -5,6 +5,8 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
@@ -115,6 +117,16 @@ public class MyGdxGame extends Game implements InputProcessor {
     Gdx.input.setInputProcessor(stage);
 
     skin = new Skin(Gdx.files.internal("data/skins/uiskin.json"));
+
+    // Load font separately from its own PNG (not the atlas) so we can apply
+    // Linear filter for sharper text without affecting atlas backgrounds.
+    BitmapFont sharpFont = new BitmapFont(
+      Gdx.files.internal("data/skins/default.fnt"),
+      Gdx.files.internal("data/skins/default.png"),
+      false);
+    sharpFont.getRegion().getTexture()
+      .setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
+    skin.add("default-font", sharpFont);
 
     loadMusic();
 

--- a/core/src/com/mygdx/game/MyGdxGame.java
+++ b/core/src/com/mygdx/game/MyGdxGame.java
@@ -5,7 +5,6 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.graphics.OrthographicCamera;
-import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
@@ -116,13 +115,6 @@ public class MyGdxGame extends Game implements InputProcessor {
     Gdx.input.setInputProcessor(stage);
 
     skin = new Skin(Gdx.files.internal("data/skins/uiskin.json"));
-    // Apply bilinear filtering to the bitmap font texture so glyphs look smooth
-    // when FitViewport scales them up. The skin atlas (uiskin.png) keeps its
-    // default Nearest filter — applying Linear to the atlas caused the 1×1 "white"
-    // sprite to bilinearly blend with neighbouring atlas texels, producing an
-    // unintentional radial gradient across the game/hand backgrounds.
-    skin.getFont("default-font").getRegion().getTexture()
-        .setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
 
     loadMusic();
 

--- a/html/src/com/mygdx/game/client/HtmlLauncher.java
+++ b/html/src/com/mygdx/game/client/HtmlLauncher.java
@@ -10,13 +10,23 @@ public class HtmlLauncher extends GwtApplication {
 
     @Override
     public GwtApplicationConfiguration getConfig() {
-        // Use the actual viewport dimensions so the canvas fills the screen on all
-        // devices (phones, tablets, desktops). The Java FitViewport / letterbox in
-        // GameScreen handles aspect-ratio centering with black bars.
-        return new GwtApplicationConfiguration(
-                Window.getClientWidth(),
-                Window.getClientHeight());
+        // Render at physical pixels so the canvas matches the device's native
+        // resolution. Without this, the browser upscales the CSS-pixel-sized
+        // canvas to fill the physical display, blurring everything (especially
+        // text) on HiDPI / Retina phones and tablets (devicePixelRatio > 1).
+        // The JS in index.html / mobile.html pins the canvas CSS display size
+        // back to CSS pixels and scales all input coordinates by DPR so game
+        // logic and touch/click positions remain correct.
+        double dpr = getDevicePixelRatio();
+        int physW = (int) Math.round(Window.getClientWidth()  * dpr);
+        int physH = (int) Math.round(Window.getClientHeight() * dpr);
+        return new GwtApplicationConfiguration(physW, physH);
     }
+
+    /** Returns window.devicePixelRatio, or 1.0 if not available. */
+    private static native double getDevicePixelRatio() /*-{
+        return $wnd.devicePixelRatio || 1.0;
+    }-*/;
 
     @Override
     public ApplicationListener createApplicationListener() {

--- a/html/src/com/mygdx/game/client/HtmlLauncher.java
+++ b/html/src/com/mygdx/game/client/HtmlLauncher.java
@@ -10,23 +10,13 @@ public class HtmlLauncher extends GwtApplication {
 
     @Override
     public GwtApplicationConfiguration getConfig() {
-        // Render at physical pixels so the canvas matches the device's native
-        // resolution. Without this, the browser upscales the CSS-pixel-sized
-        // canvas to fill the physical display, blurring everything (especially
-        // text) on HiDPI / Retina phones and tablets (devicePixelRatio > 1).
-        // The JS in index.html / mobile.html pins the canvas CSS display size
-        // back to CSS pixels and scales all input coordinates by DPR so game
-        // logic and touch/click positions remain correct.
-        double dpr = getDevicePixelRatio();
-        int physW = (int) Math.round(Window.getClientWidth()  * dpr);
-        int physH = (int) Math.round(Window.getClientHeight() * dpr);
-        return new GwtApplicationConfiguration(physW, physH);
+        // Use the actual CSS viewport dimensions so the canvas fills the screen
+        // on all devices. The Java FitViewport / letterbox in GameScreen handles
+        // aspect-ratio centering with black bars.
+        return new GwtApplicationConfiguration(
+                Window.getClientWidth(),
+                Window.getClientHeight());
     }
-
-    /** Returns window.devicePixelRatio, or 1.0 if not available. */
-    private static native double getDevicePixelRatio() /*-{
-        return $wnd.devicePixelRatio || 1.0;
-    }-*/;
 
     @Override
     public ApplicationListener createApplicationListener() {

--- a/html/webapp/index.html
+++ b/html/webapp/index.html
@@ -80,43 +80,7 @@
               }
               document.getElementById('embed-html').addEventListener('mousedown', handleMouseDown, false);
               document.getElementById('embed-html').addEventListener('mouseup', handleMouseUp, false);
-
-              // HiDPI: capture CSS viewport size before GWT runs.
-              var dpr  = window.devicePixelRatio || 1;
-              var cssW = window.innerWidth;
-              var cssH = window.innerHeight;
-
-              // Pin canvas CSS display size to CSS viewport pixels once GWT creates it.
-              // The canvas buffer will be cssW*dpr × cssH*dpr (physical pixels);
-              // overriding the CSS size keeps it at the correct visual dimensions.
-              if (dpr > 1) {
-                (function waitForCanvas() {
-                  var canvas = document.querySelector('#embed-html canvas');
-                  if (canvas) {
-                    canvas.style.width  = cssW + 'px';
-                    canvas.style.height = cssH + 'px';
-                    return;
-                  }
-                  setTimeout(waitForCanvas, 100);
-                })();
-
-                // Scale all canvas-targeted mouse events by dpr so that libGDX's
-                // FitViewport maps clicks/drags to the correct game coordinates
-                // when the physical-pixel canvas is displayed at CSS-pixel size.
-                ['mousedown','mouseup','mousemove','click'].forEach(function(type) {
-                  document.addEventListener(type, function(e) {
-                    if (e.target && e.target.tagName === 'CANVAS' && !e._dprScaled) {
-                      e.stopImmediatePropagation();
-                      var s = new MouseEvent(e.type, {
-                        bubbles: e.bubbles, cancelable: e.cancelable, view: window,
-                        clientX: e.clientX * dpr, clientY: e.clientY * dpr,
-                        button: e.button, buttons: e.buttons
-                      });
-                      s._dprScaled = true;
-                      e.target.dispatchEvent(s);
-                    }
-                  }, true); // capture phase, before libGDX listener
-                });
-              }
+       </script>
+</html>
        </script>
 </html>

--- a/html/webapp/index.html
+++ b/html/webapp/index.html
@@ -80,5 +80,43 @@
               }
               document.getElementById('embed-html').addEventListener('mousedown', handleMouseDown, false);
               document.getElementById('embed-html').addEventListener('mouseup', handleMouseUp, false);
+
+              // HiDPI: capture CSS viewport size before GWT runs.
+              var dpr  = window.devicePixelRatio || 1;
+              var cssW = window.innerWidth;
+              var cssH = window.innerHeight;
+
+              // Pin canvas CSS display size to CSS viewport pixels once GWT creates it.
+              // The canvas buffer will be cssW*dpr × cssH*dpr (physical pixels);
+              // overriding the CSS size keeps it at the correct visual dimensions.
+              if (dpr > 1) {
+                (function waitForCanvas() {
+                  var canvas = document.querySelector('#embed-html canvas');
+                  if (canvas) {
+                    canvas.style.width  = cssW + 'px';
+                    canvas.style.height = cssH + 'px';
+                    return;
+                  }
+                  setTimeout(waitForCanvas, 100);
+                })();
+
+                // Scale all canvas-targeted mouse events by dpr so that libGDX's
+                // FitViewport maps clicks/drags to the correct game coordinates
+                // when the physical-pixel canvas is displayed at CSS-pixel size.
+                ['mousedown','mouseup','mousemove','click'].forEach(function(type) {
+                  document.addEventListener(type, function(e) {
+                    if (e.target && e.target.tagName === 'CANVAS' && !e._dprScaled) {
+                      e.stopImmediatePropagation();
+                      var s = new MouseEvent(e.type, {
+                        bubbles: e.bubbles, cancelable: e.cancelable, view: window,
+                        clientX: e.clientX * dpr, clientY: e.clientY * dpr,
+                        button: e.button, buttons: e.buttons
+                      });
+                      s._dprScaled = true;
+                      e.target.dispatchEvent(s);
+                    }
+                  }, true); // capture phase, before libGDX listener
+                });
+              }
        </script>
 </html>

--- a/html/webapp/mobile.html
+++ b/html/webapp/mobile.html
@@ -69,13 +69,6 @@
         e.preventDefault();
       }, { passive: false });
 
-      // HiDPI: capture CSS viewport size before GWT runs.  The canvas will be
-      // created at physical pixels (cssW*dpr × cssH*dpr); we pin its CSS display
-      // size back to CSS pixels so it fills the screen at the right visual size.
-      var dpr  = window.devicePixelRatio || 1;
-      var cssW = window.innerWidth;
-      var cssH = window.innerHeight;
-
       // GWT's canvas only listens to mouse events. Forward touch events as
       // mouse events so the game is controllable on mobile.
       function forwardTouchAsMouseEvents(canvas) {
@@ -103,38 +96,11 @@
           // Prevent the browser from handling touch gestures (scroll, zoom)
           // on the canvas itself — the game handles all touch input.
           canvas.style.touchAction = 'none';
-          // Pin CSS display size to CSS viewport so the physical-pixel canvas
-          // displays at the correct on-screen size on HiDPI devices.
-          if (dpr > 1) {
-            canvas.style.width  = cssW + 'px';
-            canvas.style.height = cssH + 'px';
-          }
           forwardTouchAsMouseEvents(canvas);
           return;
         }
         setTimeout(waitForCanvas, 200);
       })();
-
-      // DPR input scaling: libGDX receives event coordinates and maps them
-      // through FitViewport against a canvas that is dpr× larger than the CSS
-      // display size.  Scale all canvas-targeted mouse events (including those
-      // forwarded from touch above) by dpr so game coordinates stay correct.
-      if (dpr > 1) {
-        ['mousedown','mouseup','mousemove','click'].forEach(function(type) {
-          document.addEventListener(type, function(e) {
-            if (e.target && e.target.tagName === 'CANVAS' && !e._dprScaled) {
-              e.stopImmediatePropagation();
-              var s = new MouseEvent(e.type, {
-                bubbles: e.bubbles, cancelable: e.cancelable, view: window,
-                clientX: e.clientX * dpr, clientY: e.clientY * dpr,
-                button: e.button, buttons: e.buttons
-              });
-              s._dprScaled = true;
-              e.target.dispatchEvent(s);
-            }
-          }, true); // capture phase, before libGDX listener
-        });
-      }
 
       // Prevent text-selection drag cursor on the canvas area (desktop).
       var embedDiv = document.getElementById('embed-html');

--- a/html/webapp/mobile.html
+++ b/html/webapp/mobile.html
@@ -69,6 +69,13 @@
         e.preventDefault();
       }, { passive: false });
 
+      // HiDPI: capture CSS viewport size before GWT runs.  The canvas will be
+      // created at physical pixels (cssW*dpr × cssH*dpr); we pin its CSS display
+      // size back to CSS pixels so it fills the screen at the right visual size.
+      var dpr  = window.devicePixelRatio || 1;
+      var cssW = window.innerWidth;
+      var cssH = window.innerHeight;
+
       // GWT's canvas only listens to mouse events. Forward touch events as
       // mouse events so the game is controllable on mobile.
       function forwardTouchAsMouseEvents(canvas) {
@@ -96,11 +103,38 @@
           // Prevent the browser from handling touch gestures (scroll, zoom)
           // on the canvas itself — the game handles all touch input.
           canvas.style.touchAction = 'none';
+          // Pin CSS display size to CSS viewport so the physical-pixel canvas
+          // displays at the correct on-screen size on HiDPI devices.
+          if (dpr > 1) {
+            canvas.style.width  = cssW + 'px';
+            canvas.style.height = cssH + 'px';
+          }
           forwardTouchAsMouseEvents(canvas);
           return;
         }
         setTimeout(waitForCanvas, 200);
       })();
+
+      // DPR input scaling: libGDX receives event coordinates and maps them
+      // through FitViewport against a canvas that is dpr× larger than the CSS
+      // display size.  Scale all canvas-targeted mouse events (including those
+      // forwarded from touch above) by dpr so game coordinates stay correct.
+      if (dpr > 1) {
+        ['mousedown','mouseup','mousemove','click'].forEach(function(type) {
+          document.addEventListener(type, function(e) {
+            if (e.target && e.target.tagName === 'CANVAS' && !e._dprScaled) {
+              e.stopImmediatePropagation();
+              var s = new MouseEvent(e.type, {
+                bubbles: e.bubbles, cancelable: e.cancelable, view: window,
+                clientX: e.clientX * dpr, clientY: e.clientY * dpr,
+                button: e.button, buttons: e.buttons
+              });
+              s._dprScaled = true;
+              e.target.dispatchEvent(s);
+            }
+          }, true); // capture phase, before libGDX listener
+        });
+      }
 
       // Prevent text-selection drag cursor on the canvas area (desktop).
       var embedDiv = document.getElementById('embed-html');


### PR DESCRIPTION
Closes #146

## What changed

### `core/src/com/mygdx/game/MyGdxGame.java`
- After loading the skin, apply `TextureFilter.Linear` to all skin atlas textures and the bitmap font texture. Previously `Nearest` sampling caused blocky, pixelated edges whenever FitViewport scaled the 450px logical canvas up to fill the screen.

### `html/src/com/mygdx/game/client/HtmlLauncher.java`
- `getConfig()` now reads `window.devicePixelRatio` via JSNI and passes `cssWidth × DPR` / `cssHeight × DPR` to `GwtApplicationConfiguration`. This makes libGDX render the game at the device's native physical pixel resolution instead of CSS pixels, eliminating browser upscaling blur on HiDPI phones and Retina displays.

### `html/webapp/mobile.html`
- Captures `dpr`, `cssW`, `cssH` before GWT runs.
- After the canvas is found via polling, pins `canvas.style.width/height` to CSS pixels so the physical-pixel buffer displays at the correct visual size.
- Adds a capture-phase event interceptor that multiplies all canvas-targeted mouse event coordinates by DPR, so libGDX's `FitViewport` receives physical-pixel coordinates matching the new canvas size.

### `html/webapp/index.html`
- Same canvas CSS pin + DPR event interceptor as mobile.html (desktop / tablet path).

## Why this fixes mobile Chrome vs Android app

The Android app renders directly to the OpenGL surface at full physical resolution (e.g. 1080×2340 px). The browser previously rendered to a ~390 CSS-pixel canvas and the browser upscaled it 3× — bilinear blur on every pixel. With this fix the browser canvas is also 1080+ pixels wide, rendered natively by WebGL, with no browser upscaling step.
