### PR TITLE
Replace libGDX loading screen with a game-branded loading overlay

### DIFF
--- a/html/src/com/mygdx/game/client/HtmlLauncher.java
+++ b/html/src/com/mygdx/game/client/HtmlLauncher.java
@@ -3,7 +3,12 @@ package com.mygdx.game.client;
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.backends.gwt.GwtApplication;
 import com.badlogic.gdx.backends.gwt.GwtApplicationConfiguration;
+import com.badlogic.gdx.backends.gwt.preloader.Preloader;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.InlineHTML;
+import com.google.gwt.user.client.ui.Panel;
 import com.mygdx.game.MyGdxGame;
 
 public class HtmlLauncher extends GwtApplication {
@@ -16,6 +21,22 @@ public class HtmlLauncher extends GwtApplication {
         return new GwtApplicationConfiguration(
                 Window.getClientWidth(),
                 Window.getClientHeight());
+    }
+
+    @Override
+    public Preloader.PreloaderCallback getPreloaderCallback() {
+        // Return a no-op callback so the default libGDX logo/progress bar
+        // is never rendered. Our custom HTML loading overlay handles this instead.
+        return new Preloader.PreloaderCallback() {
+            @Override
+            public void update(Preloader.PreloaderState state) {
+                // intentionally empty
+            }
+            @Override
+            public void error(String file) {
+                // silently ignore individual asset load errors
+            }
+        };
     }
 
     @Override

--- a/html/src/com/mygdx/game/client/HtmlLauncher.java
+++ b/html/src/com/mygdx/game/client/HtmlLauncher.java
@@ -3,12 +3,7 @@ package com.mygdx.game.client;
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.backends.gwt.GwtApplication;
 import com.badlogic.gdx.backends.gwt.GwtApplicationConfiguration;
-import com.badlogic.gdx.backends.gwt.preloader.Preloader;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.InlineHTML;
-import com.google.gwt.user.client.ui.Panel;
 import com.mygdx.game.MyGdxGame;
 
 public class HtmlLauncher extends GwtApplication {
@@ -21,22 +16,6 @@ public class HtmlLauncher extends GwtApplication {
         return new GwtApplicationConfiguration(
                 Window.getClientWidth(),
                 Window.getClientHeight());
-    }
-
-    @Override
-    public Preloader.PreloaderCallback getPreloaderCallback() {
-        // Return a no-op callback so the default libGDX logo/progress bar
-        // is never rendered. Our custom HTML loading overlay handles this instead.
-        return new Preloader.PreloaderCallback() {
-            @Override
-            public void update(Preloader.PreloaderState state) {
-                // intentionally empty
-            }
-            @Override
-            public void error(String file) {
-                // silently ignore individual asset load errors
-            }
-        };
     }
 
     @Override

--- a/html/webapp/index.html
+++ b/html/webapp/index.html
@@ -44,6 +44,10 @@
                   right: 10px;
                   z-index: 9999;
                 }
+                /* ── Hide the default libGDX preloader logo/progress bar ─── */
+                /* The GWT backend injects .gdx-preloader into the DOM during  */
+                /* asset download. Our custom overlay handles this phase.       */
+                .gdx-preloader { display: none !important; }
                 /* ── Game-branded loading overlay ─────────────────────────── */
                 #loading-overlay {
                   position: fixed;

--- a/html/webapp/index.html
+++ b/html/webapp/index.html
@@ -45,9 +45,10 @@
                   z-index: 9999;
                 }
                 /* ── Hide the default libGDX preloader logo/progress bar ─── */
-                /* The GWT backend injects .gdx-preloader into the DOM during  */
-                /* asset download. Our custom overlay handles this phase.       */
+                /* The GWT backend injects a wrapper <table> then .gdx-preloader */
+                /* inside #embed-html. Our custom overlay handles this phase.   */
                 .gdx-preloader { display: none !important; }
+                #embed-html > table { display: none !important; }
                 /* ── Game-branded loading overlay ─────────────────────────── */
                 #loading-overlay {
                   position: fixed;

--- a/html/webapp/index.html
+++ b/html/webapp/index.html
@@ -44,10 +44,71 @@
                   right: 10px;
                   z-index: 9999;
                 }
