### PR TITLE
feat: interactive hero tutorials for all 12 heroes (#171)

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -4711,6 +4711,13 @@ public class GameScreen extends ScreenAdapter {
         // Note: turn notification is fired in the socket listener callback (not here)
         // so it works even when the tab is hidden and the render loop is paused.
       }
+      // Issue #171: track the previous player index here (not only in show()) so that
+      // MY_TURN_START fires correctly even when multiple stateUpdates arrive in the same
+      // render frame (e.g. the bot plays and finishes its turn synchronously, sending both
+      // "bot's turn" and "player's turn again" before the next requestAnimationFrame tick).
+      if (isHeroTutorial && heroTutorialStep >= 0) {
+        heroTutorialPrevPlayerIdx = prevCurrentIdx;
+      }
       gameState.setCurrentPlayer(serverCurrentIdx);
 
       // Broadcast own Reservists count on every stateUpdate so all clients always see the

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -3564,7 +3564,7 @@ public class GameScreen extends ScreenAdapter {
       handStage.addActor(spectatorLabel);
     } else if (isMyTurn && (currentPlayer.getPlayerTurn().isAttackPending() || pendingAttackBroadcast != null)) {
       finishTurnButton.setVisible(false);
-    } else if (isMyTurn && pendingExposeCard && !isTutorial && !isHeroTutorial) {
+    } else if (isMyTurn && pendingExposeCard) {
       finishTurnButton.setVisible(false);
       // Self-heal: if there is no covered defense card to expose (e.g. state
       // changed before the overlay rebuild), drop the flag and fall through
@@ -3594,9 +3594,7 @@ public class GameScreen extends ScreenAdapter {
         public void clicked(InputEvent event, float x, float y) {
           if (checkedPenalty) { super.clicked(event, x, y); return; }
           checkedPenalty = true;
-          // Skip the covered-card expose penalty in any tutorial: players start
-          // with covered defense cards and are not expected to have flipped them.
-          if (!isTutorial && !isHeroTutorial && currentPlayer.getPlayerTurn().getAttackCounter() == 0) {
+          if (currentPlayer.getPlayerTurn().getAttackCounter() == 0) {
             boolean hasCoveredCard = false;
             for (Card c : currentPlayer.getDefCards().values()) {
               if (c.isCovered()) { hasCoveredCard = true; break; }

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -158,6 +158,12 @@ public class GameScreen extends ScreenAdapter {
   private boolean isTutorial = false;
   private int tutorialStep = 0;
   private int tutorialDefenseBaseline = -1; // defense card count when DEFENSE step started; -1 = unset
+  // Issue #171: hero-specific interactive tutorial. Independent state machine
+  // running alongside (but mutually exclusive with) the basic tutorial.
+  private boolean isHeroTutorial = false;
+  private String heroTutorialName = null;
+  private int heroTutorialStep = 0;
+  private TutorialStepDef[] heroTutorialSteps = null;
   private JSONArray activityLog = new JSONArray();
   // Emit Reservists count to other clients once on first render (before any stateUpdate fires)
   private boolean initialReservistsBroadcastDone = false;
@@ -208,6 +214,16 @@ public class GameScreen extends ScreenAdapter {
     players = gameState.getPlayers();
     currentPlayer = players.get(this.playerIndex);
     this.isTutorial = centralizedState.optBoolean("isTutorial", false);
+    // Issue #171: hero tutorial detection — overrides the basic tutorial flow.
+    String htn = centralizedState.optString("heroTutorialName", null);
+    if (htn != null && !htn.isEmpty() && !"null".equals(htn)) {
+      this.heroTutorialName = htn;
+      this.heroTutorialSteps = HeroTutorialSteps.forHero(htn);
+      if (this.heroTutorialSteps != null) {
+        this.isHeroTutorial = true;
+        this.isTutorial = false; // hero tutorial owns the overlay; basic flow disabled
+      }
+    }
 
     // Single stateUpdate listener — replaces all specific sync events
     final int notifyPlayerIdx = this.playerIndex; // capture field before parameter shadows it
@@ -715,6 +731,8 @@ public class GameScreen extends ScreenAdapter {
       addMenuButtonToOverlay();
       if (isTutorial && tutorialStep >= 0) {
         buildTutorialOverlay();
+      } else if (isHeroTutorial && heroTutorialStep >= 0) {
+        buildHeroTutorialOverlay();
       }
     }
   }
@@ -1597,6 +1615,7 @@ public class GameScreen extends ScreenAdapter {
             e.printStackTrace();
           }
           tutorialAdvance(TUTORIAL_STEP_PLUNDER);
+          tutorialAdvanceHook("PLUNDER");
           pt.getPendingAttackCards().clear();
           pt.getPendingAttackOwnDefCards().clear();
           pt.resetReservistAttackBonus();
@@ -3587,6 +3606,7 @@ public class GameScreen extends ScreenAdapter {
           }
           super.clicked(event, x, y);
           tutorialAdvance(TUTORIAL_STEP_ENDTURN);
+          tutorialAdvanceHook("FINISH_TURN");
         }
       };
       finishTurnButton.addListener(finishTurnButtonListener);
@@ -3762,6 +3782,7 @@ public class GameScreen extends ScreenAdapter {
             ftData.put("currentPlayerIndex", gameState.getCurrentPlayerIndex());
             socket.emit("finishTurn", ftData);
             tutorialAdvance(TUTORIAL_STEP_ENDTURN);
+            tutorialAdvanceHook("FINISH_TURN");
           } catch (JSONException ex) { ex.printStackTrace(); }
           pendingExposeCard = false;
           gameState.setUpdateState(true);
@@ -4044,7 +4065,7 @@ public class GameScreen extends ScreenAdapter {
    * Blocking steps show a full-screen overlay with title/body/button.
    * Non-blocking steps show a guidance banner with bannerTitle/bannerText.
    */
-  private static final class TutorialStepDef {
+  static final class TutorialStepDef {
     final boolean blocking;
     // Blocking overlay fields (used when blocking == true)
     final String title;
@@ -4053,6 +4074,11 @@ public class GameScreen extends ScreenAdapter {
     // Guidance banner fields (used when blocking == false)
     final String bannerTitle;
     final String bannerText;
+    // Hero-tutorial: action hook string. When set on a banner step, the hero
+    // tutorial advances when tutorialAdvanceHook(hook) is called. Null = no hook.
+    final String hook;
+    // Hero-tutorial: marks the final "complete" step (shows Back to Menu / Keep Playing).
+    final boolean terminal;
 
     /** Blocking overlay step. */
     TutorialStepDef(String title, String body, String buttonLabel) {
@@ -4062,6 +4088,8 @@ public class GameScreen extends ScreenAdapter {
       this.buttonLabel = buttonLabel;
       this.bannerTitle = "";
       this.bannerText = "";
+      this.hook = null;
+      this.terminal = false;
     }
 
     /** Non-blocking banner step. */
@@ -4072,6 +4100,37 @@ public class GameScreen extends ScreenAdapter {
       this.buttonLabel = null;
       this.bannerTitle = bannerTitle;
       this.bannerText = bannerText;
+      this.hook = null;
+      this.terminal = false;
+    }
+
+    /** Hero-tutorial blocking step (with terminal flag). */
+    TutorialStepDef(String title, String body, String buttonLabel, boolean terminal) {
+      this.blocking = true;
+      this.title = title;
+      this.body = body;
+      this.buttonLabel = buttonLabel;
+      this.bannerTitle = "";
+      this.bannerText = "";
+      this.hook = null;
+      this.terminal = terminal;
+    }
+
+    /** Hero-tutorial banner step with auto-advance hook (private; use {@link #banner}). */
+    private TutorialStepDef(boolean bannerMarker, String bannerTitle, String bannerText, String hook) {
+      this.blocking = false;
+      this.title = "";
+      this.body = "";
+      this.buttonLabel = null;
+      this.bannerTitle = bannerTitle;
+      this.bannerText = bannerText;
+      this.hook = hook;
+      this.terminal = false;
+    }
+
+    /** Factory: hero-tutorial banner with auto-advance hook. */
+    static TutorialStepDef banner(String bannerTitle, String bannerText, String hook) {
+      return new TutorialStepDef(true, bannerTitle, bannerText, hook);
     }
   }
 
@@ -4340,6 +4399,167 @@ public class GameScreen extends ScreenAdapter {
     overlayStage.addActor(skipBtn);
   }
 
+  // ── Hero tutorial overlay (Issue #171) ──────────────────────────────────────
+
+  /** Advances the hero tutorial when the current step's hook matches. */
+  private void tutorialAdvanceHook(String hook) {
+    if (!isHeroTutorial || heroTutorialStep < 0 || hook == null) return;
+    if (heroTutorialSteps == null || heroTutorialStep >= heroTutorialSteps.length) return;
+    String stepHook = heroTutorialSteps[heroTutorialStep].hook;
+    if (hook.equals(stepHook)) {
+      heroTutorialStep++;
+      gameState.setUpdateState(true);
+    }
+  }
+
+  /** Builds the hero-tutorial overlay (blocking info or non-blocking banner). */
+  private void buildHeroTutorialOverlay() {
+    if (heroTutorialSteps == null || heroTutorialStep < 0
+        || heroTutorialStep >= heroTutorialSteps.length) return;
+    TutorialStepDef step = heroTutorialSteps[heroTutorialStep];
+    if (step.blocking) {
+      buildHeroBlockingOverlay(step);
+    } else {
+      buildHeroBanner(step);
+    }
+  }
+
+  private void buildHeroBlockingOverlay(final TutorialStepDef step) {
+    Image bg = new Image(MyGdxGame.skin, "white");
+    bg.setFillParent(true);
+    bg.setColor(0f, 0f, 0f, 0.88f);
+    overlayStage.addActor(bg);
+
+    Table outer = new Table();
+    outer.setFillParent(true);
+    outer.center().pad(20f);
+
+    Label heroLbl = new Label(heroTutorialName + " Tutorial", MyGdxGame.skin);
+    heroLbl.setColor(1f, 1f, 1f, 0.5f);
+    outer.add(heroLbl).padBottom(2).row();
+
+    int total = heroTutorialSteps.length;
+    Label stepLabel = new Label("Step " + (heroTutorialStep + 1) + " / " + total, MyGdxGame.skin);
+    stepLabel.setColor(1f, 1f, 1f, 0.5f);
+    outer.add(stepLabel).padBottom(6).row();
+
+    Label titleLbl = new Label(step.title, MyGdxGame.skin);
+    titleLbl.setColor(Color.GOLD);
+    outer.add(titleLbl).padBottom(14).row();
+
+    Label bodyLbl = new Label(step.body, MyGdxGame.skin);
+    bodyLbl.setWrap(true);
+    outer.add(bodyLbl).width(390f).padBottom(24).row();
+
+    if (step.terminal) {
+      TextButton exitBtn = new TextButton("Back to Menu", MyGdxGame.skin);
+      exitBtn.addListener(new ClickListener() {
+        @Override public void clicked(InputEvent event, float x, float y) {
+          heroTutorialStep = -1;
+          emitGiveUp();
+        }
+      });
+      outer.add(exitBtn).width(280).height(50).padBottom(10).row();
+
+      TextButton keepBtn = new TextButton("Keep Playing", MyGdxGame.skin);
+      keepBtn.addListener(new ClickListener() {
+        @Override public void clicked(InputEvent event, float x, float y) {
+          heroTutorialStep = -1;
+          overlayStage.clear();
+          addMenuButtonToOverlay();
+          gameState.setUpdateState(true);
+        }
+      });
+      outer.add(keepBtn).width(280).height(50).row();
+    } else {
+      String btnLabel = step.buttonLabel != null ? step.buttonLabel : "Got it!";
+      TextButton gotItBtn = new TextButton(btnLabel, MyGdxGame.skin);
+      gotItBtn.addListener(new ClickListener() {
+        @Override public void clicked(InputEvent event, float x, float y) {
+          heroTutorialStep++;
+          overlayStage.clear();
+          addMenuButtonToOverlay();
+          buildHeroTutorialOverlay();
+        }
+      });
+      outer.add(gotItBtn).width(280).height(52).row();
+
+      TextButton skipBtn = new TextButton("Skip Tutorial", MyGdxGame.skin);
+      skipBtn.addListener(new ClickListener() {
+        @Override public void clicked(InputEvent event, float x, float y) {
+          heroTutorialStep = -1;
+          overlayStage.clear();
+          addMenuButtonToOverlay();
+          gameState.setUpdateState(true);
+        }
+      });
+      outer.add(skipBtn).width(200).height(40).padTop(8).row();
+    }
+
+    overlayStage.addActor(outer);
+  }
+
+  private void buildHeroBanner(TutorialStepDef step) {
+    float bannerH = 88f;
+    float bannerY = MyGdxGame.HEIGHT - bannerH - 2f;
+
+    Image bannerBg = new Image(MyGdxGame.skin, "white");
+    bannerBg.setSize(MyGdxGame.WIDTH, bannerH);
+    bannerBg.setPosition(0, bannerY);
+    bannerBg.setColor(0f, 0.05f, 0.2f, 0.92f);
+    overlayStage.addActor(bannerBg);
+
+    Table banner = new Table();
+    banner.setSize(MyGdxGame.WIDTH, bannerH);
+    banner.setPosition(0, bannerY);
+    banner.top().padTop(6f).padLeft(10f).padRight(10f);
+
+    int total = heroTutorialSteps.length;
+    Label stepLbl = new Label("Step " + (heroTutorialStep + 1) + "/" + total + "  ", MyGdxGame.skin);
+    stepLbl.setColor(1f, 1f, 1f, 0.55f);
+    Label titleLbl = new Label(step.bannerTitle, MyGdxGame.skin);
+    titleLbl.setColor(Color.GOLD);
+
+    Table topRow = new Table();
+    topRow.add(stepLbl);
+    topRow.add(titleLbl).left();
+    banner.add(topRow).left().padBottom(4f).row();
+
+    Label bodyLbl = new Label(step.bannerText, MyGdxGame.skin);
+    bodyLbl.setWrap(true);
+    banner.add(bodyLbl).width(MyGdxGame.WIDTH - 20f).left().row();
+
+    overlayStage.addActor(banner);
+
+    TextButton skipBtn = new TextButton("Skip", MyGdxGame.skin);
+    skipBtn.setSize(70f, 30f);
+    skipBtn.setPosition(MyGdxGame.WIDTH - 75f, bannerY + bannerH - 34f);
+    skipBtn.addListener(new ClickListener() {
+      @Override public void clicked(InputEvent event, float x, float y) {
+        heroTutorialStep = -1;
+        overlayStage.clear();
+        addMenuButtonToOverlay();
+        gameState.setUpdateState(true);
+      }
+    });
+    overlayStage.addActor(skipBtn);
+
+    // Manual "Next" button so the player can advance past steps whose hook
+    // they may not be able to satisfy in the current state.
+    TextButton nextBtn = new TextButton("Next ►", MyGdxGame.skin);
+    nextBtn.setSize(90f, 30f);
+    nextBtn.setPosition(MyGdxGame.WIDTH - 170f, bannerY + bannerH - 34f);
+    nextBtn.addListener(new ClickListener() {
+      @Override public void clicked(InputEvent event, float x, float y) {
+        heroTutorialStep++;
+        overlayStage.clear();
+        addMenuButtonToOverlay();
+        buildHeroTutorialOverlay();
+      }
+    });
+    overlayStage.addActor(nextBtn);
+  }
+
   private void emitGiveUp() {
     if (socket == null) return;
     try {
@@ -4446,6 +4666,7 @@ public class GameScreen extends ScreenAdapter {
       payload.put("positionId", positionId);
       socket.emit("takeDefCard", payload);
       tutorialAdvance(TUTORIAL_STEP_TAKE_DEF_FIRST);
+      tutorialAdvanceHook("TAKE_DEF");
     } catch (JSONException e) { e.printStackTrace(); }
   }
 
@@ -4458,6 +4679,7 @@ public class GameScreen extends ScreenAdapter {
       payload.put("cardId", cardId);
       socket.emit("putDefCard", payload);
       tutorialAdvance(TUTORIAL_STEP_DEFENSE);
+      tutorialAdvanceHook("PUT_DEF");
     } catch (JSONException e) { e.printStackTrace(); }
   }
 

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -164,6 +164,9 @@ public class GameScreen extends ScreenAdapter {
   private String heroTutorialName = null;
   private int heroTutorialStep = 0;
   private TutorialStepDef[] heroTutorialSteps = null;
+  // Tracks the previous frame's currentPlayerIndex so we can detect a turn flip
+  // from bot back to player and fire the MY_TURN_START hook exactly once.
+  private int heroTutorialPrevPlayerIdx = -1;
   private JSONArray activityLog = new JSONArray();
   // Emit Reservists count to other clients once on first render (before any stateUpdate fires)
   private boolean initialReservistsBroadcastDone = false;
@@ -723,6 +726,17 @@ public class GameScreen extends ScreenAdapter {
       if (tutorialStep == TUTORIAL_STEP_WAITING && gameState.getCurrentPlayerIndex() == playerIndex) {
         tutorialStep = TUTORIAL_STEP_INFO_EXPOSE;
       }
+    }
+    // Issue #171: hero-tutorial — fire MY_TURN_START hook when control flips
+    // back from the bot to the player.
+    if (isHeroTutorial && heroTutorialStep >= 0) {
+      int curIdx = gameState.getCurrentPlayerIndex();
+      if (heroTutorialPrevPlayerIdx != -1
+          && heroTutorialPrevPlayerIdx != playerIndex
+          && curIdx == playerIndex) {
+        tutorialAdvanceHook("MY_TURN_START");
+      }
+      heroTutorialPrevPlayerIdx = curIdx;
     }
 
     if (menuOpen) {
@@ -4456,7 +4470,8 @@ public class GameScreen extends ScreenAdapter {
       exitBtn.addListener(new ClickListener() {
         @Override public void clicked(InputEvent event, float x, float y) {
           heroTutorialStep = -1;
-          emitGiveUp();
+          // Tear down the tutorial session and navigate away so the bot stops.
+          emitGiveUpAndLeave();
         }
       });
       outer.add(exitBtn).width(280).height(50).padBottom(10).row();
@@ -4488,9 +4503,7 @@ public class GameScreen extends ScreenAdapter {
       skipBtn.addListener(new ClickListener() {
         @Override public void clicked(InputEvent event, float x, float y) {
           heroTutorialStep = -1;
-          overlayStage.clear();
-          addMenuButtonToOverlay();
-          gameState.setUpdateState(true);
+          emitGiveUpAndLeave();
         }
       });
       outer.add(skipBtn).width(200).height(40).padTop(8).row();
@@ -4537,9 +4550,7 @@ public class GameScreen extends ScreenAdapter {
     skipBtn.addListener(new ClickListener() {
       @Override public void clicked(InputEvent event, float x, float y) {
         heroTutorialStep = -1;
-        overlayStage.clear();
-        addMenuButtonToOverlay();
-        gameState.setUpdateState(true);
+        emitGiveUpAndLeave();
       }
     });
     overlayStage.addActor(skipBtn);

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -3564,7 +3564,7 @@ public class GameScreen extends ScreenAdapter {
       handStage.addActor(spectatorLabel);
     } else if (isMyTurn && (currentPlayer.getPlayerTurn().isAttackPending() || pendingAttackBroadcast != null)) {
       finishTurnButton.setVisible(false);
-    } else if (isMyTurn && pendingExposeCard) {
+    } else if (isMyTurn && pendingExposeCard && !isTutorial && !isHeroTutorial) {
       finishTurnButton.setVisible(false);
       // Self-heal: if there is no covered defense card to expose (e.g. state
       // changed before the overlay rebuild), drop the flag and fall through
@@ -3594,7 +3594,9 @@ public class GameScreen extends ScreenAdapter {
         public void clicked(InputEvent event, float x, float y) {
           if (checkedPenalty) { super.clicked(event, x, y); return; }
           checkedPenalty = true;
-          if (currentPlayer.getPlayerTurn().getAttackCounter() == 0) {
+          // Skip the covered-card expose penalty in any tutorial: players start
+          // with covered defense cards and are not expected to have flipped them.
+          if (!isTutorial && !isHeroTutorial && currentPlayer.getPlayerTurn().getAttackCounter() == 0) {
             boolean hasCoveredCard = false;
             for (Card c : currentPlayer.getDefCards().values()) {
               if (c.isCovered()) { hasCoveredCard = true; break; }

--- a/core/src/com/mygdx/game/HeroTutorialSteps.java
+++ b/core/src/com/mygdx/game/HeroTutorialSteps.java
@@ -1,0 +1,388 @@
+package com.mygdx.game;
+
+/**
+ * Issue #171: per-hero interactive tutorial step sequences.
+ *
+ * Each sequence is a list of {@link GameScreen.TutorialStepDef} entries.
+ * Steps are either:
+ *   - blocking info overlays the player dismisses with "Got it!"
+ *   - non-blocking banner steps that auto-advance when an action hook fires
+ *     (e.g. "FINISH_TURN", "PLUNDER", "PUT_DEF", "TAKE_DEF")
+ *   - a final terminal blocking step (Back to Menu / Keep Playing)
+ *
+ * Banner steps also have a "Next" button so the player can skip past
+ * action gates they cannot or do not want to satisfy.
+ */
+final class HeroTutorialSteps {
+  private HeroTutorialSteps() {}
+
+  static GameScreen.TutorialStepDef[] forHero(String heroName) {
+    if ("Mercenaries".equals(heroName))     return MERCENARIES;
+    if ("Marshal".equals(heroName))         return MARSHAL;
+    if ("Spy".equals(heroName))             return SPY;
+    if ("Battery Tower".equals(heroName))   return BATTERY_TOWER;
+    if ("Merchant".equals(heroName))        return MERCHANT;
+    if ("Priest".equals(heroName))          return PRIEST;
+    if ("Reservists".equals(heroName))      return RESERVISTS;
+    if ("Banneret".equals(heroName))        return BANNERET;
+    if ("Saboteurs".equals(heroName))       return SABOTEURS;
+    if ("Fortified Tower".equals(heroName)) return FORTIFIED_TOWER;
+    if ("Magician".equals(heroName))        return MAGICIAN;
+    if ("Warlord".equals(heroName))         return WARLORD;
+    return null;
+  }
+
+  // Common terminal step shared by all hero tutorials.
+  private static final GameScreen.TutorialStepDef DONE =
+    new GameScreen.TutorialStepDef(
+      "Tutorial Complete!",
+      "Well done! You've practised the key abilities of this hero.\n\n"
+      + "You can keep playing this game freely or return to the menu to try another tutorial.",
+      "Back to Menu",
+      true);
+
+  // Mercenaries
+  private static final GameScreen.TutorialStepDef[] MERCENARIES = new GameScreen.TutorialStepDef[] {
+    new GameScreen.TutorialStepDef(
+      "Mercenaries",
+      "You start with the Mercenaries hero. Mercenaries add +1 to attack or defense.\n\n"
+      + "You have up to 8 units. 4 units recover at the start of each new turn.\n\n"
+      + "This tutorial walks you through both uses.",
+      "Begin"),
+    new GameScreen.TutorialStepDef(
+      "Defense Boost",
+      "To boost a defense card:\n"
+      + "  1. Tap the Mercenaries hero icon to select it.\n"
+      + "  2. Tap one of your own defense cards (top half adds, bottom half removes).\n\n"
+      + "A pawn icon and +N label appears on the boosted card.\n\n"
+      + "Try it now: place mercenaries on a defense card.",
+      null),
+    GameScreen.TutorialStepDef.banner(
+      "Try the Defense Boost",
+      "Tap Mercenaries, then tap one of your own defense cards to add a unit.",
+      "MERC_DEF_BOOST"),
+    new GameScreen.TutorialStepDef(
+      "Remove Mercenaries",
+      "Tap Mercenaries again, then tap the bottom half of the boosted defense card. "
+      + "The unit returns to your pool.\n\n"
+      + "Mercenaries on a defense card are also lost if that card is taken away by a successful attack.",
+      null),
+    new GameScreen.TutorialStepDef(
+      "Attack Boost",
+      "To boost an attack:\n"
+      + "  1. Select hand cards for an attack.\n"
+      + "  2. Tap the Mercenaries hero icon - each tap adds +1 attack strength.\n\n"
+      + "Then plunder a deck or attack an enemy as usual.",
+      null),
+    GameScreen.TutorialStepDef.banner(
+      "Try a Plunder with Mercenaries",
+      "Select a hand card, tap Mercenaries to boost, then tap a harvest deck.",
+      "PLUNDER"),
+    new GameScreen.TutorialStepDef(
+      "Recovery",
+      "Mercenaries lost in a failed attack are gone forever.\n\n"
+      + "Each new turn you regain up to 4 units (capped at 8 total). "
+      + "End your turn now and watch your pool refill.",
+      null),
+    GameScreen.TutorialStepDef.banner(
+      "Finish Your Turn",
+      "Click 'Finish turn' to let the bot play and see your mercenaries recover.",
+      "FINISH_TURN"),
+    DONE,
+  };
+
+  // Marshal
+  private static final GameScreen.TutorialStepDef[] MARSHAL = new GameScreen.TutorialStepDef[] {
+    new GameScreen.TutorialStepDef(
+      "Marshal",
+      "Normally you have 1 take + 1 put action for defense cards per turn.\n\n"
+      + "With the Marshal, both limits are replaced by a shared pool of 3 actions "
+      + "you can mix and match in any combination.\n\n"
+      + "It's passive - no activation needed.",
+      "Begin"),
+    GameScreen.TutorialStepDef.banner(
+      "Take a Defense Card",
+      "Tap one of your defense cards to take it back to your hand. With the Marshal you can "
+      + "take more than one this turn.",
+      "TAKE_DEF"),
+    GameScreen.TutorialStepDef.banner(
+      "Place a Defense Card",
+      "Select a hand card, then tap an empty shield slot to place it. "
+      + "You can do this multiple times this turn.",
+      "PUT_DEF"),
+    new GameScreen.TutorialStepDef(
+      "Use the Pool Freely",
+      "You have actions left! Try discarding all 3 defense cards, then placing 3 fresh ones - "
+      + "all in a single Marshal turn. When done, finish your turn.",
+      null),
+    GameScreen.TutorialStepDef.banner(
+      "Finish Your Turn",
+      "Click 'Finish turn' when you're satisfied with your defense layout.",
+      "FINISH_TURN"),
+    DONE,
+  };
+
+  // Spy
+  private static final GameScreen.TutorialStepDef[] SPY = new GameScreen.TutorialStepDef[] {
+    new GameScreen.TutorialStepDef(
+      "Spy",
+      "The Spy lets you flip a face-down enemy defense card so you (and only you) can see its value.\n\n"
+      + "You start with 1 flip per turn.",
+      "Begin"),
+    new GameScreen.TutorialStepDef(
+      "Flip an Enemy Card",
+      "Tap the Spy hero icon to select it, then tap one of the bot's face-down defense cards. "
+      + "The card flips face-up for you only.",
+      null),
+    new GameScreen.TutorialStepDef(
+      "Extend Mode",
+      "If you sacrifice one of your own defense cards to the Spy, you gain +2 extra flips this turn (max 3 total).\n\n"
+      + "To extend: with Spy selected, tap one of your own defense cards.",
+      null),
+    GameScreen.TutorialStepDef.banner(
+      "Finish Your Turn",
+      "Spy reveals reset each turn. Click 'Finish turn' when done.",
+      "FINISH_TURN"),
+    DONE,
+  };
+
+  // Battery Tower
+  private static final GameScreen.TutorialStepDef[] BATTERY_TOWER = new GameScreen.TutorialStepDef[] {
+    new GameScreen.TutorialStepDef(
+      "Battery Tower",
+      "When one of your defense cards or your king is attacked, you can spend a charge to "
+      + "completely deny that attack. You start with 1 charge that auto-refills each turn.\n\n"
+      + "To trigger this scenario the bot must attack you - finish your turn first.",
+      "Begin"),
+    GameScreen.TutorialStepDef.banner(
+      "Finish Your Turn",
+      "Click 'Finish turn' to let the bot play. You can place defense cards first if you wish.",
+      "FINISH_TURN"),
+    new GameScreen.TutorialStepDef(
+      "Defend with Battery Tower",
+      "If the bot attacks one of your defense cards or your king this turn, an Allow / Deny prompt appears.\n\n"
+      + "Tap 'Battery Tower' (Deny) to block the attack. The attacker's hand cards are then locked for the rest of their turn and their attack cards are revealed to you.",
+      null),
+    new GameScreen.TutorialStepDef(
+      "Recovery",
+      "Battery Tower automatically refills 1 charge at the start of each new turn - "
+      + "so you always have one ready when defending.",
+      null),
+    DONE,
+  };
+
+  // Merchant
+  private static final GameScreen.TutorialStepDef[] MERCHANT = new GameScreen.TutorialStepDef[] {
+    new GameScreen.TutorialStepDef(
+      "Merchant",
+      "The Merchant trades a hand card for a new random card from the deck (once per turn).\n\n"
+      + "You see the new card first and can choose to keep it or try a 2nd time.",
+      "Begin"),
+    new GameScreen.TutorialStepDef(
+      "Trade a Card",
+      "Tap the Merchant hero icon, then tap the hand card you want to replace.",
+      null),
+    new GameScreen.TutorialStepDef(
+      "Keep or Re-roll",
+      "After the new card is shown:\n"
+      + "  - Keep it: old card is discarded, new card stays.\n"
+      + "  - 2nd chance: discard the new card and draw again (uses your trade action again).",
+      null),
+    GameScreen.TutorialStepDef.banner(
+      "Finish Your Turn",
+      "Click 'Finish turn' when done. You get 1 trade per new turn.",
+      "FINISH_TURN"),
+    DONE,
+  };
+
+  // Priest
+  private static final GameScreen.TutorialStepDef[] PRIEST = new GameScreen.TutorialStepDef[] {
+    new GameScreen.TutorialStepDef(
+      "Priest",
+      "After initiating an attack on an enemy defense card, the Priest can attempt to convert "
+      + "one of the defender's hand cards to your attack symbol - adding it to your hand.\n\n"
+      + "You have up to 2 conversion attempts per turn.",
+      "Begin"),
+    new GameScreen.TutorialStepDef(
+      "Set Your Attack Symbol",
+      "Select a hand card. The symbol on that card becomes your attack symbol for this turn. "
+      + "The Priest needs an attack symbol locked in.",
+      null),
+    new GameScreen.TutorialStepDef(
+      "Initiate an Attack",
+      "Tap an enemy defense card to start an attack. After the attack overlay appears, the Priest can act.",
+      null),
+    new GameScreen.TutorialStepDef(
+      "Convert a Card",
+      "Tap the Priest hero icon and follow the conversion dialog. The bot's hand is revealed and you pick a card.",
+      null),
+    GameScreen.TutorialStepDef.banner(
+      "Finish Your Turn",
+      "Click 'Finish turn' when done. Conversion attempts reset each new turn.",
+      "FINISH_TURN"),
+    DONE,
+  };
+
+  // Reservists
+  private static final GameScreen.TutorialStepDef[] RESERVISTS = new GameScreen.TutorialStepDef[] {
+    new GameScreen.TutorialStepDef(
+      "Reservists",
+      "Reservists provide both a passive defense bonus and an on-demand attack boost.\n\n"
+      + "You start with 2 ready units (max 4). 2 recover each new turn.",
+      "Begin"),
+    new GameScreen.TutorialStepDef(
+      "Defense Bonus (Passive)",
+      "Each ready reservist automatically adds +1 to your king card's defense strength. "
+      + "Look at your king - the bonus is reflected in the displayed strength.",
+      null),
+    new GameScreen.TutorialStepDef(
+      "Attack Boost",
+      "During an attack, when the attack preview overlay shows, a 'Reservists +1' button appears "
+      + "if spending a reservist would flip a failing attack to a success.\n\n"
+      + "Tap it to spend one unit and add +1 to the attack.",
+      null),
+    GameScreen.TutorialStepDef.banner(
+      "Try an Attack",
+      "Plunder a harvest deck or attack an enemy defense card. If the attack is failing and you "
+      + "have ready reservists, the boost button will appear.",
+      "PLUNDER"),
+    GameScreen.TutorialStepDef.banner(
+      "Finish Your Turn",
+      "Click 'Finish turn'. 2 reservists will recover for next turn.",
+      "FINISH_TURN"),
+    DONE,
+  };
+
+  // Banneret
+  private static final GameScreen.TutorialStepDef[] BANNERET = new GameScreen.TutorialStepDef[] {
+    new GameScreen.TutorialStepDef(
+      "Banneret",
+      "The Banneret unlocks two passive abilities: Dual Symbol and Defense-to-Attack.",
+      "Begin"),
+    new GameScreen.TutorialStepDef(
+      "Dual Symbol (Passive)",
+      "When you start an attack, a paired symbol unlocks automatically:\n"
+      + "  - Hearts <-> Diamonds\n"
+      + "  - Spades <-> Clubs\n\n"
+      + "Both symbols can be combined in the same attack round.",
+      null),
+    new GameScreen.TutorialStepDef(
+      "Defense-to-Attack (Passive)",
+      "Your own defense cards can also be used as attack cards. Select a mix of hand cards "
+      + "and own defense cards, then attack as usual. Used defense cards are discarded.",
+      null),
+    GameScreen.TutorialStepDef.banner(
+      "Try a Plunder",
+      "Select hand cards (and optionally own defense cards) and plunder a harvest deck. "
+      + "Notice the dual symbol unlocking.",
+      "PLUNDER"),
+    GameScreen.TutorialStepDef.banner(
+      "Finish Your Turn",
+      "Click 'Finish turn' when done.",
+      "FINISH_TURN"),
+    DONE,
+  };
+
+  // Saboteurs
+  private static final GameScreen.TutorialStepDef[] SABOTEURS = new GameScreen.TutorialStepDef[] {
+    new GameScreen.TutorialStepDef(
+      "Saboteurs",
+      "You have 2 saboteur units. Place them on empty enemy defense slots to block them - "
+      + "the enemy cannot place a defense card there.\n\n"
+      + "If the enemy attacks through a sabotaged slot and wins, the saboteur is destroyed "
+      + "and takes 2 turns to recover.",
+      "Begin"),
+    new GameScreen.TutorialStepDef(
+      "Sabotage an Empty Slot",
+      "Tap the Saboteurs hero icon, then tap an empty defense slot of the bot.\n\n"
+      + "(If the bot has no empty slots, attack one of their defense cards first to clear a slot.)",
+      null),
+    new GameScreen.TutorialStepDef(
+      "Removal & Recovery",
+      "The enemy can remove a saboteur on their turn. If they attack through it and win, "
+      + "the saboteur dies - recover takes 2 turns.",
+      null),
+    GameScreen.TutorialStepDef.banner(
+      "Finish Your Turn",
+      "Click 'Finish turn' to let the bot play.",
+      "FINISH_TURN"),
+    DONE,
+  };
+
+  // Fortified Tower
+  private static final GameScreen.TutorialStepDef[] FORTIFIED_TOWER = new GameScreen.TutorialStepDef[] {
+    new GameScreen.TutorialStepDef(
+      "Fortified Tower",
+      "The Fortified Tower lets you place a second card face-down on top of an existing defense slot - "
+      + "an attacker must break through the top card before reaching the card below.",
+      "Begin"),
+    new GameScreen.TutorialStepDef(
+      "Stack a Defense Card",
+      "  1. Select a hand card with the same symbol as a defense card.\n"
+      + "  2. Tap the Fortified Tower hero icon to select it.\n"
+      + "  3. Tap one of your own defense slots - the hand card stacks on top.",
+      null),
+    new GameScreen.TutorialStepDef(
+      "Take the Stack Back",
+      "You can take both cards back in one defense-take action by tapping the stacked slot. "
+      + "The Marshal hero pairs nicely here.",
+      null),
+    GameScreen.TutorialStepDef.banner(
+      "Finish Your Turn",
+      "Click 'Finish turn' when done. The Tower's stack action refreshes each new turn.",
+      "FINISH_TURN"),
+    DONE,
+  };
+
+  // Magician
+  private static final GameScreen.TutorialStepDef[] MAGICIAN = new GameScreen.TutorialStepDef[] {
+    new GameScreen.TutorialStepDef(
+      "Magician",
+      "Once per turn, the Magician replaces all cards in an enemy defense slot with random "
+      + "cards drawn from the deck. The replaced cards go to the cemetery.\n\n"
+      + "The new cards' face state is inverted: face-down becomes face-up and vice versa.",
+      "Begin"),
+    new GameScreen.TutorialStepDef(
+      "Cast Card Replacement",
+      "Tap the Magician hero icon, then tap any enemy defense card. "
+      + "The slot is rebuilt with new cards from the deck.",
+      null),
+    new GameScreen.TutorialStepDef(
+      "Stacked Slots",
+      "Stacked slots (two cards) are replaced layer by layer - both cards swap.",
+      null),
+    GameScreen.TutorialStepDef.banner(
+      "Finish Your Turn",
+      "Click 'Finish turn' when done. The spell recharges next turn.",
+      "FINISH_TURN"),
+    DONE,
+  };
+
+  // Warlord
+  private static final GameScreen.TutorialStepDef[] WARLORD = new GameScreen.TutorialStepDef[] {
+    new GameScreen.TutorialStepDef(
+      "Warlord",
+      "The Warlord grants two abilities: a Direct King Attack (once per turn) and "
+      + "a King Swap (swap your king with a hand card without spending the king attack action).",
+      "Begin"),
+    new GameScreen.TutorialStepDef(
+      "Direct King Attack",
+      "Your king can attack an enemy defense card directly - no need to clear your own defense cards first.\n\n"
+      + "  1. Tap the Warlord hero icon to select it.\n"
+      + "  2. Tap an enemy defense card.\n\n"
+      + "Cannot be combined with hand cards in the same attack.",
+      null),
+    new GameScreen.TutorialStepDef(
+      "King Swap",
+      "Swap your king with a hand card any time:\n"
+      + "  1. Tap your own king card to select it.\n"
+      + "  2. Tap the hand card you want as the new king.\n\n"
+      + "The old king moves to your hand. This does NOT consume your normal once-per-turn king attack.",
+      null),
+    GameScreen.TutorialStepDef.banner(
+      "Finish Your Turn",
+      "Click 'Finish turn' when done.",
+      "FINISH_TURN"),
+    DONE,
+  };
+}

--- a/core/src/com/mygdx/game/HeroTutorialSteps.java
+++ b/core/src/com/mygdx/game/HeroTutorialSteps.java
@@ -122,13 +122,13 @@ final class HeroTutorialSteps {
   private static final GameScreen.TutorialStepDef[] SPY = new GameScreen.TutorialStepDef[] {
     new GameScreen.TutorialStepDef(
       "Spy",
-      "The Spy lets you flip a face-down enemy defense card so you (and only you) can see its value.\n\n"
+      "The Spy lets you flip a face-down enemy defense card so everyone can see its value.\n\n"
       + "You start with 1 flip per turn.",
       "Begin"),
     new GameScreen.TutorialStepDef(
       "Flip an Enemy Card",
       "Tap the Spy hero icon to select it, then tap one of the bot's face-down defense cards. "
-      + "The card flips face-up for you only.",
+      + "The card flips face-up and its value becomes visible to all players.",
       null),
     GameScreen.TutorialStepDef.banner(
       "Try Flipping",
@@ -206,25 +206,23 @@ final class HeroTutorialSteps {
   private static final GameScreen.TutorialStepDef[] PRIEST = new GameScreen.TutorialStepDef[] {
     new GameScreen.TutorialStepDef(
       "Priest",
-      "After initiating an attack on an enemy defense card, the Priest can attempt to convert "
+      "After completing an attack or plunder, the Priest can attempt to convert "
       + "one of the defender's hand cards to your attack symbol - adding it to your hand.\n\n"
+      + "Your attack symbol is set automatically when you make your first attack or plunder. "
       + "You have up to 2 conversion attempts per turn.",
       "Begin"),
     new GameScreen.TutorialStepDef(
-      "Step 1: Set Your Attack Symbol",
-      "Select a hand card. The symbol on that card becomes your attack symbol for this turn. "
-      + "The Priest needs an attack symbol locked in.",
-      null),
-    new GameScreen.TutorialStepDef(
-      "Step 2: Initiate an Attack & Convert",
-      "Tap an enemy defense card to start an attack. After the attack overlay appears, tap the "
-      + "Priest hero icon and follow the conversion dialog. The bot's hand is revealed and you pick a card.",
+      "Perform an Attack or Plunder",
+      "Select hand cards and attack an enemy defense card or plunder a harvest deck. "
+      + "This sets your attack symbol for this turn.\n\n"
+      + "After the action resolves, you can tap the Priest hero icon to open the conversion dialog. "
+      + "The bot's hand is revealed and you pick a card to convert.",
       null),
     GameScreen.TutorialStepDef.banner(
       "Try the Priest",
-      "Select a hand card, tap an enemy defense card, then tap Priest in the overlay. "
+      "Plunder a deck or attack an enemy, then tap Priest to convert a card. "
       + "Click Next when done.",
-      null),
+      "PLUNDER"),
     GameScreen.TutorialStepDef.banner(
       "Finish Your Turn",
       "Click 'Finish turn' when done. Conversion attempts reset each new turn.",
@@ -326,18 +324,20 @@ final class HeroTutorialSteps {
   private static final GameScreen.TutorialStepDef[] FORTIFIED_TOWER = new GameScreen.TutorialStepDef[] {
     new GameScreen.TutorialStepDef(
       "Fortified Tower",
-      "The Fortified Tower lets you place a second card face-down on top of an existing defense slot - "
-      + "an attacker must break through the top card before reaching the card below.",
+      "The Fortified Tower lets you stack a second card on top of a defense slot. "
+      + "When the slot is attacked, the values of both cards are added together - "
+      + "making it much harder to break through.",
       "Begin"),
     new GameScreen.TutorialStepDef(
       "Stack a Defense Card",
-      "  1. Select a hand card with the same symbol as a defense card.\n"
-      + "  2. Tap the Fortified Tower hero icon to select it.\n"
+      "To stack a card:\n"
+      + "  1. Tap the Fortified Tower hero icon to select it.\n"
+      + "  2. Tap a hand card to select it.\n"
       + "  3. Tap one of your own defense slots - the hand card stacks on top.",
       null),
     GameScreen.TutorialStepDef.banner(
       "Try Stacking",
-      "Select a hand card, tap Fortified Tower, then tap one of your own defense slots. "
+      "Tap Fortified Tower, select a hand card, then tap one of your own defense slots. "
       + "Click Next when done.",
       null),
     new GameScreen.TutorialStepDef(

--- a/core/src/com/mygdx/game/HeroTutorialSteps.java
+++ b/core/src/com/mygdx/game/HeroTutorialSteps.java
@@ -206,22 +206,16 @@ final class HeroTutorialSteps {
   private static final GameScreen.TutorialStepDef[] PRIEST = new GameScreen.TutorialStepDef[] {
     new GameScreen.TutorialStepDef(
       "Priest",
-      "After completing an attack or plunder, the Priest can attempt to convert "
-      + "one of the defender's hand cards to your attack symbol - adding it to your hand.\n\n"
-      + "Your attack symbol is set automatically when you make your first attack or plunder. "
-      + "You have up to 2 conversion attempts per turn.",
+      "The Priest lets you steal a card from the enemy's hand - but only cards matching your attack symbol.",
       "Begin"),
     new GameScreen.TutorialStepDef(
-      "Perform an Attack or Plunder",
-      "Select hand cards and attack an enemy defense card or plunder a harvest deck. "
-      + "This sets your attack symbol for this turn.\n\n"
-      + "After the action resolves, you can tap the Priest hero icon to open the conversion dialog. "
-      + "The bot's hand is revealed and you pick a card to convert.",
+      "How to Use the Priest",
+      "To steal an enemy hand card:\n  1. Tap the Priest hero icon to select it.\n  2. Tap the enemy's hand card deck.\n  3. Pick a card matching your attack symbol to take it.\n\n"
+      + "Note: you must make at least one attack or plunder first this turn to set your attack symbol.",
       null),
     GameScreen.TutorialStepDef.banner(
       "Try the Priest",
-      "Plunder a deck or attack an enemy, then tap Priest to convert a card. "
-      + "Click Next when done.",
+      "First plunder or attack to set your symbol, then tap Priest and tap the bot's hand deck. Click Next when done.",
       "PLUNDER"),
     GameScreen.TutorialStepDef.banner(
       "Finish Your Turn",

--- a/core/src/com/mygdx/game/HeroTutorialSteps.java
+++ b/core/src/com/mygdx/game/HeroTutorialSteps.java
@@ -3,15 +3,18 @@ package com.mygdx.game;
 /**
  * Issue #171: per-hero interactive tutorial step sequences.
  *
- * Each sequence is a list of {@link GameScreen.TutorialStepDef} entries.
- * Steps are either:
- *   - blocking info overlays the player dismisses with "Got it!"
- *   - non-blocking banner steps that auto-advance when an action hook fires
- *     (e.g. "FINISH_TURN", "PLUNDER", "PUT_DEF", "TAKE_DEF")
- *   - a final terminal blocking step (Back to Menu / Keep Playing)
+ * Design pattern: each instructional blocking overlay is followed by a
+ * non-blocking banner that pauses the flow (advancing on a relevant action
+ * hook where available, otherwise via the manual Next button on the banner).
+ * This prevents subsequent explanations from popping up before the player
+ * has had a chance to actually try the previous instruction.
  *
- * Banner steps also have a "Next" button so the player can skip past
- * action gates they cannot or do not want to satisfy.
+ * Hooks fired by GameScreen:
+ *   FINISH_TURN     - player clicked Finish Turn
+ *   PLUNDER         - player resolved a plunder
+ *   PUT_DEF         - player placed a defense card
+ *   TAKE_DEF        - player took a defense card back
+ *   MY_TURN_START   - player turn started (after bot turn ended)
  */
 final class HeroTutorialSteps {
   private HeroTutorialSteps() {}
@@ -46,26 +49,18 @@ final class HeroTutorialSteps {
     new GameScreen.TutorialStepDef(
       "Mercenaries",
       "You start with the Mercenaries hero. Mercenaries add +1 to attack or defense.\n\n"
-      + "You have up to 8 units. 4 units recover at the start of each new turn.\n\n"
-      + "This tutorial walks you through both uses.",
+      + "You have up to 8 units. 4 units recover at the start of each new turn.",
       "Begin"),
     new GameScreen.TutorialStepDef(
       "Defense Boost",
       "To boost a defense card:\n"
       + "  1. Tap the Mercenaries hero icon to select it.\n"
       + "  2. Tap one of your own defense cards (top half adds, bottom half removes).\n\n"
-      + "A pawn icon and +N label appears on the boosted card.\n\n"
-      + "Try it now: place mercenaries on a defense card.",
+      + "A pawn icon and +N label appears on the boosted card.",
       null),
     GameScreen.TutorialStepDef.banner(
       "Try the Defense Boost",
-      "Tap Mercenaries, then tap one of your own defense cards to add a unit.",
-      "MERC_DEF_BOOST"),
-    new GameScreen.TutorialStepDef(
-      "Remove Mercenaries",
-      "Tap Mercenaries again, then tap the bottom half of the boosted defense card. "
-      + "The unit returns to your pool.\n\n"
-      + "Mercenaries on a defense card are also lost if that card is taken away by a successful attack.",
+      "Tap Mercenaries, then tap one of your own defense cards. Click Next when done.",
       null),
     new GameScreen.TutorialStepDef(
       "Attack Boost",
@@ -88,6 +83,10 @@ final class HeroTutorialSteps {
       "Finish Your Turn",
       "Click 'Finish turn' to let the bot play and see your mercenaries recover.",
       "FINISH_TURN"),
+    GameScreen.TutorialStepDef.banner(
+      "Bot is Playing...",
+      "Wait for the bot to finish its turn.",
+      "MY_TURN_START"),
     DONE,
   };
 
@@ -97,23 +96,20 @@ final class HeroTutorialSteps {
       "Marshal",
       "Normally you have 1 take + 1 put action for defense cards per turn.\n\n"
       + "With the Marshal, both limits are replaced by a shared pool of 3 actions "
-      + "you can mix and match in any combination.\n\n"
-      + "It's passive - no activation needed.",
+      + "you can mix and match in any combination. It's passive - no activation needed.",
       "Begin"),
     GameScreen.TutorialStepDef.banner(
       "Take a Defense Card",
-      "Tap one of your defense cards to take it back to your hand. With the Marshal you can "
-      + "take more than one this turn.",
+      "Tap one of your defense cards to take it back to your hand.",
       "TAKE_DEF"),
     GameScreen.TutorialStepDef.banner(
       "Place a Defense Card",
-      "Select a hand card, then tap an empty shield slot to place it. "
-      + "You can do this multiple times this turn.",
+      "Select a hand card, then tap an empty shield slot to place it.",
       "PUT_DEF"),
     new GameScreen.TutorialStepDef(
       "Use the Pool Freely",
       "You have actions left! Try discarding all 3 defense cards, then placing 3 fresh ones - "
-      + "all in a single Marshal turn. When done, finish your turn.",
+      + "all in a single Marshal turn. Click Got it when ready to finish your turn.",
       null),
     GameScreen.TutorialStepDef.banner(
       "Finish Your Turn",
@@ -134,10 +130,18 @@ final class HeroTutorialSteps {
       "Tap the Spy hero icon to select it, then tap one of the bot's face-down defense cards. "
       + "The card flips face-up for you only.",
       null),
+    GameScreen.TutorialStepDef.banner(
+      "Try Flipping",
+      "Tap Spy, then tap an enemy face-down defense card. Click Next when done.",
+      null),
     new GameScreen.TutorialStepDef(
       "Extend Mode",
       "If you sacrifice one of your own defense cards to the Spy, you gain +2 extra flips this turn (max 3 total).\n\n"
       + "To extend: with Spy selected, tap one of your own defense cards.",
+      null),
+    GameScreen.TutorialStepDef.banner(
+      "Try Extending (Optional)",
+      "Tap Spy, then tap one of your own defense cards to gain +2 flips. Or click Next to skip.",
       null),
     GameScreen.TutorialStepDef.banner(
       "Finish Your Turn",
@@ -158,14 +162,16 @@ final class HeroTutorialSteps {
       "Finish Your Turn",
       "Click 'Finish turn' to let the bot play. You can place defense cards first if you wish.",
       "FINISH_TURN"),
-    new GameScreen.TutorialStepDef(
+    GameScreen.TutorialStepDef.banner(
       "Defend with Battery Tower",
-      "If the bot attacks one of your defense cards or your king this turn, an Allow / Deny prompt appears.\n\n"
-      + "Tap 'Battery Tower' (Deny) to block the attack. The attacker's hand cards are then locked for the rest of their turn and their attack cards are revealed to you.",
-      null),
+      "If the bot attacks one of your defense cards or your king, an Allow / Deny prompt appears. "
+      + "Tap 'Battery Tower' (Deny) to block the attack.",
+      "MY_TURN_START"),
     new GameScreen.TutorialStepDef(
-      "Recovery",
-      "Battery Tower automatically refills 1 charge at the start of each new turn - "
+      "After the Bot's Turn",
+      "If you denied an attack, the attacker's hand cards are locked for the rest of their turn "
+      + "and their attack cards are revealed to you.\n\n"
+      + "Battery Tower automatically refills 1 charge at the start of each new turn - "
       + "so you always have one ready when defending.",
       null),
     DONE,
@@ -180,13 +186,14 @@ final class HeroTutorialSteps {
       "Begin"),
     new GameScreen.TutorialStepDef(
       "Trade a Card",
-      "Tap the Merchant hero icon, then tap the hand card you want to replace.",
-      null),
-    new GameScreen.TutorialStepDef(
-      "Keep or Re-roll",
-      "After the new card is shown:\n"
+      "Tap the Merchant hero icon, then tap the hand card you want to replace.\n\n"
+      + "After the new card is shown:\n"
       + "  - Keep it: old card is discarded, new card stays.\n"
-      + "  - 2nd chance: discard the new card and draw again (uses your trade action again).",
+      + "  - 2nd chance: discard the new card and draw again.",
+      null),
+    GameScreen.TutorialStepDef.banner(
+      "Try the Merchant",
+      "Tap Merchant, then tap a hand card to trade it. Click Next when done.",
       null),
     GameScreen.TutorialStepDef.banner(
       "Finish Your Turn",
@@ -204,17 +211,19 @@ final class HeroTutorialSteps {
       + "You have up to 2 conversion attempts per turn.",
       "Begin"),
     new GameScreen.TutorialStepDef(
-      "Set Your Attack Symbol",
+      "Step 1: Set Your Attack Symbol",
       "Select a hand card. The symbol on that card becomes your attack symbol for this turn. "
       + "The Priest needs an attack symbol locked in.",
       null),
     new GameScreen.TutorialStepDef(
-      "Initiate an Attack",
-      "Tap an enemy defense card to start an attack. After the attack overlay appears, the Priest can act.",
+      "Step 2: Initiate an Attack & Convert",
+      "Tap an enemy defense card to start an attack. After the attack overlay appears, tap the "
+      + "Priest hero icon and follow the conversion dialog. The bot's hand is revealed and you pick a card.",
       null),
-    new GameScreen.TutorialStepDef(
-      "Convert a Card",
-      "Tap the Priest hero icon and follow the conversion dialog. The bot's hand is revealed and you pick a card.",
+    GameScreen.TutorialStepDef.banner(
+      "Try the Priest",
+      "Select a hand card, tap an enemy defense card, then tap Priest in the overlay. "
+      + "Click Next when done.",
       null),
     GameScreen.TutorialStepDef.banner(
       "Finish Your Turn",
@@ -297,10 +306,14 @@ final class HeroTutorialSteps {
       "Tap the Saboteurs hero icon, then tap an empty defense slot of the bot.\n\n"
       + "(If the bot has no empty slots, attack one of their defense cards first to clear a slot.)",
       null),
+    GameScreen.TutorialStepDef.banner(
+      "Try Sabotaging",
+      "Tap Saboteurs, then tap an empty enemy defense slot. Click Next when done.",
+      null),
     new GameScreen.TutorialStepDef(
       "Removal & Recovery",
       "The enemy can remove a saboteur on their turn. If they attack through it and win, "
-      + "the saboteur dies - recover takes 2 turns.",
+      + "the saboteur dies - recovery takes 2 turns.",
       null),
     GameScreen.TutorialStepDef.banner(
       "Finish Your Turn",
@@ -322,6 +335,11 @@ final class HeroTutorialSteps {
       + "  2. Tap the Fortified Tower hero icon to select it.\n"
       + "  3. Tap one of your own defense slots - the hand card stacks on top.",
       null),
+    GameScreen.TutorialStepDef.banner(
+      "Try Stacking",
+      "Select a hand card, tap Fortified Tower, then tap one of your own defense slots. "
+      + "Click Next when done.",
+      null),
     new GameScreen.TutorialStepDef(
       "Take the Stack Back",
       "You can take both cards back in one defense-take action by tapping the stacked slot. "
@@ -340,16 +358,17 @@ final class HeroTutorialSteps {
       "Magician",
       "Once per turn, the Magician replaces all cards in an enemy defense slot with random "
       + "cards drawn from the deck. The replaced cards go to the cemetery.\n\n"
-      + "The new cards' face state is inverted: face-down becomes face-up and vice versa.",
+      + "The new cards' face state is inverted: face-down becomes face-up and vice versa. "
+      + "Stacked slots (two cards) are replaced layer by layer - both cards swap.",
       "Begin"),
     new GameScreen.TutorialStepDef(
       "Cast Card Replacement",
       "Tap the Magician hero icon, then tap any enemy defense card. "
       + "The slot is rebuilt with new cards from the deck.",
       null),
-    new GameScreen.TutorialStepDef(
-      "Stacked Slots",
-      "Stacked slots (two cards) are replaced layer by layer - both cards swap.",
+    GameScreen.TutorialStepDef.banner(
+      "Try the Magician",
+      "Tap Magician, then tap any enemy defense card. Click Next when done.",
       null),
     GameScreen.TutorialStepDef.banner(
       "Finish Your Turn",
@@ -372,12 +391,20 @@ final class HeroTutorialSteps {
       + "  2. Tap an enemy defense card.\n\n"
       + "Cannot be combined with hand cards in the same attack.",
       null),
+    GameScreen.TutorialStepDef.banner(
+      "Try a Direct King Attack",
+      "Tap Warlord, then tap an enemy defense card. Click Next when done (or to skip).",
+      null),
     new GameScreen.TutorialStepDef(
       "King Swap",
       "Swap your king with a hand card any time:\n"
       + "  1. Tap your own king card to select it.\n"
       + "  2. Tap the hand card you want as the new king.\n\n"
       + "The old king moves to your hand. This does NOT consume your normal once-per-turn king attack.",
+      null),
+    GameScreen.TutorialStepDef.banner(
+      "Try a King Swap (Optional)",
+      "Tap your own king, then tap a hand card to swap. Or click Next to skip.",
       null),
     GameScreen.TutorialStepDef.banner(
       "Finish Your Turn",

--- a/core/src/com/mygdx/game/TutorialSelectScreen.java
+++ b/core/src/com/mygdx/game/TutorialSelectScreen.java
@@ -13,6 +13,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.utils.viewport.FitViewport;
 import com.mygdx.game.net.SocketClient;
+import com.mygdx.game.util.JSONException;
 import com.mygdx.game.util.JSONObject;
 
 /**
@@ -69,7 +70,15 @@ public class TutorialSelectScreen extends AbstractScreen {
       btn.addListener(new ClickListener() {
         @Override
         public void clicked(InputEvent event, float x, float y) {
-          game.setScreen(new HeroTutorialScreen(game, socket, heroName));
+          // Issue #171: launch an interactive bot game scenario for this hero
+          // (replaces the prior text-only HeroTutorialScreen).
+          try {
+            JSONObject payload = new JSONObject();
+            payload.put("heroName", heroName);
+            socket.emit("createHeroTutorial", payload);
+          } catch (JSONException ex) {
+            ex.printStackTrace();
+          }
         }
       });
       heroTable.add(btn).width(320f).height(48f).padBottom(6f).row();

--- a/server/bot.js
+++ b/server/bot.js
@@ -276,20 +276,16 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     var atkAfterPlunder = botChooseDefAttack(gs, idx, false);
     if (atkAfterPlunder) {
       var apDefCardId = gs.players[atkAfterPlunder.defenderIdx].defCards[atkAfterPlunder.positionId];
-      gs.setAttackPreview({ attackerIdx: idx, defenderIdx: atkAfterPlunder.defenderIdx,
-                             positionId: atkAfterPlunder.positionId, level: 0,
-                             attackingSymbol: atkAfterPlunder.symbol, attackingSymbol2: 'none',
-                             success: atkAfterPlunder.success, attackCardIds: atkAfterPlunder.cardIds,
-                             defCardIds: apDefCardId != null ? [apDefCardId] : [] });
+      var apPreview = { attackerIdx: idx, defenderIdx: atkAfterPlunder.defenderIdx,
+                        positionId: atkAfterPlunder.positionId, level: 0,
+                        attackingSymbol: atkAfterPlunder.symbol, attackingSymbol2: 'none',
+                        success: atkAfterPlunder.success, attackCardIds: atkAfterPlunder.cardIds,
+                        defCardIds: apDefCardId != null ? [apDefCardId] : [] };
+      gs.setAttackPreview(apPreview);
       io.to(sess.id).emit('stateUpdate', gs.serialize());
-      var captured = atkAfterPlunder;
-      setTimeout(function() {
-        gs.defAttackResolved(idx, captured.defenderIdx, captured.positionId,
-                              0, captured.success, captured.cardIds, false, []);
-        io.to(sess.id).emit('stateUpdate', gs.serialize());
-        checkAndHandleWinner(sess);
+      botDoDefAttackWithBatteryCheck(sess, gs, atkAfterPlunder, apPreview, function() {
         botFinishTurn(sess, gs, idx, true);
-      }, BOT_ACTION_DELAY);
+      });
     } else {
       botFinishTurn(sess, gs, idx, false);
     }
@@ -353,6 +349,51 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
       }
     }
     return false;
+  }
+
+  // Returns true if the given player has Battery Tower with at least one charge.
+  function defenderHasBatteryWithCharges(gs, defenderIdx) {
+    var d = gs.players[defenderIdx];
+    return d && (d.heroes || []).indexOf('Battery Tower') !== -1 && (d.batteryTowerCharges || 0) > 0;
+  }
+
+  // Perform a defense-card attack as the bot, respecting Battery Tower on the defender side.
+  // atkPreviewData: the object already passed to gs.setAttackPreview()
+  // resolveCallback: called after the attack is resolved (or denied) — no args.
+  // If defender has Battery Tower, emits batteryDefenseCheck and stores pending state on sess.
+  // Otherwise resolves immediately after BOT_ACTION_DELAY.
+  function botDoDefAttackWithBatteryCheck(sess, gs, atkChoice, atkPreviewData, resolveCallback) {
+    var defenderIdx = atkChoice.defenderIdx;
+    if (defenderHasBatteryWithCharges(gs, defenderIdx)) {
+      // Pause: store the pending attack on the session, then emit batteryDefenseCheck.
+      // Resolution happens in the batteryAllowAttack / batteryDenyAttack socket handlers.
+      sess.pendingBotBatteryAttack = {
+        gs: gs,
+        attackerIdx: atkPreviewData.attackerIdx,
+        defenderIdx: defenderIdx,
+        positionId: atkChoice.positionId,
+        success: atkChoice.success,
+        cardIds: atkChoice.cardIds,
+        callback: resolveCallback
+      };
+      io.to(sess.id).emit('batteryDefenseCheck', {
+        attackerIdx: atkPreviewData.attackerIdx,
+        targetPlayerIdx: defenderIdx,
+        positionId: atkChoice.positionId,
+        level: 0,
+        isKing: false,
+        success: atkChoice.success,
+        attackCardIds: atkChoice.cardIds
+      });
+    } else {
+      setTimeout(function() {
+        gs.defAttackResolved(atkPreviewData.attackerIdx, defenderIdx, atkChoice.positionId,
+                             0, atkChoice.success, atkChoice.cardIds, false, []);
+        io.to(sess.id).emit('stateUpdate', gs.serialize());
+        checkAndHandleWinner(sess);
+        resolveCallback();
+      }, BOT_ACTION_DELAY);
+    }
   }
 
   // Determine the hero name the bot should acquire from a joker sacrifice oracle card.
@@ -623,20 +664,16 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
       var atkChoice = botChooseDefAttack(gs, idx, false);
       if (atkChoice) {
         var atkDefCardId = gs.players[atkChoice.defenderIdx].defCards[atkChoice.positionId];
-        gs.setAttackPreview({ attackerIdx: idx, defenderIdx: atkChoice.defenderIdx,
-                               positionId: atkChoice.positionId, level: 0,
-                               attackingSymbol: atkChoice.symbol, attackingSymbol2: 'none',
-                               success: atkChoice.success, attackCardIds: atkChoice.cardIds,
-                               defCardIds: atkDefCardId != null ? [atkDefCardId] : [] });
+        var atkPreview = { attackerIdx: idx, defenderIdx: atkChoice.defenderIdx,
+                           positionId: atkChoice.positionId, level: 0,
+                           attackingSymbol: atkChoice.symbol, attackingSymbol2: 'none',
+                           success: atkChoice.success, attackCardIds: atkChoice.cardIds,
+                           defCardIds: atkDefCardId != null ? [atkDefCardId] : [] };
+        gs.setAttackPreview(atkPreview);
         io.to(sess.id).emit('stateUpdate', gs.serialize());
-        var capturedAtk = atkChoice;
-        setTimeout(function() {
-          gs.defAttackResolved(idx, capturedAtk.defenderIdx, capturedAtk.positionId,
-                                0, capturedAtk.success, capturedAtk.cardIds, false, []);
-          io.to(sess.id).emit('stateUpdate', gs.serialize());
-          checkAndHandleWinner(sess);
+        botDoDefAttackWithBatteryCheck(sess, gs, atkChoice, atkPreview, function() {
           botFinishTurn(sess, gs, idx, true);
-        }, BOT_ACTION_DELAY);
+        });
         return;
       }
 
@@ -644,20 +681,16 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
       var scoutChoice = botChooseDefAttack(gs, idx, true);
       if (scoutChoice) {
         var scoutDefCardId = gs.players[scoutChoice.defenderIdx].defCards[scoutChoice.positionId];
-        gs.setAttackPreview({ attackerIdx: idx, defenderIdx: scoutChoice.defenderIdx,
-                               positionId: scoutChoice.positionId, level: 0,
-                               attackingSymbol: scoutChoice.symbol, attackingSymbol2: 'none',
-                               success: scoutChoice.success, attackCardIds: scoutChoice.cardIds,
-                               defCardIds: scoutDefCardId != null ? [scoutDefCardId] : [] });
+        var scoutPreview = { attackerIdx: idx, defenderIdx: scoutChoice.defenderIdx,
+                             positionId: scoutChoice.positionId, level: 0,
+                             attackingSymbol: scoutChoice.symbol, attackingSymbol2: 'none',
+                             success: scoutChoice.success, attackCardIds: scoutChoice.cardIds,
+                             defCardIds: scoutDefCardId != null ? [scoutDefCardId] : [] };
+        gs.setAttackPreview(scoutPreview);
         io.to(sess.id).emit('stateUpdate', gs.serialize());
-        var capturedScout = scoutChoice;
-        setTimeout(function() {
-          gs.defAttackResolved(idx, capturedScout.defenderIdx, capturedScout.positionId,
-                                0, false, capturedScout.cardIds, false, []);
-          io.to(sess.id).emit('stateUpdate', gs.serialize());
-          checkAndHandleWinner(sess);
+        botDoDefAttackWithBatteryCheck(sess, gs, scoutChoice, scoutPreview, function() {
           botFinishTurn(sess, gs, idx, true);
-        }, BOT_ACTION_DELAY);
+        });
         return;
       }
 

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -848,6 +848,7 @@ class GameState {
       pendingHeroSelection: this.pendingHeroSelection || null,
       pendingHeroAuction: this.pendingHeroAuction || null,
       isTutorial: this.isTutorial || false,
+      heroTutorialName: this.heroTutorialName || null,
     };
   }
 

--- a/server/index.js
+++ b/server/index.js
@@ -1553,6 +1553,38 @@ io.on('connection', function(socket) {
     bot.playBotTurnIfNeeded(sess);
   });
 
+  // Issue #171: hero-specific interactive tutorial. Same setup as the basic
+  // tutorial (player vs bot, isTutorial=true) but the player starts with the
+  // chosen hero already in their inventory.
+  socket.on('createHeroTutorial', function(data) {
+    leaveCurrentSession(socket);
+    var heroName = (data && data.heroName) ? String(data.heroName) : null;
+    if (!heroName) return;
+    var sess = createSession('Hero Tutorial: ' + heroName, false, 6, false);
+    sess.isTutorial = true;
+    var player = connectedPlayers[socket.id];
+    var userName = player ? player.name : 'Player';
+    var botId = 'bot_' + sess.id;
+    sess.users = [
+      makeUser(socket.id, userName),
+      makeUser(botId, 'Tutorial Bot')
+    ];
+    socket.join(sess.id);
+    socketToSession[socket.id] = sess.id;
+    sess.gameState = new GameState(sess.users, { startingCards: 8 });
+    sess.gameState.isTutorial = true;
+    sess.gameState.heroTutorialName = heroName;
+    // Grant the chosen hero to the player (player index 0).
+    sess.gameState.heroAcquired(0, heroName);
+    io.to(socket.id).emit('gameState', {
+      playerIndex: 0,
+      gameState: sess.gameState.serialize()
+    });
+    broadcastSessionList();
+    broadcastPlayerList();
+    bot.playBotTurnIfNeeded(sess);
+  });
+
   socket.on('giveUp', function(data) {
     var sess = getSession(socket.id);
     if (!sess || !sess.gameState) return;

--- a/server/index.js
+++ b/server/index.js
@@ -1476,12 +1476,60 @@ io.on('connection', function(socket) {
   socket.on('batteryAllowAttack', function(data) {
     var sess = getSession(socket.id);
     if (!sess) return;
+    // If this allow is a response to a bot attack that was paused for Battery Tower check:
+    if (sess.pendingBotBatteryAttack) {
+      var pending = sess.pendingBotBatteryAttack;
+      sess.pendingBotBatteryAttack = null;
+      var gs = pending.gs;
+      // Relay to attacker side too (shows the "attack allowed" banner on client)
+      socket.to(sess.id).emit('batteryAllowAttack', data);
+      setTimeout(function() {
+        gs.defAttackResolved(pending.attackerIdx, pending.defenderIdx, pending.positionId,
+                             0, pending.success, pending.cardIds, false, []);
+        io.to(sess.id).emit('stateUpdate', gs.serialize());
+        checkAndHandleWinner(sess);
+        pending.callback();
+      }, 1500);
+      return;
+    }
     socket.to(sess.id).emit('batteryAllowAttack', data);
   });
 
   socket.on('batteryDenyAttack', function(data) {
     var sess = getSession(socket.id);
     if (!sess) return;
+    // If this deny is a response to a bot attack that was paused for Battery Tower check:
+    if (sess.pendingBotBatteryAttack) {
+      var pending = sess.pendingBotBatteryAttack;
+      sess.pendingBotBatteryAttack = null;
+      var gs = pending.gs;
+      // Spend the Battery Tower charge on the server
+      var defPlayer = gs.players[pending.defenderIdx];
+      if (defPlayer && (defPlayer.batteryTowerCharges || 0) > 0) {
+        defPlayer.batteryTowerCharges--;
+      }
+      // Re-cover the defense card that was revealed by setAttackPreview
+      if (defPlayer && pending.positionId >= 1) {
+        if (!defPlayer.defCardsCovered) defPlayer.defCardsCovered = {};
+        if (defPlayer.defCards[pending.positionId] !== undefined) defPlayer.defCardsCovered[pending.positionId] = true;
+        if (!defPlayer.topDefCardsCovered) defPlayer.topDefCardsCovered = {};
+        if (defPlayer.topDefCards && defPlayer.topDefCards[pending.positionId] !== undefined)
+          defPlayer.topDefCardsCovered[pending.positionId] = true;
+      }
+      // Clear the attack preview
+      gs.pendingAttack = null;
+      // Relay deny to attacker side (shows "attack BLOCKED" banner on client)
+      socket.to(sess.id).emit('batteryDenyAttack', {
+        attackerIdx: pending.attackerIdx,
+        targetPlayerIdx: pending.defenderIdx,
+        positionId: pending.positionId,
+        isKing: false
+      });
+      io.to(sess.id).emit('stateUpdate', gs.serialize());
+      // Bot's turn continues (attack was blocked; bot doesn't need to expose since it attacked)
+      pending.callback();
+      return;
+    }
     socket.to(sess.id).emit('batteryDenyAttack', data);
   });
 

--- a/server/index.js
+++ b/server/index.js
@@ -271,8 +271,17 @@ function leaveCurrentSession(socket) {
   if (specIdx !== -1) sess.spectators.splice(specIdx, 1);
   socket.leave(sess.id);
   io.to(sess.id).emit('getUsers', getUsersWithHeroes(sess));
-  if (sess.users.length === 0 && sess.spectators.length === 0) {
+  // Destroy tutorial sessions when the human leaves: only the bot would remain
+  // and it would keep playing in a session no real user will ever rejoin.
+  var humansLeft = sess.users.filter(function(u) { return u.id.indexOf('bot_') !== 0; }).length;
+  if (sess.isTutorial && humansLeft === 0 && sess.spectators.length === 0) {
     if (sess.timer) clearInterval(sess.timer);
+    sess.gameState = null; // pending bot turns will see this and bail
+    delete sessions[sess.id];
+    console.log('Tutorial session ' + sess.id + ' deleted (human left)');
+  } else if (sess.users.length === 0 && sess.spectators.length === 0) {
+    if (sess.timer) clearInterval(sess.timer);
+    sess.gameState = null;
     delete sessions[sess.id];
     console.log('Session ' + sess.id + ' deleted (empty)');
   }


### PR DESCRIPTION
Closes #171. Replaces the prior text-only HeroTutorialScreen with an actual interactive bot game scenario for each of the 12 heroes. Each hero gets a step sequence of blocking info overlays plus non-blocking banner steps that auto-advance on player actions (FINISH_TURN, PLUNDER, PUT_DEF, TAKE_DEF). See issue comment for the per-hero scenario specifications.