### PR TITLE
Automate bot card setup during manual setup phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,11 @@ gradle-app.setting
 ## OS Specific
 .DS_Store
 Thumbs.db
+# Windows NTFS alternate data streams created when files are downloaded
+*:Zone.Identifier
+
+## Node.js generated files (not committed — lock file lives in server/)
+/package-lock.json
 
 ## iOS
 /ios/xcode/*.xcodeproj/*

--- a/server/bot.js
+++ b/server/bot.js
@@ -565,8 +565,49 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     return best;
   }
 
+  /**
+   * Compute the smart manual-setup card selection for a bot player.
+   * Strategy:
+   *   - King card  : highest-strength non-joker (jokers used only as fallback)
+   *   - Def cards  : next 3 highest-strength non-jokers
+   *   - Joker      : always kept in hand when possible
+   *   - Discard    : 2 lowest-strength remaining cards (non-jokers preferred)
+   *
+   * Returns { kingId, defIds, discardIds } or null if the hand is too small.
+   */
+  function botComputeSetup(gs, playerIdx) {
+    var bp = gs.players[playerIdx];
+    if (!bp || bp.hand.length < 4) return null;
+
+    var jokers = bp.hand.filter(function(id) { return id > 52; });
+    var nonJokers = bp.hand.filter(function(id) { return id <= 52; });
+
+    // Sort non-jokers descending by strength (highest = best king/def candidate)
+    nonJokers.sort(function(a, b) { return gs.cardStrength(b) - gs.cardStrength(a); });
+
+    // Build king + def from non-jokers first; use jokers only if non-jokers run out
+    var pool = nonJokers.concat(jokers);
+    var kingId = pool[0];
+    var defIds = [pool[1], pool[2], pool[3]];
+
+    // Remaining cards (not king or def), jokers pushed to end so they are discarded last
+    var assigned = new Set([kingId, pool[1], pool[2], pool[3]]);
+    var remaining = bp.hand.filter(function(id) { return !assigned.has(id); });
+    remaining.sort(function(a, b) {
+      var aJoker = a > 52, bJoker = b > 52;
+      if (aJoker !== bJoker) return aJoker ? 1 : -1; // jokers survive, go last
+      return gs.cardStrength(a) - gs.cardStrength(b); // lowest-strength first
+    });
+
+    // Discard 2 lowest (mirrors the 2 cemetery cards from auto-setup)
+    var discardIds = remaining.slice(0, 2);
+
+    return { kingId: kingId, defIds: defIds, discardIds: discardIds };
+  }
+
   return {
     isBot: isBot,
-    playBotTurnIfNeeded: playBotTurnIfNeeded
+    playBotTurnIfNeeded: playBotTurnIfNeeded,
+    autoSetupBot: botComputeSetup
   };
 };

--- a/server/index.js
+++ b/server/index.js
@@ -206,16 +206,13 @@ function startGameForSession(sess, requesterSocketId) {
       tokenMap[u.token].sessionId = sess.id;
     }
   });
-  // Auto-submit manual setup for bots
+  // Auto-submit manual setup for bots using the smart card-selection strategy
   if (sess.manualSetup && sess.gameState.setupPhase) {
     sess.users.forEach(function(u, idx) {
       if (bot.isBot(u)) {
-        var bp = sess.gameState.players[idx];
-        if (bp && bp.hand.length >= 4) {
-          var kingId = bp.hand[0];
-          var defIds = [bp.hand[1], bp.hand[2], bp.hand[3]];
-          var discardIds = bp.hand.length > 6 ? [bp.hand[4], bp.hand[5]] : [];
-          sess.gameState.applyManualSetup(idx, kingId, defIds, discardIds);
+        var setup = bot.autoSetupBot(sess.gameState, idx);
+        if (setup) {
+          sess.gameState.applyManualSetup(idx, setup.kingId, setup.defIds, setup.discardIds);
         }
       }
     });


### PR DESCRIPTION
Closes #158

## Changes

Added `botComputeSetup` (exported as `bot.autoSetupBot`) in `server/bot.js` that implements the smart card-selection strategy for bots during the manual setup phase:

- **King card**: highest-strength non-joker in hand
- **Defense cards**: the 3 next-highest non-jokers
- **Jokers**: always kept in hand (jokers are only used for king/def as a last resort if not enough non-jokers exist)
- **Discard**: 2 lowest-strength remaining cards, non-jokers discarded before jokers

The naive random card selection in `server/index.js` (which also had an incorrect discard count for non-8 starting card counts) is replaced with a call to `bot.autoSetupBot(gs, idx)`.

## Testing

- Deployed and verified on https://baisch-game.fly.dev/
- Human players are unaffected — they still perform manual setup themselves
- With mixed human+bot games, bots auto-submit immediately and the game starts as soon as the human player confirms their setup