### PR TITLE
Fix: king card selectable after coup swap; Finish Turn works post-swap

### DIFF
--- a/core/src/com/mygdx/game/Card.java
+++ b/core/src/com/mygdx/game/Card.java
@@ -297,10 +297,15 @@ public class Card extends Actor {
   }
 
   public void removeAllListeners() {
-    Array<EventListener> listeners = getListeners();
-    for (EventListener listener : listeners) {
-      removeListener(listener);
-    }
+    // The naive `for (EventListener l : getListeners()) removeListener(l)` pattern is
+    // broken: libGDX's Array iterator advances by index, so when removeListener shrinks
+    // the underlying array each iteration skips one element and roughly half of the
+    // listeners survive. Real-world impact: after a coup/Warlord king swap, the new
+    // king ended up with two click listeners (the anonymous one from Player.setKingCard
+    // plus OwnKingCardListener) that toggled each other — clicks did nothing visible
+    // until the next turn (#169). Use Actor.clearListeners() which clears via the
+    // underlying DelayedRemovalArray.clear().
+    clearListeners();
   }
 
   public void setDeckPosition() {

--- a/core/src/com/mygdx/game/CardDeck.java
+++ b/core/src/com/mygdx/game/CardDeck.java
@@ -89,11 +89,9 @@ public class CardDeck extends Actor {
   }
 
   public void addCard(Card card) {
-    // remove all listeners
-    Array<EventListener> listeners = card.getListeners();
-    for (EventListener listener : listeners) {
-      card.removeListener(listener);
-    }
+    // remove all listeners (clearListeners avoids the buggy for-each + removeListener
+    // pattern that skips elements as the Array shrinks during iteration)
+    card.clearListeners();
 
     card.setCovered(false);
     cards.add(card);

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -4855,10 +4855,9 @@ public class GameScreen extends ScreenAdapter {
   }
 
   public void removeAllListeners(Actor actor) {
-    Array<EventListener> listeners = actor.getListeners();
-    for (EventListener listener : listeners) {
-      actor.removeListener(listener);
-    }
+    // See Card.removeAllListeners — the for-each + removeListener pattern is buggy
+    // (skips elements as the Array shrinks). Use clearListeners() instead.
+    actor.clearListeners();
   }
 
   @Override

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -3085,7 +3085,7 @@ public class GameScreen extends ScreenAdapter {
                     Card target = (Card) hit;
                     int posId = target.getPositionId();
                     if (target.isPlaceholder() && posId >= 1 && posId <= 3
-                        && currentPlayer.canMobilize() && !currentPlayer.isSlotSabotaged(posId)) {
+                        && currentPlayer.canPutDefCard() && !currentPlayer.isSlotSabotaged(posId)) {
                       currentPlayer.putDefCard(posId, 0);
                       emitPutDefCard(posId, handCard.getCardId());
                       gameState.setUpdateState(true);

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -1895,7 +1895,11 @@ public class GameScreen extends ScreenAdapter {
           apt.resetPendingAttackMercenaryBonus();
           apt.setAttackPending(false);
           apt.setAttackTargetIsKing(false);
-          if (apt.isKingUsed()) apt.setKingUsedThisTurn(true);
+          // Mark king as spent only for normal king attacks. Warlord direct attacks
+          // are an additional action granted by the hero and must NOT consume the
+          // regular once-per-turn king attack/plunder.
+          if (apt.isKingUsed() && !apt.isPendingAttackIsWarlord()) apt.setKingUsedThisTurn(true);
+          apt.setPendingAttackIsWarlord(false);
           // Clear hand card attack boost visuals after attack resolves
           for (Card c : atkPlayer.getHandCards()) {
             c.setSelected(false);

--- a/core/src/com/mygdx/game/Player.java
+++ b/core/src/com/mygdx/game/Player.java
@@ -59,10 +59,9 @@ public class Player {
 
     handCards.add(card);
 
-    Array<EventListener> listeners = card.getListeners();
-    for (EventListener listener : listeners) {
-      card.removeListener(listener);
-    }
+    // See Card.removeAllListeners — the for-each + removeListener pattern is buggy
+    // (skips elements as the Array shrinks). Use clearListeners() instead.
+    card.clearListeners();
 
     card.addListener(new ClickListener() {
       @Override
@@ -481,10 +480,9 @@ public class Player {
 
     kingCard.setSelected(false);
 
-    Array<EventListener> listeners = kingCard.getListeners();
-    for (EventListener listener : listeners) {
-      kingCard.removeListener(listener);
-    }
+    // See Card.removeAllListeners — the for-each + removeListener pattern is buggy
+    // (skips elements as the Array shrinks). Use clearListeners() instead.
+    kingCard.clearListeners();
 
     final Card refCard = kingCard;
 

--- a/core/src/com/mygdx/game/Player.java
+++ b/core/src/com/mygdx/game/Player.java
@@ -101,6 +101,16 @@ public class Player {
     return playerTurn.getTakeDefCard() > 0 || playerTurn.getPutDefCard() > 0;
   }
 
+  /** Returns true only if a put-defense-card action is still available this turn. */
+  public boolean canPutDefCard() {
+    for (int i = 0; i < heroes.size(); i++) {
+      if (heroes.get(i).getHeroName() == "Marshal") {
+        return ((Marshal) heroes.get(i)).getMobilizations() > 0;
+      }
+    }
+    return playerTurn.getPutDefCard() > 0;
+  }
+
   /** Returns true only if a take-defense-card action is still available this turn. */
   public boolean canTakeDefCard() {
     for (int i = 0; i < heroes.size(); i++) {

--- a/core/src/com/mygdx/game/PlayerTurn.java
+++ b/core/src/com/mygdx/game/PlayerTurn.java
@@ -157,6 +157,14 @@ public class PlayerTurn {
   public boolean isAttackTargetIsKing() { return attackTargetIsKing; }
   public void setAttackTargetIsKing(boolean v) { this.attackTargetIsKing = v; }
 
+  // True when the pending attack was initiated via the Warlord hero's extra attack.
+  // Warlord grants an additional attack action, so resolving such an attack must NOT
+  // mark the king as spent for the turn — otherwise the regular once-per-turn king
+  // attack/plunder is permanently blocked even after the player clears all defenses.
+  private boolean pendingAttackIsWarlord = false;
+  public boolean isPendingAttackIsWarlord() { return pendingAttackIsWarlord; }
+  public void setPendingAttackIsWarlord(boolean v) { this.pendingAttackIsWarlord = v; }
+
   // --- Mercenary attack bonus ---
   // Incremented each time the player clicks the Mercenaries hero to add +1 attack.
   // Reset to 0 after the attack resolves.

--- a/core/src/com/mygdx/game/heroes/Hero.java
+++ b/core/src/com/mygdx/game/heroes/Hero.java
@@ -69,10 +69,9 @@ public class Hero extends Actor {
   }
 
   public void removeAllListeners() {
-    Array<EventListener> listeners = getListeners();
-    for (EventListener listener : listeners) {
-      removeListener(listener);
-    }
+    // See Card.removeAllListeners — the for-each + removeListener pattern is buggy
+    // (skips elements as the Array shrinks). Use clearListeners() instead.
+    clearListeners();
   }
 
   public void recover() {

--- a/core/src/com/mygdx/game/listeners/EnemyDefCardListener.java
+++ b/core/src/com/mygdx/game/listeners/EnemyDefCardListener.java
@@ -301,6 +301,11 @@ public class EnemyDefCardListener extends ClickListener {
 
     // Consume Warlord charge after attack is committed
     if (warlordAttack && warlord != null) {
+      // Mark this pending attack as a Warlord extra-attack so the resolved
+      // callback does NOT mark the king as spent for the turn (Warlord grants
+      // an additional attack action; the regular king attack/plunder must
+      // remain available).
+      pt.setPendingAttackIsWarlord(true);
       warlord.useAttack();
       if (socket != null) {
         try {

--- a/core/src/com/mygdx/game/listeners/EnemyDefCardListener.java
+++ b/core/src/com/mygdx/game/listeners/EnemyDefCardListener.java
@@ -215,8 +215,8 @@ public class EnemyDefCardListener extends ClickListener {
       if (kingSelected && (!player.getDefCards().isEmpty() || !player.getTopDefCards().isEmpty())) return;
     }
 
-    // King can only be used once per turn
-    if (kingSelected && pt.isKingUsedThisTurn()) return;
+    // King can only be used once per turn (Warlord grants an extra attack and bypasses this)
+    if (kingSelected && !warlordAttack && pt.isKingUsedThisTurn()) return;
 
     // Symbol constraint — joker bypasses; other cards must match the set symbol
     // For Banneret using only own def cards (no hand cards), use the first def card's symbol

--- a/core/src/com/mygdx/game/listeners/EnemyKingCardListener.java
+++ b/core/src/com/mygdx/game/listeners/EnemyKingCardListener.java
@@ -190,6 +190,11 @@ public class EnemyKingCardListener extends ClickListener {
 
     // Consume Warlord charge after attack is committed
     if (warlordAttack && warlord != null) {
+      // Mark this pending attack as a Warlord extra-attack so the resolved
+      // callback does NOT mark the king as spent for the turn (Warlord grants
+      // an additional attack action; the regular king attack/plunder must
+      // remain available).
+      pt.setPendingAttackIsWarlord(true);
       warlord.useAttack();
       if (socket != null) {
         try {

--- a/core/src/com/mygdx/game/listeners/EnemyKingCardListener.java
+++ b/core/src/com/mygdx/game/listeners/EnemyKingCardListener.java
@@ -116,8 +116,8 @@ public class EnemyKingCardListener extends ClickListener {
       if (!kingSelected && player.getSelectedHandCards().size() == 0) return;
     }
 
-    // Attacker's king: one-use-per-turn
-    if (kingSelected && pt.isKingUsedThisTurn()) return;
+    // Attacker's king: one-use-per-turn (Warlord grants an extra attack and bypasses this)
+    if (kingSelected && !warlordAttack && pt.isKingUsedThisTurn()) return;
     // Without Warlord, king can only be used when attacker has no defense cards
     if (kingSelected && !warlordAttack && (!player.getDefCards().isEmpty() || !player.getTopDefCards().isEmpty())) return;
 

--- a/core/src/com/mygdx/game/listeners/OwnKingCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnKingCardListener.java
@@ -56,13 +56,9 @@ public class OwnKingCardListener extends ClickListener {
     }
 
     {
-      // Unselect all hand cards via player.getHandCards() so we always use the
-      // current list — sortHandCards() and the post-swap re-add can replace the
-      // underlying ArrayList, so the stored handCards field becomes stale and
-      // would miss cards added after the last show() call (e.g. the old king
-      // pushed back into hand by a coup swap).
-      for (Card c : player.getHandCards()) {
-        c.setSelected(false);
+      // unselect all handcards
+      for (int i = 0; i < handCards.size(); i++) {
+        handCards.get(i).setSelected(false);
       }
       // Selecting own king cancels any pending coup-swap auto-select
       player.getPlayerTurn().setCoupSwapPendingCardId(-1);
@@ -83,12 +79,8 @@ public class OwnKingCardListener extends ClickListener {
         kingCard.setSelected(true);
       }
     }
-    // Trigger a screen rebuild so a fresh OwnKingCardListener is attached to
-    // the current board king — after a coup/Warlord swap the old listener
-    // still references the previous king Card object, so without a rebuild the
-    // first click on the new king goes to a stale listener and has no visible
-    // effect.
-    gameState.setUpdateState(true);
+    ;
+
   }
 
 }

--- a/core/src/com/mygdx/game/listeners/OwnKingCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnKingCardListener.java
@@ -56,9 +56,13 @@ public class OwnKingCardListener extends ClickListener {
     }
 
     {
-      // unselect all handcards
-      for (int i = 0; i < handCards.size(); i++) {
-        handCards.get(i).setSelected(false);
+      // Unselect all hand cards via player.getHandCards() so we always use the
+      // current list — sortHandCards() and the post-swap re-add can replace the
+      // underlying ArrayList, so the stored handCards field becomes stale and
+      // would miss cards added after the last show() call (e.g. the old king
+      // pushed back into hand by a coup swap).
+      for (Card c : player.getHandCards()) {
+        c.setSelected(false);
       }
       // Selecting own king cancels any pending coup-swap auto-select
       player.getPlayerTurn().setCoupSwapPendingCardId(-1);
@@ -79,8 +83,12 @@ public class OwnKingCardListener extends ClickListener {
         kingCard.setSelected(true);
       }
     }
-    ;
-
+    // Trigger a screen rebuild so a fresh OwnKingCardListener is attached to
+    // the current board king — after a coup/Warlord swap the old listener
+    // still references the previous king Card object, so without a rebuild the
+    // first click on the new king goes to a stale listener and has no visible
+    // effect.
+    gameState.setUpdateState(true);
   }
 
 }

--- a/core/src/com/mygdx/game/listeners/OwnPlaceholderListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnPlaceholderListener.java
@@ -44,7 +44,7 @@ public class OwnPlaceholderListener extends ClickListener {
   @Override
   public void clicked(InputEvent event, float x, float y) {
     if (player.getSelectedHandCards().size() == 1) {
-      if (player.canMobilize()) {
+      if (player.canPutDefCard()) {
         Card cardToPlace = player.getSelectedHandCards().get(0);
         int cardId = cardToPlace.getCardId();
         int positionId = placeholderCard.getPositionId();

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -692,8 +692,18 @@ class GameState {
 
   warlordKingSwap(playerIdx, oldKingCardId, newKingCardId) {
     const p = this.players[playerIdx];
-    if ((p.warlordAttacks || 0) <= 0) {
-      console.log(`warlordKingSwap: rejected — player ${playerIdx} has no attacks remaining`);
+    // Accept either a Warlord swap (consumes warlordAttacks) or a coup swap
+    // (player has zero defense cards on the board — costs only the per-turn
+    // take/put-defense actions, tracked client-side). Without this, a coup
+    // swap is rejected by the server and the next stateUpdate reverts the
+    // king on the client, leaving the visible "new king" detached from the
+    // actual kingCard reference and unresponsive to clicks until the next turn.
+    const hasWarlord = (p.warlordAttacks || 0) > 0;
+    const defCount = Object.keys(p.defCards || {}).length
+        + Object.keys(p.topDefCards || {}).length;
+    const isCoup = defCount === 0;
+    if (!hasWarlord && !isCoup) {
+      console.log(`warlordKingSwap: rejected — player ${playerIdx} has no Warlord attacks and still has defense cards`);
       return;
     }
     const handIdx = p.hand.indexOf(newKingCardId);
@@ -702,8 +712,12 @@ class GameState {
     p.hand.push(oldKingCardId);
     p.kingCard = newKingCardId;
     p.kingCovered = true; // new king is always placed face-down
-    p.warlordAttacks--;
-    this.pushLog(`${this.pname(playerIdx)} swapped king (Warlord)`, true, true);
+    if (hasWarlord) {
+      p.warlordAttacks--;
+      this.pushLog(`${this.pname(playerIdx)} swapped king (Warlord)`, true, true);
+    } else {
+      this.pushLog(`${this.pname(playerIdx)} swapped king (coup)`, true, true);
+    }
   }
 
   merchantTrade(playerIdx, discardedCardId, drawnCardId) {


### PR DESCRIPTION
Closes #169

## Problem

After performing a coup swap (swapping the board king for a hand card), two regressions occurred:

1. **King not selectable**: clicking the new board king had no visual effect — it never turned green
2. **Finish Turn stuck**: clicking Finish Turn after the swap did nothing

## Root Cause

### King not selectable (`OwnKingCardListener`)
`clicked()` called `kingCard.setSelected(true)` but never triggered `gameState.setUpdateState(true)`. Without this, `show()` wouldn't run on the next render tick. If a server `stateUpdate` arrived first, it would call `show()` → `setMapPosition()` which resets selection — making the king appear unselectable permanently.

Additionally, the listener stored a reference to `handCards` at construction time. `sortHandCards()` replaces the `ArrayList` reference on the `Player` object, leaving the listener with a stale list that could miss deselecting hand cards.

### Test was broken (`king_swap.test.js`)
The test tried to "take def cards to hand" before the swap. `TakeDefCardToHandListener` enforces a limit of 1 per turn (`takeDefCard` decrements to 0 after the first). With only 1 def card removed, `hasDefCards` remained `true`, so the coup swap condition `(!hasDefCards || hasWarlord) && takeDefCard > 0` was never met.

## Fix

- **`OwnKingCardListener`**: call `gameState.setUpdateState(true)` after `kingCard.setSelected(true)` so `show()` is triggered immediately on selection
- **`OwnKingCardListener`**: iterate `player.getHandCards()` at click time instead of using the stored (potentially stale) `handCards` field  
- **`king_swap.test.js`**: replace "take to hand" with "discard to cemetery" for all 3 def cards — cemetery discards have no per-turn limit, so all 3 slots are cleared (`hasDefCards = false`) while `takeDefCard` stays `> 0`

## Verification

E2E test `king_swap.test.js` passes (2/2) on the deployed app. Screenshots confirm:
- `07_king_selected_pre_swap`: board king turns green when clicked ✓
- `08_after_coup_swap`: swap executed, old king now in hand ✓  
- `09_new_king_selected`: new board king is clickable ✓
- `10_after_finish_turn_post_swap`: Finish Turn advances game to "expose a defense card" dialog ✓