+                /* ── Game-branded loading overlay ─────────────────────────── */
+                #loading-overlay {
+                  position: fixed;
+                  inset: 0;
+                  background: #1a1a2e;
+                  display: flex;
+                  flex-direction: column;
+                  align-items: center;
+                  justify-content: center;
+                  z-index: 8000;
+                  transition: opacity 0.4s ease;
+                }
+                #loading-overlay.fade-out {
+                  opacity: 0;
+                  pointer-events: none;
+                }
+                #loading-title {
+                  font-family: Georgia, 'Times New Roman', serif;
+                  font-size: clamp(48px, 12vw, 96px);
+                  font-weight: bold;
+                  letter-spacing: 0.15em;
+                  color: #f5c842;
+                  text-shadow: 0 0 30px rgba(245,200,66,0.6), 0 2px 8px rgba(0,0,0,0.8);
+                  margin-bottom: 20px;
+                  animation: pulse 2s ease-in-out infinite;
+                }
+                #loading-suits {
+                  font-size: clamp(24px, 6vw, 42px);
+                  letter-spacing: 0.3em;
+                  color: #cccccc;
+                  margin-bottom: 40px;
+                }
+                #loading-suits .red { color: #e05555; }
+                #loading-bar-wrap {
+                  width: clamp(160px, 40vw, 260px);
+                  height: 6px;
+                  background: rgba(255,255,255,0.15);
+                  border-radius: 3px;
+                  overflow: hidden;
+                }
+                #loading-bar {
+                  height: 100%;
+                  width: 30%;
+                  background: linear-gradient(90deg, #f5c842, #e0a020);
+                  border-radius: 3px;
+                  animation: slide 1.4s ease-in-out infinite;
+                }
+                @keyframes pulse {
+                  0%, 100% { opacity: 1; }
+                  50%       { opacity: 0.75; }
+                }
+                @keyframes slide {
+                  0%   { transform: translateX(-120%); }
+                  100% { transform: translateX(500%); }
+                }
               </style>
        </head>
 
        <body>
+              <!-- Game-branded loading screen, removed once the canvas appears -->
+              <div id="loading-overlay">
+                <div id="loading-title">BAISCH</div>
+                <div id="loading-suits">♠ <span class="red">♥</span> <span class="red">♦</span> ♣</div>
+                <div id="loading-bar-wrap"><div id="loading-bar"></div></div>
+              </div>
               <a class="superdev" href="javascript:%7B%20window.__gwt_bookmarklet_params%20%3D%20%7B'server_url'%3A'http%3A%2F%2Flocalhost%3A9876%2F'%7D%3B%20var%20s%20%3D%20document.createElement('script')%3B%20s.src%20%3D%20'http%3A%2F%2Flocalhost%3A9876%2Fdev_mode_on.js'%3B%20void(document.getElementsByTagName('head')%5B0%5D.appendChild(s))%3B%7D">&#8635;</a>
               <div id="embed-html"></div>
               <script type="text/javascript" src="html/html.nocache.js"></script>
@@ -80,6 +141,22 @@
               }
               document.getElementById('embed-html').addEventListener('mousedown', handleMouseDown, false);
               document.getElementById('embed-html').addEventListener('mouseup', handleMouseUp, false);
+
+              // Remove the loading overlay once GWT creates the canvas
+              (function() {
+                var overlay = document.getElementById('loading-overlay');
+                if (!overlay) return;
+                var observer = new MutationObserver(function() {
+                  if (document.querySelector('#embed-html canvas')) {
+                    observer.disconnect();
+                    overlay.classList.add('fade-out');
+                    setTimeout(function() {
+                      if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+                    }, 450);
+                  }
+                });
+                observer.observe(document.getElementById('embed-html'), { childList: true, subtree: true });
+              })();
        </script>
 </html>
        </script>

--- a/html/webapp/mobile.html
+++ b/html/webapp/mobile.html
@@ -46,9 +46,73 @@
         justify-content: center;
         align-items: flex-start;
       }
+      /* ── Hide the default libGDX preloader logo/progress bar ─── */
+      .gdx-preloader { display: none !important; }
+      #embed-html > table { display: none !important; }
+      /* ── Game-branded loading overlay ─────────────────────────── */
+      #loading-overlay {
+        position: fixed;
+        inset: 0;
+        background: #1a1a2e;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        z-index: 8000;
+        transition: opacity 0.4s ease;
+      }
+      #loading-overlay.fade-out {
+        opacity: 0;
+        pointer-events: none;
+      }
+      #loading-title {
+        font-family: Georgia, 'Times New Roman', serif;
+        font-size: clamp(48px, 12vw, 96px);
+        font-weight: bold;
+        letter-spacing: 0.15em;
+        color: #f5c842;
+        text-shadow: 0 0 30px rgba(245,200,66,0.6), 0 2px 8px rgba(0,0,0,0.8);
+        margin-bottom: 20px;
+        animation: pulse 2s ease-in-out infinite;
+      }
+      #loading-suits {
+        font-size: clamp(24px, 6vw, 42px);
+        letter-spacing: 0.3em;
+        color: #cccccc;
+        margin-bottom: 40px;
+      }
+      #loading-suits .red { color: #e05555; }
+      #loading-bar-wrap {
+        width: clamp(160px, 40vw, 260px);
+        height: 6px;
+        background: rgba(255,255,255,0.15);
+        border-radius: 3px;
+        overflow: hidden;
+      }
+      #loading-bar {
+        height: 100%;
+        width: 30%;
+        background: linear-gradient(90deg, #f5c842, #e0a020);
+        border-radius: 3px;
+        animation: slide 1.4s ease-in-out infinite;
+      }
+      @keyframes pulse {
+        0%, 100% { opacity: 1; }
+        50%       { opacity: 0.75; }
+      }
+      @keyframes slide {
+        0%   { transform: translateX(-120%); }
+        100% { transform: translateX(500%); }
+      }
     </style>
   </head>
   <body>
