### PR TITLE
Hero usability improvements (#54 #174 #175 #176 #177 #178 #179 #180)

### DIFF
--- a/core/src/com/mygdx/game/Card.java
+++ b/core/src/com/mygdx/game/Card.java
@@ -258,6 +258,15 @@ public class Card extends Actor {
     this.rotate = rotation;
   }
 
+  /**
+   * Internal rotation used by Card.draw (centered around the card's geometric centre).
+   * Distinct from {@link com.badlogic.gdx.scenes.scene2d.Actor#getRotation()} which is
+   * not used for board cards. Returned in degrees; 0 = upright, 90/-90 = sideways, 180 = upside-down.
+   */
+  public float getRotate() {
+    return rotate;
+  }
+
   public void addBoosted(int boost) {
     boosted += boost; // can be positive or negative
   }

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -1361,6 +1361,8 @@ public class GameScreen extends ScreenAdapter {
         // Issues #54, #178, #179, #180: highlight enemy def cards (and empty enemy slots
         // for Saboteurs) when the relevant attacker hero is selected.
         applyEnemyDefCardHighlight(defCard, players.get(i), currentPlayer, j);
+        // Issue #174: highlight own def cards on which the selected hand card can be stacked.
+        applyOwnDefCardFortifyHighlight(defCard, players.get(i), currentPlayer, j);
 
         // Issue #167: when Mercenaries hero is selected, overlay translucent
         // green (top half) / red (bottom half) tint on each own def card so the
@@ -5503,6 +5505,28 @@ public class GameScreen extends ScreenAdapter {
       if (m.getTrades() > 0) {
         addCardActionHighlight(handCard, new Color(1f, 0.6f, 0f, 0.32f), handStage);
       }
+    }
+  }
+
+  /**
+   * Issue #174: when the player has the Fortified Tower hero with charges and exactly
+   * one hand card is selected, highlight every own defense slot whose bottom card matches
+   * the hand card's symbol (and is not already stacked) so the player sees where the
+   * auto-stack click will work.
+   */
+  private void applyOwnDefCardFortifyHighlight(Card defCard, Player owner, Player current, int slot) {
+    if (owner != current) return;
+    if (defCard.getLevel() != 0) return;
+    if (owner.getTopDefCards().containsKey(slot)) return;
+    if (current.getSelectedHandCards().size() != 1) return;
+    com.mygdx.game.heroes.FortifiedTower ft = null;
+    for (Hero h : current.getHeroes()) {
+      if ("Fortified Tower".equals(h.getHeroName())) { ft = (com.mygdx.game.heroes.FortifiedTower) h; break; }
+    }
+    if (ft == null || ft.getDefenseExpands() <= 0) return;
+    Card handCard = current.getSelectedHandCards().get(0);
+    if (handCard.getSymbol().equals(defCard.getSymbol())) {
+      addCardActionHighlight(defCard, new Color(0.6f, 0f, 1f, 0.32f), gameStage);
     }
   }
 

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -154,6 +154,11 @@ public class GameScreen extends ScreenAdapter {
   private float batteryBotNotificationTimer = 0f;
   // Set when the current player ended their turn without attacking -- they must expose a defense card.
   private boolean pendingExposeCard = false;
+  // Static reference to the live GameScreen so listeners (e.g. OwnDefCardListener)
+  // can submit a covered-card-expose tap without us threading a parameter through
+  // every constructor call site. Set in show(), cleared in hide().
+  private static GameScreen INSTANCE = null;
+  public static GameScreen getInstance() { return INSTANCE; }
   // Tutorial mode: guided overlay steps for new players
   private boolean isTutorial = false;
   private int tutorialStep = 0;
@@ -685,6 +690,7 @@ public class GameScreen extends ScreenAdapter {
 
   @Override
   public void show() {
+    INSTANCE = this;
     MyGdxGame.setMusicTrack(null); // no music during the game
 
     players = gameState.getPlayers();
@@ -3054,10 +3060,33 @@ public class GameScreen extends ScreenAdapter {
 
     // Merchant 2nd-try reveal: display the drawn card face-up for ALL players (incl. trader),
     // and show "JOKER — lost" if the second draw was a joker. Hidden once the server clears
-    // merchantReveal on finishTurn.
+    // merchantReveal on finishTurn. The whole stage gets a transparent click-catcher so any
+    // tap dismisses the overlay (sends dismissMerchantReveal to the server, which clears
+    // lastMerchantReveal for every client on next stateUpdate).
     if (merchantRevealCardId != -1) {
       Card revealCard = Card.fromCardId(merchantRevealCardId);
       boolean isJoker = revealCard != null && "joker".equals(revealCard.getSymbol());
+      // Tap-anywhere dismiss layer (must be added FIRST so it is below the card visually
+      // but receives clicks meant for the empty area around the card).
+      Image dismissLayer = new Image(MyGdxGame.skin, "white");
+      dismissLayer.setFillParent(true);
+      dismissLayer.setColor(0f, 0f, 0f, 0.55f);
+      dismissLayer.addListener(new com.badlogic.gdx.scenes.scene2d.InputListener() {
+        @Override
+        public boolean touchDown(InputEvent event, float x, float y, int pointer, int button) {
+          // Hide locally for snappy UX, then notify the server to clear for everyone.
+          merchantRevealCardId = -1;
+          merchantRevealPlayerIdx = -1;
+          if (socket != null) {
+            JSONObject d = new JSONObject();
+            socket.emit("dismissMerchantReveal", d);
+          }
+          gameState.setUpdateState(true);
+          return true;
+        }
+      });
+      gameStage.addActor(dismissLayer);
+
       float rcw = revealCard.getDefWidth() * 1.5f;
       float rch = revealCard.getDefHeight() * 1.5f;
       revealCard.setWidth(rcw);
@@ -3065,17 +3094,33 @@ public class GameScreen extends ScreenAdapter {
       revealCard.setPosition(
           (MyGdxGame.WIDTH - rcw) / 2f,
           (MyGdxGame.WIDTH - rch) / 2f);
+      // Card itself also dismisses on tap.
+      revealCard.clearListeners();
+      revealCard.addListener(new com.badlogic.gdx.scenes.scene2d.InputListener() {
+        @Override
+        public boolean touchDown(InputEvent event, float x, float y, int pointer, int button) {
+          merchantRevealCardId = -1;
+          merchantRevealPlayerIdx = -1;
+          if (socket != null) {
+            JSONObject d = new JSONObject();
+            socket.emit("dismissMerchantReveal", d);
+          }
+          gameState.setUpdateState(true);
+          return true;
+        }
+      });
       gameStage.addActor(revealCard);
       String revealText;
       if (merchantRevealPlayerIdx == playerIndex) {
-        revealText = isJoker ? "JOKER — lost!" : "Your 2nd-try card";
+        revealText = isJoker ? "JOKER — lost! (tap to dismiss)" : "Your 2nd-try card (tap to dismiss)";
       } else {
         revealText = isJoker
-            ? "P" + merchantRevealPlayerIdx + " drew JOKER — lost!"
-            : "P" + merchantRevealPlayerIdx + " 2nd-try reveal";
+            ? "P" + merchantRevealPlayerIdx + " drew JOKER — lost! (tap to dismiss)"
+            : "P" + merchantRevealPlayerIdx + " 2nd-try reveal (tap to dismiss)";
       }
       Label revealLabel = new Label(revealText, MyGdxGame.skin);
       revealLabel.setColor(isJoker ? Color.RED : Color.GREEN);
+      revealLabel.setTouchable(com.badlogic.gdx.scenes.scene2d.Touchable.disabled);
       revealLabel.setPosition(
           revealCard.getX() + (revealCard.getWidth() - revealLabel.getPrefWidth()) / 2f,
           revealCard.getY() + revealCard.getHeight() + 2f);
@@ -3844,25 +3889,14 @@ public class GameScreen extends ScreenAdapter {
       slotBtn.setSize(btnW, slotBtn.getPrefHeight() * 1.5f);
       slotBtn.setPosition(btnX, stageH / 2f - slotBtn.getHeight() / 2f);
       btnX += btnW + 4;
-      slotBtn.addListener(new ClickListener() {
+      slotBtn.addListener(new com.badlogic.gdx.scenes.scene2d.InputListener() {
+        // Use touchDown rather than ClickListener.clicked so the event fires even if a
+        // stateUpdate destroys/recreates the slot button between touchDown and touchUp
+        // (recurring bug: "select card to expose, nothing happens").
         @Override
-        public void clicked(InputEvent event, float x, float y) {
-          // Emit BEFORE mutating local state. If a stateUpdate arrives during the
-          // click and clears handStage, the messages have already been sent and
-          // the server is the authority on turn progression.
-          try {
-            JSONObject exposeData = new JSONObject();
-            exposeData.put("playerIdx", playerIndex);
-            exposeData.put("slot", finalSlot);
-            socket.emit("exposeDefCard", exposeData);
-            JSONObject ftData = new JSONObject();
-            ftData.put("currentPlayerIndex", gameState.getCurrentPlayerIndex());
-            socket.emit("finishTurn", ftData);
-            tutorialAdvance(TUTORIAL_STEP_ENDTURN);
-            tutorialAdvanceHook("FINISH_TURN");
-          } catch (JSONException ex) { ex.printStackTrace(); }
-          pendingExposeCard = false;
-          gameState.setUpdateState(true);
+        public boolean touchDown(InputEvent event, float x, float y, int pointer, int button) {
+          submitExposeAndFinishTurn(finalSlot);
+          return true;
         }
       });
       handStage.addActor(slotBtn);
@@ -3882,6 +3916,33 @@ public class GameScreen extends ScreenAdapter {
         socket.emit("finishTurn", ftData);
       } catch (JSONException ex) { ex.printStackTrace(); }
     }
+  }
+
+  /** True when this client is in the "choose a covered defense card to expose" state. */
+  public boolean isPendingExpose() {
+    return pendingExposeCard;
+  }
+
+  /**
+   * Submit the choice of which slot to expose, then end the turn.
+   * Called by the slot buttons in {@link #addExposeCardOverlay()} and by
+   * OwnDefCardListener when the player taps a covered own defense card directly.
+   */
+  public void submitExposeAndFinishTurn(int slot) {
+    if (!pendingExposeCard) return;
+    pendingExposeCard = false;
+    try {
+      JSONObject exposeData = new JSONObject();
+      exposeData.put("playerIdx", playerIndex);
+      exposeData.put("slot", slot);
+      socket.emit("exposeDefCard", exposeData);
+      JSONObject ftData = new JSONObject();
+      ftData.put("currentPlayerIndex", gameState.getCurrentPlayerIndex());
+      socket.emit("finishTurn", ftData);
+      tutorialAdvance(TUTORIAL_STEP_ENDTURN);
+      tutorialAdvanceHook("FINISH_TURN");
+    } catch (JSONException ex) { ex.printStackTrace(); }
+    gameState.setUpdateState(true);
   }
 
   private void showHeroInfoOverlay(String heroName) {
@@ -5581,6 +5642,7 @@ public class GameScreen extends ScreenAdapter {
 
   @Override
   public void hide() {
+    if (INSTANCE == this) INSTANCE = null;
     dispose();
 
   }

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -3052,9 +3052,12 @@ public class GameScreen extends ScreenAdapter {
       gameStage.addActor(tryBtn);
     }
 
-    // Merchant 2nd-try reveal: display the drawn card face-up for all non-trading clients
-    if (merchantRevealCardId != -1 && merchantRevealPlayerIdx != playerIndex) {
+    // Merchant 2nd-try reveal: display the drawn card face-up for ALL players (incl. trader),
+    // and show "JOKER — lost" if the second draw was a joker. Hidden once the server clears
+    // merchantReveal on finishTurn.
+    if (merchantRevealCardId != -1) {
       Card revealCard = Card.fromCardId(merchantRevealCardId);
+      boolean isJoker = revealCard != null && "joker".equals(revealCard.getSymbol());
       float rcw = revealCard.getDefWidth() * 1.5f;
       float rch = revealCard.getDefHeight() * 1.5f;
       revealCard.setWidth(rcw);
@@ -3063,8 +3066,16 @@ public class GameScreen extends ScreenAdapter {
           (MyGdxGame.WIDTH - rcw) / 2f,
           (MyGdxGame.WIDTH - rch) / 2f);
       gameStage.addActor(revealCard);
-      Label revealLabel = new Label("Merch. reveal (P" + merchantRevealPlayerIdx + ")", MyGdxGame.skin);
-      revealLabel.setColor(Color.GREEN);
+      String revealText;
+      if (merchantRevealPlayerIdx == playerIndex) {
+        revealText = isJoker ? "JOKER — lost!" : "Your 2nd-try card";
+      } else {
+        revealText = isJoker
+            ? "P" + merchantRevealPlayerIdx + " drew JOKER — lost!"
+            : "P" + merchantRevealPlayerIdx + " 2nd-try reveal";
+      }
+      Label revealLabel = new Label(revealText, MyGdxGame.skin);
+      revealLabel.setColor(isJoker ? Color.RED : Color.GREEN);
       revealLabel.setPosition(
           revealCard.getX() + (revealCard.getWidth() - revealLabel.getPrefWidth()) / 2f,
           revealCard.getY() + revealCard.getHeight() + 2f);
@@ -3610,6 +3621,10 @@ public class GameScreen extends ScreenAdapter {
       finishTurnButton.setVisible(false);
     } else if (isMyTurn && pendingExposeCard) {
       finishTurnButton.setVisible(false);
+      // Defensive: also disable touch on the hidden finish-turn button so it can
+      // never absorb the slot button click after being re-added on top of the overlay
+      // (recurring bug: "finish turn does nothing").
+      finishTurnButton.setTouchable(com.badlogic.gdx.scenes.scene2d.Touchable.disabled);
       // Self-heal: if there is no covered defense card to expose (e.g. state
       // changed before the overlay rebuild), drop the flag and fall through
       // so the regular finish-turn button is shown instead of a dead overlay.
@@ -3627,11 +3642,13 @@ public class GameScreen extends ScreenAdapter {
       } else {
         pendingExposeCard = false;
         finishTurnButton.setVisible(isMyTurn);
+        finishTurnButton.setTouchable(com.badlogic.gdx.scenes.scene2d.Touchable.enabled);
         finishTurnButtonListener = new FinishTurnButtonListener(gameState, socket);
         finishTurnButton.addListener(finishTurnButtonListener);
       }
     } else {
       finishTurnButton.setVisible(isMyTurn);
+      finishTurnButton.setTouchable(com.badlogic.gdx.scenes.scene2d.Touchable.enabled);
       finishTurnButtonListener = new FinishTurnButtonListener(gameState, socket) {
         private boolean checkedPenalty = false;
         @Override
@@ -3798,8 +3815,10 @@ public class GameScreen extends ScreenAdapter {
     bg.setSize(stageW, stageH);
     bg.setPosition(0, 0);
     bg.setColor(0f, 0f, 0f, 0.72f);
-    // Block input under the overlay but don't capture clicks meant for slot buttons.
-    bg.setTouchable(com.badlogic.gdx.scenes.scene2d.Touchable.enabled);
+    // The veil is purely visual — keep it non-touchable so it can never absorb the
+    // slot button click in any race condition (recurring bug: "finish turn does
+    // nothing" when the user taps the expose slot button).
+    bg.setTouchable(com.badlogic.gdx.scenes.scene2d.Touchable.disabled);
     handStage.addActor(bg);
 
     Label prompt = new Label("No attack -- expose a defense card:", MyGdxGame.skin);
@@ -5381,14 +5400,25 @@ public class GameScreen extends ScreenAdapter {
    */
   private void addCardActionHighlight(Actor actor, Color color, com.badlogic.gdx.scenes.scene2d.Stage stage) {
     Image hi = new Image(MyGdxGame.skin.newDrawable("white", color));
-    // For rotated hand cards we want an axis-aligned overlay, so use the actor's
-    // visual width/height (swap when rotated 90°/270°).
+    // For rotated cards we want an axis-aligned overlay matching the visual bounds.
+    // Hand cards rotate via Actor.setRotation(); board cards (left/right/top players)
+    // rotate via Card's internal `rotate` field used inside Card.draw — Actor.getRotation()
+    // returns 0 in that case so we must inspect Card.getRotate() too (issue: highlight
+    // overlay was vertical on horizontally-displayed enemy cards for left/right players).
     float w = actor.getWidth();
     float h = actor.getHeight();
     float rot = actor.getRotation();
-    if (Math.abs(rot - 90f) < 1f || Math.abs(rot - 270f) < 1f || Math.abs(rot + 90f) < 1f) {
-      // Visual bounds for a rotated card: centred on (x + w/2, y + h/2),
-      // visual size (h, w).
+    if (actor instanceof Card) {
+      float cardRot = ((Card) actor).getRotate();
+      if (Math.abs(cardRot) > 0.5f) rot = cardRot;
+    }
+    // Normalise to [-180,180]
+    while (rot > 180f) rot -= 360f;
+    while (rot < -180f) rot += 360f;
+    boolean sideways = Math.abs(Math.abs(rot) - 90f) < 1f;
+    if (sideways) {
+      // Visual bounds for a card rotated 90/-90 around its centre: still centred on
+      // (x + w/2, y + h/2) but visual size is (h, w).
       float cx = actor.getX() + w / 2f;
       float cy = actor.getY() + h / 2f;
       hi.setBounds(cx - h / 2f, cy - w / 2f, h, w);
@@ -5437,7 +5467,8 @@ public class GameScreen extends ScreenAdapter {
     } else if ("Warlord".equals(name) && !defCard.isPlaceholder()) {
       com.mygdx.game.heroes.Warlord wl = (com.mygdx.game.heroes.Warlord) sel;
       if (wl.isAttackAvailable()) {
-        addCardActionHighlight(defCard, new Color(1f, 0.3f, 0.3f, 0.32f), gameStage);
+        // Issue: red highlight invisible on face-down red card backs — use bright magenta.
+        addCardActionHighlight(defCard, new Color(1f, 0.1f, 0.85f, 0.45f), gameStage);
       }
     }
   }
@@ -5457,7 +5488,7 @@ public class GameScreen extends ScreenAdapter {
     } else if ("Warlord".equals(name) && defenderHasNoDef) {
       com.mygdx.game.heroes.Warlord wl = (com.mygdx.game.heroes.Warlord) sel;
       if (wl.isAttackAvailable()) {
-        addCardActionHighlight(kingCard, new Color(1f, 0.3f, 0.3f, 0.32f), gameStage);
+        addCardActionHighlight(kingCard, new Color(1f, 0.1f, 0.85f, 0.45f), gameStage);
       }
     } else if ("Spy".equals(name) && defenderHasNoDef && kingCard.isCovered()) {
       // Spy peek on king is allowed only when all defs are face-up; here the defender has none.

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -1164,6 +1164,10 @@ public class GameScreen extends ScreenAdapter {
               gameState.getPlayers(), i, gameState);
           handCard.addListener(enemyHandCardListener);
           gameStage.addActor(handCard);
+          // Issue #175: highlight the top hand card of an enemy deck when Priest is selected.
+          if (j == handCards.size() - 1) {
+            applyEnemyHandDeckHighlight(handCard, players.get(i), currentPlayer);
+          }
         }
 
         // Count label only for other players (not the local player).
@@ -1220,6 +1224,10 @@ public class GameScreen extends ScreenAdapter {
       if (players.get(i) == currentPlayer && isMercenariesSelectedBy(currentPlayer)) {
         addMercenarySelectionHighlight(kingCard);
       }
+
+      // Issues #54, #179, #180: highlight enemy king when Magician/Warlord/Spy is selected
+      // and the appropriate conditions are met.
+      applyEnemyKingHighlight(kingCard, players.get(i), currentPlayer);
 
       if (kingCard.getBoosted() > 0) {
         TextureRegion mercenaryRegion = new TextureRegion(texMercenary, 0, 0, 512, 512);
@@ -1350,6 +1358,10 @@ public class GameScreen extends ScreenAdapter {
         }
         gameStage.addActor(defCard);
 
+        // Issues #54, #178, #179, #180: highlight enemy def cards (and empty enemy slots
+        // for Saboteurs) when the relevant attacker hero is selected.
+        applyEnemyDefCardHighlight(defCard, players.get(i), currentPlayer, j);
+
         // Issue #167: when Mercenaries hero is selected, overlay translucent
         // green (top half) / red (bottom half) tint on each own def card so the
         // player sees where to click to add or remove a mercenary. Skip if a top
@@ -1467,6 +1479,8 @@ public class GameScreen extends ScreenAdapter {
           if (players.get(i) == currentPlayer && isMercenariesSelectedBy(currentPlayer)) {
             addMercenarySelectionHighlight(topDefCard);
           }
+          // Issues #54, #178, #179, #180: enemy-targeting hero highlight on top def card.
+          applyEnemyDefCardHighlight(topDefCard, players.get(i), currentPlayer, j);
         }
       }
 
@@ -3135,6 +3149,30 @@ public class GameScreen extends ScreenAdapter {
             } else {
               display.setCovered(true);
               display.setActive(false);
+              // Issue #175: face-down cards remain clickable while attempts remain so the
+              // player can retry directly without an extra "Try again" button.
+              if (priest.getConversionAttempts() > 0) {
+                display.addListener(new ClickListener() {
+                  @Override
+                  public void clicked(InputEvent event, float x, float y) {
+                    String atkSym = priestCurrentPlayer.getPlayerTurn().getAttackingSymbol()[0];
+                    priest.conversionAttempt();
+                    if (atkSym.equals(tc.getSymbol()) || "joker".equals(tc.getSymbol())) {
+                      priest.conversion();
+                      Iterator<Card> it = priestPlayers.get(priestTarget).getHandCards().iterator();
+                      while (it.hasNext()) { if (it.next() == tc) { it.remove(); break; } }
+                      priestCurrentPlayer.addHandCard(tc);
+                      emitPriestConvert(priestTarget, tc.getCardId());
+                      gameState.setPriestTargetPlayerIdx(-1);
+                      gameState.setPriestRevealedCardId(-1);
+                    } else {
+                      gameState.setPriestRevealedCardId(tc.getCardId());
+                      emitPriestAttemptFailed();
+                    }
+                    gameState.setUpdateState(true);
+                  }
+                });
+              }
             }
           }
           gameStage.addActor(display);
@@ -3145,10 +3183,12 @@ public class GameScreen extends ScreenAdapter {
         float btnW = 120f;
         if (revealedId >= 0) {
           if (priest.getConversionAttempts() > 0) {
-            TextButton tryAgainBtn = new TextButton("Try again", MyGdxGame.skin);
-            tryAgainBtn.setSize(btnW, 45f);
-            tryAgainBtn.setPosition(MyGdxGame.WIDTH / 2f - btnW / 2f, btnY);
-            tryAgainBtn.addListener(new ClickListener() {
+            // Issue #175: replace "Try again" with "Cancel" — face-down cards are now
+            // directly clickable for retry.
+            TextButton cancelBtn = new TextButton("Cancel", MyGdxGame.skin);
+            cancelBtn.setSize(btnW, 45f);
+            cancelBtn.setPosition(MyGdxGame.WIDTH / 2f - btnW / 2f, btnY);
+            cancelBtn.addListener(new ClickListener() {
               @Override
               public void clicked(InputEvent event, float x, float y) {
                 gameState.setPriestRevealedCardId(-1);
@@ -3156,7 +3196,7 @@ public class GameScreen extends ScreenAdapter {
                 gameState.setUpdateState(true);
               }
             });
-            gameStage.addActor(tryAgainBtn);
+            gameStage.addActor(cancelBtn);
           } else {
             // No more attempts
             TextButton doneBtn = new TextButton("Done", MyGdxGame.skin);
@@ -3303,6 +3343,8 @@ public class GameScreen extends ScreenAdapter {
         handcard.setY(MyGdxGame.WIDTH / 2 - handcard.getHeight());
       }
       handStage.addActor(handcard);
+      // Issues #54, #176: highlight own hand cards as discard candidates when Spy/Merchant is selected.
+      applyOwnHandCardHighlight(handcard, currentPlayer);
 
       if (handcard.getBoosted() > 0) {
         TextureRegion mercenaryRegion = new TextureRegion(texMercenary, 0, 0, 512, 512);
@@ -5327,6 +5369,141 @@ public class GameScreen extends ScreenAdapter {
     topHalf.setTouchable(com.badlogic.gdx.scenes.scene2d.Touchable.disabled);
     gameStage.addActor(bottomHalf);
     gameStage.addActor(topHalf);
+  }
+
+  /**
+   * Issues #54, #175, #176, #178, #179, #180: generic translucent highlight overlay
+   * placed on top of any actor (card, hero icon, etc.) to indicate it is targetable
+   * for the currently selected hero's action. Overlay is non-touchable so the
+   * underlying actor still receives the click.
+   */
+  private void addCardActionHighlight(Actor actor, Color color, com.badlogic.gdx.scenes.scene2d.Stage stage) {
+    Image hi = new Image(MyGdxGame.skin.newDrawable("white", color));
+    // For rotated hand cards we want an axis-aligned overlay, so use the actor's
+    // visual width/height (swap when rotated 90°/270°).
+    float w = actor.getWidth();
+    float h = actor.getHeight();
+    float rot = actor.getRotation();
+    if (Math.abs(rot - 90f) < 1f || Math.abs(rot - 270f) < 1f || Math.abs(rot + 90f) < 1f) {
+      // Visual bounds for a rotated card: centred on (x + w/2, y + h/2),
+      // visual size (h, w).
+      float cx = actor.getX() + w / 2f;
+      float cy = actor.getY() + h / 2f;
+      hi.setBounds(cx - h / 2f, cy - w / 2f, h, w);
+    } else {
+      hi.setBounds(actor.getX(), actor.getY(), w, h);
+    }
+    hi.setTouchable(com.badlogic.gdx.scenes.scene2d.Touchable.disabled);
+    stage.addActor(hi);
+  }
+
+  /** Returns the currently selected hero of the given player (if any), else null. */
+  private Hero selectedHero(Player player) {
+    if (player == null) return null;
+    for (Hero h : player.getHeroes()) {
+      if (h.isSelected()) return h;
+    }
+    return null;
+  }
+
+  /**
+   * Issues #54, #178, #179, #180: when an attacker hero is selected (Spy/Saboteurs/Magician/Warlord),
+   * tint each enemy defense card to indicate it is targetable by the current action.
+   * Also handles empty enemy slots (Saboteurs).
+   */
+  private void applyEnemyDefCardHighlight(Card defCard, Player owner, Player current, int slot) {
+    if (owner == current) return;
+    Hero sel = selectedHero(current);
+    if (sel == null) return;
+    String name = sel.getHeroName();
+    if ("Spy".equals(name)) {
+      com.mygdx.game.heroes.Spy spy = (com.mygdx.game.heroes.Spy) sel;
+      // Highlight only face-down enemy def cards while the spy still has flip actions.
+      if (spy.getSpyAttacks() > 0 && !defCard.isPlaceholder() && defCard.isCovered()) {
+        addCardActionHighlight(defCard, new Color(1f, 1f, 0f, 0.28f), gameStage);
+      }
+    } else if ("Saboteurs".equals(name)) {
+      com.mygdx.game.heroes.Saboteurs sab = (com.mygdx.game.heroes.Saboteurs) sel;
+      if (sab.isAvailable() && !owner.isSlotSabotaged(slot)) {
+        addCardActionHighlight(defCard, new Color(1f, 0.6f, 0f, 0.28f), gameStage);
+      }
+    } else if ("Magician".equals(name) && !defCard.isPlaceholder()) {
+      com.mygdx.game.heroes.Magician mag = (com.mygdx.game.heroes.Magician) sel;
+      if (mag.getSpells() > 0) {
+        addCardActionHighlight(defCard, new Color(0f, 0.7f, 1f, 0.28f), gameStage);
+      }
+    } else if ("Warlord".equals(name) && !defCard.isPlaceholder()) {
+      com.mygdx.game.heroes.Warlord wl = (com.mygdx.game.heroes.Warlord) sel;
+      if (wl.isAttackAvailable()) {
+        addCardActionHighlight(defCard, new Color(1f, 0.3f, 0.3f, 0.32f), gameStage);
+      }
+    }
+  }
+
+  /** Issues #179, #180, #54: highlight enemy king when a hero action targets it. */
+  private void applyEnemyKingHighlight(Card kingCard, Player owner, Player current) {
+    if (owner == current) return;
+    Hero sel = selectedHero(current);
+    if (sel == null) return;
+    boolean defenderHasNoDef = owner.getDefCards().isEmpty() && owner.getTopDefCards().isEmpty();
+    String name = sel.getHeroName();
+    if ("Magician".equals(name) && defenderHasNoDef) {
+      com.mygdx.game.heroes.Magician mag = (com.mygdx.game.heroes.Magician) sel;
+      if (mag.getSpells() > 0) {
+        addCardActionHighlight(kingCard, new Color(0f, 0.7f, 1f, 0.28f), gameStage);
+      }
+    } else if ("Warlord".equals(name) && defenderHasNoDef) {
+      com.mygdx.game.heroes.Warlord wl = (com.mygdx.game.heroes.Warlord) sel;
+      if (wl.isAttackAvailable()) {
+        addCardActionHighlight(kingCard, new Color(1f, 0.3f, 0.3f, 0.32f), gameStage);
+      }
+    } else if ("Spy".equals(name) && defenderHasNoDef && kingCard.isCovered()) {
+      // Spy peek on king is allowed only when all defs are face-up; here the defender has none.
+      com.mygdx.game.heroes.Spy spy = (com.mygdx.game.heroes.Spy) sel;
+      if (spy.getSpyAttacks() > 0) {
+        addCardActionHighlight(kingCard, new Color(1f, 1f, 0f, 0.28f), gameStage);
+      }
+    } else if ("Spy".equals(name) && !defenderHasNoDef && kingCard.isCovered()) {
+      // Also: all def cards face-up case
+      com.mygdx.game.heroes.Spy spy = (com.mygdx.game.heroes.Spy) sel;
+      if (spy.getSpyAttacks() > 0) {
+        boolean allFaceUp = true;
+        for (Card dc : owner.getDefCards().values()) { if (dc.isCovered()) { allFaceUp = false; break; } }
+        if (allFaceUp) {
+          for (Card dc : owner.getTopDefCards().values()) { if (dc.isCovered()) { allFaceUp = false; break; } }
+        }
+        if (allFaceUp) addCardActionHighlight(kingCard, new Color(1f, 1f, 0f, 0.28f), gameStage);
+      }
+    }
+  }
+
+  /** Issue #175: highlight the enemy hand deck when the Priest is selected. */
+  private void applyEnemyHandDeckHighlight(Card topHandCard, Player owner, Player current) {
+    if (owner == current) return;
+    Hero sel = selectedHero(current);
+    if (sel == null || !"Priest".equals(sel.getHeroName())) return;
+    com.mygdx.game.heroes.Priest priest = (com.mygdx.game.heroes.Priest) sel;
+    if (priest.getConversionAttempts() > 0) {
+      addCardActionHighlight(topHandCard, new Color(1f, 1f, 0f, 0.28f), gameStage);
+    }
+  }
+
+  /** Issues #54, #176: highlight own hand cards when Spy/Merchant is selected (sacrifice / trade). */
+  private void applyOwnHandCardHighlight(Card handCard, Player current) {
+    Hero sel = selectedHero(current);
+    if (sel == null) return;
+    String name = sel.getHeroName();
+    if ("Spy".equals(name)) {
+      com.mygdx.game.heroes.Spy spy = (com.mygdx.game.heroes.Spy) sel;
+      if (spy.getSpyExtends() > 0) {
+        addCardActionHighlight(handCard, new Color(1f, 0f, 0f, 0.32f), handStage);
+      }
+    } else if ("Merchant".equals(name)) {
+      com.mygdx.game.heroes.Merchant m = (com.mygdx.game.heroes.Merchant) sel;
+      if (m.getTrades() > 0) {
+        addCardActionHighlight(handCard, new Color(1f, 0.6f, 0f, 0.32f), handStage);
+      }
+    }
   }
 
   @Override

--- a/core/src/com/mygdx/game/HeroTutorialSteps.java
+++ b/core/src/com/mygdx/game/HeroTutorialSteps.java
@@ -319,14 +319,16 @@ final class HeroTutorialSteps {
       "Begin"),
     new GameScreen.TutorialStepDef(
       "Stack a Defense Card",
-      "To stack a card:\n"
-      + "  1. Tap the Fortified Tower hero icon to select it.\n"
-      + "  2. Tap a hand card to select it.\n"
-      + "  3. Tap one of your own defense slots - the hand card stacks on top.",
+      "Stacking is automatic - no need to select the Fortified Tower hero first:\n"
+      + "  1. Tap a hand card to select it.\n"
+      + "  2. Matching defense slots are highlighted in purple.\n"
+      + "  3. Tap one of the highlighted slots - the hand card stacks on top "
+      + "and the Fortified Tower icon blinks green to confirm a charge was used.\n\n"
+      + "Only matching symbols can be stacked, and the slot must not already be stacked.",
       null),
     GameScreen.TutorialStepDef.banner(
       "Try Stacking",
-      "Tap Fortified Tower, select a hand card, then tap one of your own defense slots. "
+      "Select a hand card, then tap one of the highlighted matching defense slots. "
       + "Click Next when done.",
       null),
     new GameScreen.TutorialStepDef(

--- a/core/src/com/mygdx/game/HeroTutorialSteps.java
+++ b/core/src/com/mygdx/game/HeroTutorialSteps.java
@@ -258,7 +258,7 @@ final class HeroTutorialSteps {
   private static final GameScreen.TutorialStepDef[] BANNERET = new GameScreen.TutorialStepDef[] {
     new GameScreen.TutorialStepDef(
       "Banneret",
-      "The Banneret unlocks two passive abilities: Dual Symbol and Defense-to-Attack.",
+      "The Banneret unlocks one passive ability: Dual Symbol.",
       "Begin"),
     new GameScreen.TutorialStepDef(
       "Dual Symbol (Passive)",
@@ -267,14 +267,9 @@ final class HeroTutorialSteps {
       + "  - Spades <-> Clubs\n\n"
       + "Both symbols can be combined in the same attack round.",
       null),
-    new GameScreen.TutorialStepDef(
-      "Defense-to-Attack (Passive)",
-      "Your own defense cards can also be used as attack cards. Select a mix of hand cards "
-      + "and own defense cards, then attack as usual. Used defense cards are discarded.",
-      null),
     GameScreen.TutorialStepDef.banner(
       "Try a Plunder",
-      "Select hand cards (and optionally own defense cards) and plunder a harvest deck. "
+      "Select hand cards and plunder a harvest deck. "
       + "Notice the dual symbol unlocking.",
       "PLUNDER"),
     GameScreen.TutorialStepDef.banner(
@@ -358,11 +353,14 @@ final class HeroTutorialSteps {
     new GameScreen.TutorialStepDef(
       "Cast Card Replacement",
       "Tap the Magician hero icon, then tap any enemy defense card. "
-      + "The slot is rebuilt with new cards from the deck.",
+      + "The slot is rebuilt with new cards from the deck.\n\n"
+      + "If the enemy has no defense cards left, you may instead target their king card "
+      + "to replace it.",
       null),
     GameScreen.TutorialStepDef.banner(
       "Try the Magician",
-      "Tap Magician, then tap any enemy defense card. Click Next when done.",
+      "Tap Magician, then tap any enemy defense card (or king card if the enemy has no "
+      + "defenses). Click Next when done.",
       null),
     GameScreen.TutorialStepDef.banner(
       "Finish Your Turn",

--- a/core/src/com/mygdx/game/listeners/EnemyDefCardListener.java
+++ b/core/src/com/mygdx/game/listeners/EnemyDefCardListener.java
@@ -307,6 +307,7 @@ public class EnemyDefCardListener extends ClickListener {
       // remain available).
       pt.setPendingAttackIsWarlord(true);
       warlord.useAttack();
+      pt.increaseAttackCounter(); // count Warlord attack locally so Finish Turn never triggers expose
       if (socket != null) {
         try {
           JSONObject warlordData = new JSONObject();

--- a/core/src/com/mygdx/game/listeners/EnemyKingCardListener.java
+++ b/core/src/com/mygdx/game/listeners/EnemyKingCardListener.java
@@ -233,6 +233,7 @@ public class EnemyKingCardListener extends ClickListener {
       // remain available).
       pt.setPendingAttackIsWarlord(true);
       warlord.useAttack();
+      pt.increaseAttackCounter(); // count Warlord attack locally so Finish Turn never triggers expose
       if (socket != null) {
         try {
           JSONObject warlordData = new JSONObject();

--- a/core/src/com/mygdx/game/listeners/EnemyKingCardListener.java
+++ b/core/src/com/mygdx/game/listeners/EnemyKingCardListener.java
@@ -63,6 +63,43 @@ public class EnemyKingCardListener extends ClickListener {
     }
     if (defender == null || defender == player) return;
 
+    // Issue #179: Magician can target an enemy king card if the defender has no
+    // defense cards. Replaces the king card with a new face-down card from the deck.
+    for (int mi = 0; mi < player.getHeroes().size(); mi++) {
+      Hero h = player.getHeroes().get(mi);
+      if ("Magician".equals(h.getHeroName()) && h.isSelected()) {
+        com.mygdx.game.heroes.Magician magician = (com.mygdx.game.heroes.Magician) h;
+        if (magician.getSpells() > 0
+            && defender.getDefCards().isEmpty()
+            && defender.getTopDefCards().isEmpty()
+            && player.getSelectedHandCards().isEmpty()
+            && !player.getKingCard().isSelected()) {
+          // The Magician spell on a king inverts the face state, just like for def cards.
+          boolean newCovered = !kingCard.isCovered();
+          Card newKing = gameState.getCardDeck().getCard(gameState.getCemeteryDeck());
+          gameState.getCemeteryDeck().addCard(kingCard);
+          newKing.setCovered(newCovered);
+          defender.setKingCard(newKing);
+          magician.castSpell();
+          if (socket != null) {
+            try {
+              JSONObject data = new JSONObject();
+              data.put("playerIdx", playerIdx);
+              data.put("targetPlayerIdx", defenderIdx);
+              data.put("positionId", -1);
+              data.put("bottomCardId", newKing.getCardId());
+              data.put("bottomCovered", newCovered);
+              data.put("topCardId", -1);
+              data.put("topCovered", true);
+              socket.emit("magicianSwap", data);
+            } catch (JSONException e) { e.printStackTrace(); }
+          }
+          if (gameState != null) gameState.setUpdateState(true);
+        }
+        return;
+      }
+    }
+
     // Spy peek: if Spy is selected with attacks remaining and ALL of the defender's
     // defense cards are already face-up, allow flipping the king card.
     for (int si = 0; si < player.getHeroes().size(); si++) {

--- a/core/src/com/mygdx/game/listeners/OwnDefCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnDefCardListener.java
@@ -59,6 +59,16 @@ public class OwnDefCardListener extends ClickListener {
     // Defense cards must not be interacted with when it is not the player's turn.
     if (gameState.getCurrentPlayerIndex() != playerIdx) return;
 
+    // Recurring "select card to expose, nothing happens" bug: the user expects the
+    // covered own defense card itself to be the expose target, not the slot button
+    // in the hand area. If we are in pendingExposeCard state and this card is
+    // covered, treat the click as the expose choice and finish the turn.
+    com.mygdx.game.GameScreen gs = com.mygdx.game.GameScreen.getInstance();
+    if (gs != null && gs.isPendingExpose() && selectedCard.isCovered()) {
+      gs.submitExposeAndFinishTurn(selectedCard.getPositionId());
+      return;
+    }
+
     if (!player.isSlotSabotaged(selectedCard.getPositionId())) {
       // Issue #174: Fortified Tower auto-stack — if the player has the Fortified Tower
       // hero with charges and exactly one hand card of the matching symbol is selected,

--- a/core/src/com/mygdx/game/listeners/OwnDefCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnDefCardListener.java
@@ -60,6 +60,50 @@ public class OwnDefCardListener extends ClickListener {
     if (gameState.getCurrentPlayerIndex() != playerIdx) return;
 
     if (!player.isSlotSabotaged(selectedCard.getPositionId())) {
+      // Issue #174: Fortified Tower auto-stack — if the player has the Fortified Tower
+      // hero with charges and exactly one hand card of the matching symbol is selected,
+      // stack it on this defense slot without requiring the hero to be pre-selected.
+      // The hero blinks (like the Marshal blink in HandImageListener) to confirm.
+      if (selectedCard.getLevel() == 0
+          && !player.getTopDefCards().containsKey(selectedCard.getPositionId())
+          && player.getSelectedHandCards().size() == 1) {
+        FortifiedTower ft = null;
+        for (int i = 0; i < player.getHeroes().size(); i++) {
+          if ("Fortified Tower".equals(player.getHeroes().get(i).getHeroName())) {
+            ft = (FortifiedTower) player.getHeroes().get(i);
+            break;
+          }
+        }
+        if (ft != null && ft.getDefenseExpands() > 0) {
+          Card handCard = player.getSelectedHandCards().get(0);
+          if (handCard.getSymbol().equals(selectedCard.getSymbol())) {
+            int handCardId = handCard.getCardId();
+            int slot = selectedCard.getPositionId();
+            ft.defenseExpand();
+            handCard.setLevel(1);
+            player.putDefCard(slot, 1);
+            ft.setSelected(false);
+            // Blink the Fortified Tower hero icon green (issue #174)
+            ft.addAction(com.badlogic.gdx.scenes.scene2d.actions.Actions.sequence(
+                com.badlogic.gdx.scenes.scene2d.actions.Actions.color(com.badlogic.gdx.graphics.Color.GREEN, 0f),
+                com.badlogic.gdx.scenes.scene2d.actions.Actions.delay(0.3f),
+                com.badlogic.gdx.scenes.scene2d.actions.Actions.color(com.badlogic.gdx.graphics.Color.WHITE, 0.2f)
+            ));
+            if (socket != null) {
+              try {
+                JSONObject data = new JSONObject();
+                data.put("playerIdx", playerIdx);
+                data.put("slot", slot);
+                data.put("cardId", handCardId);
+                socket.emit("fortifiedTowerStack", data);
+              } catch (JSONException e) { e.printStackTrace(); }
+            }
+            gameState.setUpdateState(true);
+            return;
+          }
+        }
+      }
+
       // if F.Tower and hand card is selected, put hand card on top
       if (player.getSelectedHeroes().size() > 0) {
         for (int i = 0; i < player.getHeroes().size(); i++) {
@@ -169,39 +213,28 @@ public class OwnDefCardListener extends ClickListener {
           pairedCard = topDefCards.get(slot);
         }
 
-        if (player.hasHero("Banneret")) {
-          // Banneret: def cards can be used as attackers alongside hand cards.
-          // Allow multi-select — just toggle this def card without disturbing hand cards.
-          if (selectedCard.isSelected()) {
-            selectedCard.setSelected(false);
-            if (pairedCard != null) pairedCard.setSelected(false);
-          } else {
-            selectedCard.setSelected(true);
-            if (pairedCard != null) pairedCard.setSelected(true);
-          }
-        } else {
-          // Default: exclusive selection — deselect hand cards and all other def cards.
-          for (int i = 0; i < handCards.size(); i++) {
-            handCards.get(i).setSelected(false);
-          }
+        // Issue #177: Banneret no longer enables defense-as-attack — exclusive
+        // selection always applies. Deselect hand cards and all other def cards.
+        for (int i = 0; i < handCards.size(); i++) {
+          handCards.get(i).setSelected(false);
+        }
 
-          // select defense card
-          if (selectedCard.isSelected()) {
-            selectedCard.setSelected(false);
-            if (pairedCard != null) pairedCard.setSelected(false);
-          } else {
-            kingCard.setSelected(false);
-            for (int i = 1; i <= 3; i++) {
-              if (defCards.containsKey(i)) {
-                defCards.get(i).setSelected(false);
-              }
-              if (topDefCards.containsKey(i)) {
-                topDefCards.get(i).setSelected(false);
-              }
+        // select defense card
+        if (selectedCard.isSelected()) {
+          selectedCard.setSelected(false);
+          if (pairedCard != null) pairedCard.setSelected(false);
+        } else {
+          kingCard.setSelected(false);
+          for (int i = 1; i <= 3; i++) {
+            if (defCards.containsKey(i)) {
+              defCards.get(i).setSelected(false);
             }
-            selectedCard.setSelected(true);
-            if (pairedCard != null) pairedCard.setSelected(true);
+            if (topDefCards.containsKey(i)) {
+              topDefCards.get(i).setSelected(false);
+            }
           }
+          selectedCard.setSelected(true);
+          if (pairedCard != null) pairedCard.setSelected(true);
         }
 
       }

--- a/core/src/com/mygdx/game/listeners/OwnHandCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnHandCardListener.java
@@ -205,6 +205,9 @@ public class OwnHandCardListener extends ClickListener {
           }
         }
       }
+      // Issue #174: refresh UI so the Fortified Tower highlight on matching own def
+      // cards appears (or disappears) immediately when a hand card is (de)selected.
+      if (gameState != null) gameState.setUpdateState(true);
     }
   };
 

--- a/core/src/com/mygdx/game/listeners/OwnHandCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnHandCardListener.java
@@ -62,12 +62,9 @@ public class OwnHandCardListener extends ClickListener {
         player.setKingCard(newKing);
         player.getHandCards().remove(newKing);
         player.addHandCard(oldKing);
-        // Non-warlord coup: keep old king selected so it can immediately attack.
-        // coupSwapPendingCardId survives stateUpdate hand rebuilds, keeping the card auto-selected.
         if (!hasWarlord) {
+          // Mark the swap for tutorial detection; reset king-used flag for the new board king
           player.getPlayerTurn().setCoupSwapPendingCardId(oldKing.getCardId());
-          player.setSelectedSymbol(oldKing.getSymbol());
-          // Fresh king on board: reset king-used flag so the new board king can attack this turn
           player.getPlayerTurn().setKingUsedThisTurn(false);
         }
         // Deselect king

--- a/core/src/com/mygdx/game/listeners/OwnHeroListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnHeroListener.java
@@ -59,11 +59,9 @@ public class OwnHeroListener extends ClickListener {
       if (hero.isSelected()) {
         // Deselect: if Mercenaries was in defense mode, just deselect
         hero.setSelected(false);
-        // Refresh the UI immediately so the Mercenaries selection highlights
-        // (issue #167: green/red halves on def + king cards) disappear.
-        if (hero.getHeroName() == "Mercenaries") {
-          if (gameState != null) gameState.setUpdateState(true);
-        }
+        // Refresh the UI immediately so any selection-driven highlights disappear.
+        // (Issue #167 Mercenaries; issues #54 #174 #175 #176 #178 #179 #180 highlight overlays.)
+        if (gameState != null) gameState.setUpdateState(true);
       } else {
         // Select: unselect everything else first
         player.getKingCard().setSelected(false);
@@ -82,11 +80,8 @@ public class OwnHeroListener extends ClickListener {
           player.getHeroes().get(i).setSelected(false);
         }
         hero.setSelected(true);
-        // Refresh the UI immediately so the Mercenaries selection highlights
-        // (issue #167: green/red halves on def + king cards) appear right away.
-        if (hero.getHeroName() == "Mercenaries") {
-          if (gameState != null) gameState.setUpdateState(true);
-        }
+        // Refresh the UI immediately so selection-driven highlights appear right away.
+        if (gameState != null) gameState.setUpdateState(true);
       }
     }
   }

--- a/server/bot.js
+++ b/server/bot.js
@@ -483,8 +483,13 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
 
   function botFillDefense(gs, playerIdx) {
     var p = gs.players[playerIdx];
+    // Respect the same put-action limit as human players:
+    // 1 placement per turn normally; 3 if the player has the Marshal hero.
+    var hasMarshal = (p.heroes || []).indexOf('Marshal') !== -1;
+    var putActionsLeft = hasMarshal ? 3 : 1;
     var nonJokerHand = p.hand.filter(function(id) { return id <= 52; });
     for (var slot = 1; slot <= 3; slot++) {
+      if (putActionsLeft <= 0) break;
       if (p.defCards[slot] == null && nonJokerHand.length > 1) {
         var weakestId = null, weakestStr = 9999;
         for (var i = 0; i < nonJokerHand.length; i++) {
@@ -494,6 +499,7 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
         if (weakestId !== null) {
           gs.putDefCard(playerIdx, slot, weakestId);
           nonJokerHand.splice(nonJokerHand.indexOf(weakestId), 1);
+          putActionsLeft--;
         }
       }
     }
@@ -508,7 +514,7 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     var acted = false;
 
     // Warlord king swap: upgrade king if a hand card is stronger
-    if (heroes.indexOf('Warlord') !== -1 && (p.warlordAttacks || 0) > 0 && p.kingCard !== null) {
+    if (heroes.indexOf('Warlord') !== -1 && (p.warlordSwaps || 0) > 0 && p.kingCard !== null) {
       var kingStr = gs.cardStrength(p.kingCard);
       var bestHandId = null, bestHandStr = kingStr;
       var nonJokerHand = p.hand.filter(function(id) { return id <= 52; });

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -355,6 +355,25 @@ class GameState {
     }
 
     const target = this.players[targetPlayerIdx];
+    // Issue #179: positionId === -1 means the spell targets the defender's king card
+    // (only allowed when the defender has no defense cards left).
+    if (positionId === -1) {
+      const hasDef = (target.defCards && Object.keys(target.defCards).length > 0)
+                  || (target.topDefCards && Object.keys(target.topDefCards).length > 0);
+      if (hasDef) {
+        console.log(`magicianSwap: rejected king-target — defender ${targetPlayerIdx} still has defense cards`);
+        return;
+      }
+      const oldKing = target.kingCard;
+      if (oldKing !== undefined && oldKing !== null) this.cemetery.push(oldKing);
+      const idx = this.deck.indexOf(newBottomCardId);
+      if (idx !== -1) this.deck.splice(idx, 1);
+      target.kingCard = newBottomCardId;
+      target.kingCovered = bottomCovered;
+      attacker.magicianSpells--;
+      this.pushLog(`${this.pname(playerIdx)} cast Magician on ${this.pname(targetPlayerIdx)}'s king`, true);
+      return;
+    }
     // Discard old bottom card
     const oldBottom = target.defCards[positionId];
     if (oldBottom !== undefined) this.cemetery.push(oldBottom);

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -712,8 +712,16 @@ class GameState {
       return false;
     }
     p.warlordAttacks--;
+    // A Warlord direct attack counts as an attack for the "finish-turn without attacking"
+    // penalty check. Without this, the client would still force the player to expose
+    // a defense card after using Warlord (issue: "Warlord attack must not require expose").
+    p.attackCount = (p.attackCount || 0) + 1;
     this.pushLog(`${this.pname(playerIdx)} used Warlord direct attack`, true, true);
     return true;
+  }
+
+  dismissMerchantReveal() {
+    this.lastMerchantReveal = null;
   }
 
   warlordKingSwap(playerIdx, oldKingCardId, newKingCardId) {

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -47,6 +47,7 @@ class GameState {
       p.magicianSpells = 1;
       p.merchantTrades = 1;
       p.warlordAttacks = 1;
+      p.warlordSwaps = 1;
       p.spyAttacks = 1;
       p.spyMaxAttacks = 1;
       p.spyExtends = 1;
@@ -591,6 +592,7 @@ class GameState {
       this.players[currentPlayerIndex].magicianSpells = 1;
       this.players[currentPlayerIndex].merchantTrades = 1;
       this.players[currentPlayerIndex].warlordAttacks = 1;
+      this.players[currentPlayerIndex].warlordSwaps = 1;
       this.players[currentPlayerIndex].spyAttacks = 1;
       this.players[currentPlayerIndex].spyMaxAttacks = 1;
       this.players[currentPlayerIndex].spyExtends = 1;
@@ -726,18 +728,18 @@ class GameState {
 
   warlordKingSwap(playerIdx, oldKingCardId, newKingCardId) {
     const p = this.players[playerIdx];
-    // Accept either a Warlord swap (consumes warlordAttacks) or a coup swap
-    // (player has zero defense cards on the board — costs only the per-turn
+    // Accept either a Warlord swap (consumes warlordSwaps — independent from direct attack)
+    // or a coup swap (player has zero defense cards on the board — costs only the per-turn
     // take/put-defense actions, tracked client-side). Without this, a coup
     // swap is rejected by the server and the next stateUpdate reverts the
     // king on the client, leaving the visible "new king" detached from the
     // actual kingCard reference and unresponsive to clicks until the next turn.
-    const hasWarlord = (p.warlordAttacks || 0) > 0;
+    const hasWarlordSwap = (p.warlordSwaps || 0) > 0;
     const defCount = Object.keys(p.defCards || {}).length
         + Object.keys(p.topDefCards || {}).length;
     const isCoup = defCount === 0;
-    if (!hasWarlord && !isCoup) {
-      console.log(`warlordKingSwap: rejected — player ${playerIdx} has no Warlord attacks and still has defense cards`);
+    if (!hasWarlordSwap && !isCoup) {
+      console.log(`warlordKingSwap: rejected — player ${playerIdx} has no swap actions remaining and still has defense cards`);
       return;
     }
     const handIdx = p.hand.indexOf(newKingCardId);
@@ -746,8 +748,8 @@ class GameState {
     p.hand.push(oldKingCardId);
     p.kingCard = newKingCardId;
     p.kingCovered = true; // new king is always placed face-down
-    if (hasWarlord) {
-      p.warlordAttacks--;
+    if (hasWarlordSwap) {
+      p.warlordSwaps--;
       this.pushLog(`${this.pname(playerIdx)} swapped king (Warlord)`, true, true);
     } else {
       this.pushLog(`${this.pname(playerIdx)} swapped king (coup)`, true, true);
@@ -858,6 +860,7 @@ class GameState {
         magicianSpells: p.magicianSpells !== undefined ? p.magicianSpells : 1,
         merchantTrades: p.merchantTrades !== undefined ? p.merchantTrades : 1,
         warlordAttacks: p.warlordAttacks !== undefined ? p.warlordAttacks : 1,
+        warlordSwaps: p.warlordSwaps !== undefined ? p.warlordSwaps : 1,
         spyAttacks: p.spyAttacks !== undefined ? p.spyAttacks : 1,
         spyMaxAttacks: p.spyMaxAttacks !== undefined ? p.spyMaxAttacks : 1,
         spyExtends: p.spyExtends !== undefined ? p.spyExtends : 1,

--- a/server/index.js
+++ b/server/index.js
@@ -1414,6 +1414,13 @@ io.on('connection', function(socket) {
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
+  socket.on('dismissMerchantReveal', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || !sess.gameState) return;
+    sess.gameState.dismissMerchantReveal();
+    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+  });
+
   socket.on('fortifiedTowerStack', function(data) {
     var sess = getSession(socket.id);
     if (!sess || !sess.gameState) return;


### PR DESCRIPTION
Combined PR addressing 8 hero-usability issues.

## Rule changes
- **#177 Banneret** — drops the defense-as-attack ability; only the Dual Symbol passive remains. Tutorial updated.
- **#179 Magician** — when the defender has no defense cards, the Magician may now target the king card (replaces it with a fresh deck card; preserves the inverted face-state semantics already used for def cards). Server magicianSwap accepts positionId == -1 to mean the king. Tutorial updated.

## Auto-trigger
- **#174 Fortified Tower** — clicking your own def card with exactly one matching hand card selected now stacks automatically; you no longer need to pre-select the Fortified Tower hero. The hero icon blinks green to confirm the use of a charge.

## Visual highlights when an attacker hero is selected
- **#54 Spy** — yellow tint on face-down enemy def cards (and on the enemy king card when allowed); red tint on own hand cards (sacrifice candidates).
- **#175 Priest** — yellow tint on the enemy hand-card stack top.
- **#176 Merchant** — orange tint on own hand cards (trade candidates).
- **#178 Saboteurs** — orange tint on enemy def cards and empty enemy slots (where a saboteur can be placed).
- **#179 Magician** — cyan tint on enemy def cards (and the enemy king card when the defender has no defs).
- **#180 Warlord** — red tint on enemy def cards (and the enemy king card when the defender has no defs).

Highlights are non-touchable so the underlying card listener still receives the click.

## Priest UX (#175)
After a wrong guess, face-down cards remain clickable so the player can retry directly. The Try Again button is replaced by Cancel.

Closes #54
Closes #174
Closes #175
Closes #176
Closes #177
Closes #178
Closes #179
Closes #180