+    <!-- Game-branded loading screen, removed once the canvas appears -->
+    <div id="loading-overlay">
+      <div id="loading-title">BAISCH</div>
+      <div id="loading-suits">♠ <span class="red">♥</span> <span class="red">♦</span> ♣</div>
+      <div id="loading-bar-wrap"><div id="loading-bar"></div></div>
+    </div>
     <div id="embed-html"></div>
     <script type="text/javascript" src="html/html.nocache.js"></script>
     <script>
@@ -113,6 +177,22 @@
         evt.preventDefault();
         evt.target.style.cursor = '';
       }, false);
+
+      // Remove the loading overlay once GWT creates the canvas
+      (function() {
+        var overlay = document.getElementById('loading-overlay');
+        if (!overlay) return;
+        var observer = new MutationObserver(function() {
+          if (document.querySelector('#embed-html canvas')) {
+            observer.disconnect();
+            overlay.classList.add('fade-out');
+            setTimeout(function() {
+              if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+            }, 450);
+          }
+        });
+        observer.observe(document.getElementById('embed-html'), { childList: true, subtree: true });
+      })();
     </script>
   </body>
 </html>

--- a/html/webapp/mobile.html
+++ b/html/webapp/mobile.html
@@ -48,7 +48,6 @@
       }
       /* ── Hide the default libGDX preloader logo/progress bar ─── */
       .gdx-preloader { display: none !important; }
-      #embed-html > table { display: none !important; }
       /* ── Game-branded loading overlay ─────────────────────────── */
       #loading-overlay {
         position: fixed;

--- a/html/webapp/mobile.html
+++ b/html/webapp/mobile.html
@@ -178,19 +178,17 @@
       }, false);
 
       // Remove the loading overlay once GWT creates the canvas
-      (function() {
+      (function waitAndRemoveOverlay() {
         var overlay = document.getElementById('loading-overlay');
         if (!overlay) return;
-        var observer = new MutationObserver(function() {
-          if (document.querySelector('#embed-html canvas')) {
-            observer.disconnect();
-            overlay.classList.add('fade-out');
-            setTimeout(function() {
-              if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
-            }, 450);
-          }
-        });
-        observer.observe(document.getElementById('embed-html'), { childList: true, subtree: true });
+        if (document.querySelector('#embed-html canvas')) {
+          overlay.classList.add('fade-out');
+          setTimeout(function() {
+            if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+          }, 450);
+          return;
+        }
+        setTimeout(waitAndRemoveOverlay, 200);
       })();
     </script>
   </body>


### PR DESCRIPTION
Closes #162

## What's changed

Replaces the default libGDX logo + red progress bar with a game-branded loading overlay shown while the GWT bundle downloads and the game initialises.

### Overlay design
- Dark navy background (`#1a1a2e`)
- **BAISCH** title in gold with a pulse glow animation
- Card suits ♠ ♥ ♦ ♣ (hearts/diamonds in red)
- Gold shimmer bar sweeping left-to-right
- 0.4 s fade-out when the game canvas appears

### Technical details
- CSS hides `.gdx-preloader` — the libGDX preloader still runs its state machine (asset loading, `setupDisplay()`, `create()`) but is invisible
- A 200 ms polling loop in `mobile.html` removes the overlay once `#embed-html canvas` is present in the DOM
- `Cache-Control: no-cache` added to `/` and `/m` routes so browsers always get the latest HTML
- `index.html` updated for consistency (desktop entry point)

### Verified with Playwright
- ✅ Canvas visible within 35 s timeout
- ✅ Loading overlay removed from DOM after canvas appears
- ✅ No JS page errors
- ✅ Works on desktop Chrome and Pixel 5 mobile viewport