### PR TITLE
Show game statistics screen after a winner is declared

### DIFF
--- a/.github/instructions/game-rules.instructions.md
+++ b/.github/instructions/game-rules.instructions.md
@@ -1,0 +1,178 @@
+---
+description: "Reference for Baisch game rules. Always consult this before implementing any game mechanic, turn logic, hero ability, or penalty check. Violations of these rules are bugs."
+---
+# Baisch – Game Rules Reference
+
+This file is the authoritative ruleset for the Baisch card game. Any code change that touches turn flow, attack resolution, hero abilities, or penalty checks **must comply with these rules**.
+
+---
+
+## Overview
+
+2–4 players compete to be the last player alive. A player is eliminated when their **king card** is captured. Players take turns in dice-roll order; the highest roller each round goes first.
+
+---
+
+## Turn Structure
+
+Each turn a player may perform any combination of the following actions in any order:
+
+1. **Mobilise** (take/put defence cards) — 1 take and 1 put per turn by default (3 combined with Marshal)
+2. **Attack** enemy defence cards (with hand cards, own defence cards via Banneret, Reservists boost, or own king)
+3. **King assault** on an exposed enemy king card
+4. **Plunder** a picking deck
+5. **Use hero abilities** (Spy, Merchant, Priest, Warlord, etc.)
+
+The turn ends when the player clicks **Finish Turn**.
+
+---
+
+## Expose-Defence-Card Penalty
+
+> **Rule**: If a player ends their turn without having performed at least one **attack**, they must expose (flip face-up) one of their own covered defence cards. If all defence slots are empty they must expose their king card instead.
+
+### What counts as an "attack" for this rule:
+| Action | Counts? |
+|---|---|
+| Attacking an enemy defence card (with hand cards) | ✅ Yes |
+| Attacking an enemy defence card (king used as attacker) | ✅ Yes |
+| Attacking an enemy defence card (Banneret own-def-cards) | ✅ Yes |
+| Attacking an enemy king card (king assault) | ✅ Yes |
+| Warlord direct attack | ✅ Yes |
+| **Plundering a picking deck** | ❌ **No** |
+| Taking or placing a defence card (mobilise) | ❌ No |
+| Using a hero ability (Spy, Merchant, Priest, etc.) | ❌ No |
+| Warlord king swap | ❌ No |
+
+### Implementation details:
+- Server: `attackCount` per player is incremented only in `defAttackResolved`, `kingAttackResolved`, and `warlordDirectAttack`.
+- `plunderResolved` must **not** increment `attackCount`.
+- Client: `playerTurn.attackCounter == 0` triggers the expose prompt in `FinishTurnButtonListener`.
+- Client: `increaseAttackCounter()` is called locally for Warlord direct attack (before the server's `stateUpdate` arrives) to prevent a race-condition false-trigger.
+
+---
+
+## Attack Rules
+
+### Defence Card Attack
+- The attacker selects one or more hand cards of the **same suit** (unless Banneret: same-colour pair allowed).
+- The combined strength of selected cards must **exceed** (not equal) the defence card's strength (plus top defence card if present — Fortified Tower).
+- The attacker's king card can be used instead of hand cards (but cannot be combined with hand cards).
+- The attacking symbol is **locked** after the first attack of a turn; all subsequent attacks in the same turn must use the same suit (or same-colour pair if Banneret).
+- On **success**: the attacker gains the captured defence card(s) as prey cards.
+- On **failure** (attacker used the king): the attacker is eliminated.
+
+### King Assault
+- The defender's king must be **exposed** (face-up) for a king assault to be possible.
+- A king assault is only possible when all 3 of the defender's defence slots are empty.
+- The attacker selects hand cards or their king whose combined strength beats the defending king's strength (plus any Reservists boost the defender has).
+- On **success**: the defender is eliminated; the attacker gains all of the defender's cards.
+- On **failure** (attacker used their king): the attacker is eliminated.
+
+### Plunder
+- The attacker selects hand cards of the same suit whose combined strength exceeds the **top card** of the target picking deck.
+- On **success**: the attacker gains all cards in that picking deck; the deck is rebuilt.
+- On **failure** (attacker used their king): the attacker is eliminated. Otherwise no penalty for failure.
+- **Plundering does not count as an attack** for the expose-defence-card penalty check.
+
+---
+
+## Mobilise Actions
+
+- Default: 1 **take** action + 1 **put** action per turn.
+- With Marshal hero: 3 combined take/put actions per turn.
+- **Take**: move a face-down defence card (and its top card if Fortified Tower stacked one) from the field back to hand.
+- **Put**: place a selected hand card face-down into an empty or occupied defence slot.
+- Sabotaged slots cannot be taken from or placed into (must be sacrificed to remove the saboteur).
+
+---
+
+## Hero Rules Summary
+
+### Mercenaries
+- Up to 8 figures. Clicking the hero before committing an attack adds +1 attack strength per figure spent.
+- Recovers 4 figures per turn.
+
+### Marshal
+- Replaces default 1 take + 1 put with **3 combined mobilise actions** per turn.
+
+### Spy
+- 1 spy action per turn: attack a face-up enemy defence card and flip it face-up (reveal) instead of capturing.
+- Can extend for +2 actions per turn by sacrificing a hand card. Maximum 1 extend per sacrifice.
+
+### Battery Tower
+- 1 charge per turn (recharges at start of owner's next turn).
+- When the owner's defence card or king is attacked, the owner may spend 1 charge to **cancel** the attack: the attacker's hand cards used are locked for the rest of their turn.
+
+### Merchant
+- 1 trade per turn: discard a hand card (or defence card), draw a replacement from the deck.
+- On the **last** trade of the turn the drawn card is revealed to all players (Merchant second-try reveal).
+
+### Priest
+- 2 conversion attempts per turn.
+- After committing an attack with a specific suit, the Priest can convert one matching hand card from the **target player** to the attacker's own hand.
+
+### Reservists
+- Up to 4 figures (starts with 2 ready). Each figure passively adds +1 to the owner's king card defence strength.
+- During an attack/plunder, the owner may spend figures to add +1 per figure to the **attack** strength.
+- Recovers 2 figures per turn.
+
+### Banneret
+- Allows two suits of the **same colour** (hearts + diamonds, or clubs + spades) in a single attack.
+- This applies from the **first attack** of the turn (before any symbol is locked).
+- Also allows the owner's face-down defence cards to be used as additional attack cards.
+
+### Saboteurs
+- 2 figures. Deploy one onto an enemy defence slot to block it (cannot take/put while sabotaged).
+- The defender can sacrifice the slot's defence card (or a hand card if the slot is empty) to remove the figure.
+- Saboteurs recover over 2 turns after being destroyed.
+
+### Fortified Tower
+- 1 fortify action per turn: stack an additional hand card face-down on top of an existing defence card.
+- Attackers must beat the **combined** strength of both cards.
+- The top card is removed first when the slot is attacked successfully.
+
+### Magician
+- 1 spell per turn: replace the bottom (and optionally top) defence card of any player's slot with fresh cards drawn from the deck. Old cards are discarded.
+
+### Warlord
+- 1 direct attack charge per turn (separate from the king-swap charge).
+- Direct attack: select Warlord + a hand card; the king attacks a target defence card directly, without needing to clear own defence slots first. **Counts as an attack** for the expose-penalty check.
+- King swap: swap the player's king with a hand card (1 swap charge per turn, independent of the direct attack charge).
+- Direct attack charges and king swap charges are **separate** counters; using one does not consume the other.
+
+---
+
+## Joker Rules
+
+- IDs 53–55 are joker cards.
+- **In defence**: a joker card has strength **1**.
+- **In attack**: a joker card has **unlimited** strength (beats any defence/king card).
+- **Sacrifice**: a player can sacrifice a joker from hand to draw a card that determines their hero. Drawing a red ace = free choice of white hero; black ace = free choice of black hero; joker = free choice of any hero; numbered card = specific hero.
+
+---
+
+## Elimination
+
+A player is eliminated when:
+1. Their king card is successfully attacked in a **king assault**, OR
+2. They used their king card in an **attack that failed** (defence/plunder/assault), OR
+3. Their king card was targeted by a Warlord direct attack that succeeded.
+
+An eliminated player's hand cards, king card, and heroes go to the attacker. If the defender had multiple heroes, the attacker chooses one; the rest are lost.
+
+---
+
+## Winning Condition
+
+The game ends when only **one player** remains. That player is the winner.
+
+---
+
+## Notes for Coding Agents
+
+- Never treat a plunder as an attack for the expose-defence-card penalty.
+- `attackCount` on the server and `attackCounter` on the client track **real attacks** only (defence/king attacks and Warlord direct attacks).
+- The Banneret dual-symbol rule applies from the **first** attack of the turn; it does not require a prior symbol to have been locked.
+- Warlord direct attack and Warlord king swap use **separate** server-side counters (`warlordAttacks` and `warlordSwaps`).
+- The Marshal hero grants 3 **combined** take/put actions, not 3 takes + 3 puts.

--- a/.github/instructions/game-rules.instructions.md
+++ b/.github/instructions/game-rules.instructions.md
@@ -67,7 +67,7 @@ The turn ends when the player clicks **Finish Turn**.
 - A king assault is only possible when all 3 of the defender's defence slots are empty.
 - The attacker selects hand cards or their king whose combined strength beats the defending king's strength (plus any Reservists boost the defender has).
 - On **success**: the defender is eliminated; the attacker gains all of the defender's cards.
-- On **failure** (attacker used their king): the attacker is eliminated.
+- On **failure**: the defending king is exposed (flipped face-up) as a result of the attack. If the attacker used their king, the attacker is also eliminated.
 
 ### Plunder
 - The attacker selects hand cards of the same suit whose combined strength exceeds the **top card** of the target picking deck.

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -593,6 +593,22 @@ public class GameScreen extends ScreenAdapter {
       }
     });
 
+    // Game ended — server sends game statistics; navigate to the stats screen
+    socket.on("gameStats", new SocketListener() {
+      @Override
+      public void call(Object... args) {
+        final JSONObject statsJson = (args.length > 0 && args[0] instanceof JSONObject)
+            ? (JSONObject) args[0] : new JSONObject();
+        Gdx.app.postRunnable(new Runnable() {
+          @Override
+          public void run() {
+            screenDisposed = true;
+            theGame.setScreen(new StatsScreen(theGame, theSocket, statsJson));
+          }
+        });
+      }
+    });
+
     // Game ended — server tells all clients to return to the lobby
     socket.on("returnToLobby", new SocketListener() {
       @Override

--- a/core/src/com/mygdx/game/StatsScreen.java
+++ b/core/src/com/mygdx/game/StatsScreen.java
@@ -254,19 +254,18 @@ public class StatsScreen extends AbstractScreen {
 
     table.pack();
 
-    // Wrap in a ScrollPane — vertical for many players, horizontal for wide tables
+    // Wrap in a ScrollPane — horizontal only (table always fits vertically)
     ScrollPane scroll = new ScrollPane(table, MyGdxGame.skin);
     scroll.setFadeScrollBars(false);
-    scroll.setScrollingDisabled(false, false);
+    scroll.setScrollingDisabled(false, true);
 
-    float maxH    = 0.70f * MyGdxGame.HEIGHT;
     float maxW    = 0.96f * MyGdxGame.WIDTH;
-    float scrollH = Math.min(table.getPrefHeight(), maxH);
-    float scrollW = Math.min(table.getPrefWidth(),  maxW);
+    float scrollH = table.getPrefHeight();
+    float scrollW = Math.min(table.getPrefWidth(), maxW);
 
     scroll.setSize(scrollW, scrollH);
     scroll.setPosition(Math.round(cx - scrollW / 2f),
-        Math.round(0.14f * MyGdxGame.HEIGHT + (maxH - scrollH) / 2f));
+        Math.round(0.14f * MyGdxGame.HEIGHT + (scrollH - scrollH) / 2f));
     stage.addActor(scroll);
   }
 

--- a/core/src/com/mygdx/game/StatsScreen.java
+++ b/core/src/com/mygdx/game/StatsScreen.java
@@ -1,0 +1,311 @@
+package com.mygdx.game;
+
+import com.mygdx.game.net.SocketClient;
+import com.mygdx.game.util.JSONArray;
+import com.mygdx.game.util.JSONException;
+import com.mygdx.game.util.JSONObject;
+
+import com.badlogic.gdx.Game;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.Touchable;
+import com.badlogic.gdx.scenes.scene2d.ui.Image;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
+import com.badlogic.gdx.utils.viewport.FitViewport;
+
+/**
+ * End-of-game statistics screen shown immediately after a winner is declared.
+ * Two tabs: General (round count) and Players (per-player breakdown).
+ * A "Return to Lobby" button navigates back to the session list.
+ */
+public class StatsScreen extends AbstractScreen {
+
+  private static final Color ACTIVE_COLOR   = Color.WHITE;
+  private static final Color INACTIVE_COLOR = new Color(1f, 1f, 1f, 0.35f);
+  private static final Color UNDERLINE_COLOR = new Color(0.98f, 0.80f, 0.25f, 1f);
+  private static final Color HEADER_COLOR    = new Color(1f, 1f, 1f, 0.9f);
+  private static final Color ROW_BG_COLOR    = new Color(0f, 0f, 0f, 0.35f);
+  private static final Color SEP_COLOR       = new Color(1f, 1f, 1f, 0.25f);
+  private static final Color DIM_SEP_COLOR   = new Color(1f, 1f, 1f, 0.14f);
+
+  private final SocketClient socket;
+  private final JSONObject stats;
+  private Stage stage;
+  private boolean showPlayersTab = false;
+
+  public StatsScreen(Game game, SocketClient socket, JSONObject stats) {
+    super(game);
+    this.socket = socket;
+    this.stats  = stats;
+  }
+
+  @Override
+  public void show() {
+    stage = new Stage(new FitViewport(MyGdxGame.WIDTH, MyGdxGame.HEIGHT));
+    Gdx.input.setInputProcessor(stage);
+    buildUI();
+  }
+
+  // ── UI construction ─────────────────────────────────────────────────────────
+
+  private void buildUI() {
+    final float cx = MyGdxGame.WIDTH / 2f;
+
+    // Title
+    Label title = new Label("Game Statistics", MyGdxGame.skin);
+    title.pack();
+    title.setPosition(Math.round(cx - title.getWidth() / 2f),
+        Math.round(0.91f * MyGdxGame.HEIGHT));
+    stage.addActor(title);
+
+    // ── Tab bar ──────────────────────────────────────────────────────────────
+    Label generalTab = new Label("General", MyGdxGame.skin);
+    Label playersTab = new Label("Players", MyGdxGame.skin);
+    generalTab.pack();
+    playersTab.pack();
+
+    float tabGap    = 32f;
+    float tabsWidth = generalTab.getWidth() + tabGap + playersTab.getWidth();
+    float tabY      = 0.855f * MyGdxGame.HEIGHT;
+    float underlineH = 3f;
+
+    generalTab.setPosition(Math.round(cx - tabsWidth / 2f), tabY);
+    playersTab.setPosition(Math.round(cx - tabsWidth / 2f + generalTab.getWidth() + tabGap), tabY);
+
+    generalTab.setColor(!showPlayersTab ? ACTIVE_COLOR : INACTIVE_COLOR);
+    playersTab.setColor( showPlayersTab ? ACTIVE_COLOR : INACTIVE_COLOR);
+    generalTab.setTouchable(Touchable.disabled);
+    playersTab.setTouchable(Touchable.disabled);
+
+    Label activeTab = !showPlayersTab ? generalTab : playersTab;
+    Image underline = new Image(MyGdxGame.skin.newDrawable("white", UNDERLINE_COLOR));
+    underline.setSize(activeTab.getWidth(), underlineH);
+    underline.setPosition(activeTab.getX(), activeTab.getY() - underlineH - 2f);
+
+    // Invisible hit actors for generous tap targets
+    com.badlogic.gdx.scenes.scene2d.Actor generalHit = new com.badlogic.gdx.scenes.scene2d.Actor();
+    generalHit.setBounds(generalTab.getX() - 8f, tabY - 8f,
+        generalTab.getWidth() + 16f, generalTab.getHeight() + 16f);
+    generalHit.addListener(new ClickListener() {
+      @Override public void clicked(InputEvent event, float x, float y) {
+        showPlayersTab = false; show();
+      }
+    });
+
+    com.badlogic.gdx.scenes.scene2d.Actor playersHit = new com.badlogic.gdx.scenes.scene2d.Actor();
+    playersHit.setBounds(playersTab.getX() - 8f, tabY - 8f,
+        playersTab.getWidth() + 16f, playersTab.getHeight() + 16f);
+    playersHit.addListener(new ClickListener() {
+      @Override public void clicked(InputEvent event, float x, float y) {
+        showPlayersTab = true; show();
+      }
+    });
+
+    stage.addActor(generalHit);
+    stage.addActor(playersHit);
+    stage.addActor(underline);
+    stage.addActor(generalTab);
+    stage.addActor(playersTab);
+
+    // ── Tab content ──────────────────────────────────────────────────────────
+    if (!showPlayersTab) {
+      buildGeneralTab(cx);
+    } else {
+      buildPlayersTab(cx);
+    }
+
+    // ── Return to Lobby button ───────────────────────────────────────────────
+    TextButton returnBtn = new TextButton("Return to Lobby", MyGdxGame.skin);
+    returnBtn.pack();
+    returnBtn.setPosition(Math.round(cx - returnBtn.getWidth() / 2f),
+        Math.round(0.055f * MyGdxGame.HEIGHT));
+    returnBtn.addListener(new ClickListener() {
+      @Override
+      public void clicked(InputEvent event, float x, float y) {
+        game.setScreen(new MenuScreen(game, socket));
+      }
+    });
+    stage.addActor(returnBtn);
+  }
+
+  private void buildGeneralTab(float cx) {
+    int rounds = 0;
+    try { rounds = stats.getInt("rounds"); } catch (JSONException e) { /* ignore */ }
+
+    Table table = new Table(MyGdxGame.skin);
+    table.setBackground(MyGdxGame.skin.newDrawable("white", ROW_BG_COLOR));
+    table.pad(18f, 22f, 18f, 22f);
+
+    Label roundsLabel = new Label("Rounds played", MyGdxGame.skin);
+    Label roundsValue = new Label(String.valueOf(rounds), MyGdxGame.skin);
+    roundsLabel.setColor(HEADER_COLOR);
+    roundsValue.setColor(HEADER_COLOR);
+
+    table.add(roundsLabel).left().padRight(32f);
+    table.add(roundsValue).right();
+
+    table.pack();
+    table.setPosition(Math.round(cx - table.getWidth() / 2f),
+        Math.round(0.5f * MyGdxGame.HEIGHT - table.getHeight() / 2f));
+    stage.addActor(table);
+  }
+
+  private void buildPlayersTab(float cx) {
+    JSONArray players = null;
+    try { players = stats.getJSONArray("players"); } catch (JSONException e) { /* fall through */ }
+
+    Table table = new Table(MyGdxGame.skin);
+    table.setBackground(MyGdxGame.skin.newDrawable("white", ROW_BG_COLOR));
+    table.pad(14f, 12f, 14f, 12f);
+
+    // Column widths
+    float colPlace  = 28f;
+    float colName   = 90f;
+    float colRounds = 44f;
+    float colPlund  = 52f;
+    float colAtk    = 52f;
+    float colHero   = 46f;
+
+    // Header row
+    Color hc = HEADER_COLOR;
+    addCell(table, "#",        colPlace,  hc, false);
+    addCell(table, "Name",     colName,   hc, true);
+    addCell(table, "Rounds",   colRounds, hc, false);
+    addCell(table, "Plunders", colPlund,  hc, false);
+    addCell(table, "Attacks",  colAtk,    hc, false);
+    addCell(table, "Heroes",   colHero,   hc, false);
+    table.row();
+
+    // Header separator
+    Image hSep = new Image(MyGdxGame.skin.newDrawable("white", SEP_COLOR));
+    table.add(hSep).colspan(6).growX().height(1f).padBottom(5f).padTop(3f);
+    table.row();
+
+    // Sub-header "(S/F)" hint row
+    addCell(table, "",      colPlace,  INACTIVE_COLOR, false);
+    addCell(table, "",      colName,   INACTIVE_COLOR, true);
+    addCell(table, "",      colRounds, INACTIVE_COLOR, false);
+    addCell(table, "(S/F)", colPlund,  INACTIVE_COLOR, false);
+    addCell(table, "(S/F)", colAtk,    INACTIVE_COLOR, false);
+    addCell(table, "",      colHero,   INACTIVE_COLOR, false);
+    table.row();
+
+    if (players == null || players.length() == 0) {
+      Label empty = new Label("No data available", MyGdxGame.skin);
+      empty.setColor(INACTIVE_COLOR);
+      table.add(empty).colspan(6).padTop(8f);
+      table.row();
+    } else {
+      for (int i = 0; i < players.length(); i++) {
+        try {
+          JSONObject p = players.getJSONObject(i);
+          int placement   = p.optInt("placement", i + 1);
+          String name     = p.optString("name", "?");
+          int roundsOut   = p.optInt("roundsUntilOut", 0);
+          int plundOk     = p.optInt("plundersSuccess", 0);
+          int plundFail   = p.optInt("plundersFailed", 0);
+          int atkOk       = p.optInt("attacksSuccess", 0);
+          int atkFail     = p.optInt("attacksFailed", 0);
+          int heroes      = p.optInt("heroesReceived", 0);
+
+          Color rowColor = (placement == 1)
+              ? new Color(1f, 0.90f, 0.30f, 1f)  // gold for winner
+              : Color.WHITE;
+
+          addCell(table, ordinal(placement), colPlace,  rowColor, false);
+          addCell(table, truncate(name, 10), colName,   rowColor, true);
+          addCell(table, String.valueOf(roundsOut),     colRounds, rowColor, false);
+          addCell(table, plundOk + "/" + plundFail,     colPlund,  rowColor, false);
+          addCell(table, atkOk   + "/" + atkFail,       colAtk,    rowColor, false);
+          addCell(table, String.valueOf(heroes),         colHero,   rowColor, false);
+          table.row();
+
+          if (i < players.length() - 1) {
+            Image rowSep = new Image(MyGdxGame.skin.newDrawable("white", DIM_SEP_COLOR));
+            table.add(rowSep).colspan(6).growX().height(1f).padTop(2f).padBottom(4f);
+            table.row();
+          }
+        } catch (JSONException e) { /* skip malformed row */ }
+      }
+    }
+
+    table.pack();
+
+    // Wrap in a ScrollPane in case many players don't fit
+    ScrollPane scroll = new ScrollPane(table, MyGdxGame.skin);
+    scroll.setFadeScrollBars(false);
+    scroll.setScrollingDisabled(true, false);
+
+    float maxH = 0.70f * MyGdxGame.HEIGHT;
+    float scrollH = Math.min(table.getPrefHeight(), maxH);
+    float scrollW = table.getPrefWidth();
+
+    scroll.setSize(scrollW, scrollH);
+    scroll.setPosition(Math.round(cx - scrollW / 2f),
+        Math.round(0.14f * MyGdxGame.HEIGHT + (maxH - scrollH) / 2f));
+    stage.addActor(scroll);
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────────
+
+  private static void addCell(Table table, String text, float minWidth, Color color, boolean leftAlign) {
+    Label lbl = new Label(text, MyGdxGame.skin);
+    lbl.setColor(color);
+    com.badlogic.gdx.scenes.scene2d.ui.Cell<?> cell = table.add(lbl).minWidth(minWidth).padRight(6f);
+    if (leftAlign) cell.left();
+    else cell.center();
+  }
+
+  private static String ordinal(int n) {
+    switch (n) {
+      case 1: return "1st";
+      case 2: return "2nd";
+      case 3: return "3rd";
+      default: return n + "th";
+    }
+  }
+
+  /** Truncate a name that's too long for the column. */
+  private static String truncate(String s, int maxChars) {
+    if (s == null) return "";
+    if (s.length() <= maxChars) return s;
+    return s.substring(0, maxChars - 1) + "\u2026"; // ellipsis
+  }
+
+  // ── Screen lifecycle ─────────────────────────────────────────────────────────
+
+  @Override
+  public void render(float delta) {
+    Gdx.gl.glClearColor(0.55f, 0.73f, 0.55f, 1f);
+    Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+    stage.getViewport().update(Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), true);
+    stage.act(delta);
+    stage.draw();
+  }
+
+  @Override
+  public void resize(int width, int height) {
+    if (stage != null) stage.getViewport().update(width, height, true);
+  }
+
+  @Override public void pause()  {}
+  @Override public void resume() {}
+
+  @Override
+  public void hide() {
+    if (stage != null) { stage.dispose(); stage = null; }
+  }
+
+  @Override
+  public void dispose() {
+    if (stage != null) { stage.dispose(); stage = null; }
+  }
+}

--- a/core/src/com/mygdx/game/StatsScreen.java
+++ b/core/src/com/mygdx/game/StatsScreen.java
@@ -166,35 +166,44 @@ public class StatsScreen extends AbstractScreen {
     table.pad(14f, 12f, 14f, 12f);
 
     // Column widths
-    float colPlace  = 28f;
-    float colName   = 90f;
-    float colRounds = 44f;
-    float colPlund  = 52f;
-    float colAtk    = 52f;
-    float colHero   = 46f;
+    float colPlace    = 28f;
+    float colName     = 90f;
+    float colRounds   = 44f;
+    float colPlund    = 52f;
+    float colAtk      = 52f;
+    float colDefeated = 52f;
+    float colKing     = 44f;
+    float colMobilise = 52f;
+    float colHero     = 46f;
 
     // Header row
     Color hc = HEADER_COLOR;
-    addCell(table, "#",        colPlace,  hc, false);
-    addCell(table, "Name",     colName,   hc, true);
-    addCell(table, "Rounds",   colRounds, hc, false);
-    addCell(table, "Plunders", colPlund,  hc, false);
-    addCell(table, "Attacks",  colAtk,    hc, false);
-    addCell(table, "Heroes",   colHero,   hc, false);
+    addCell(table, "#",        colPlace,    hc, false);
+    addCell(table, "Name",     colName,     hc, true);
+    addCell(table, "Rounds",   colRounds,   hc, false);
+    addCell(table, "Plunders", colPlund,    hc, false);
+    addCell(table, "Attacks",  colAtk,      hc, false);
+    addCell(table, "Defeated", colDefeated, hc, false);
+    addCell(table, "King",     colKing,     hc, false);
+    addCell(table, "T/P",      colMobilise, hc, false);
+    addCell(table, "Heroes",   colHero,     hc, false);
     table.row();
 
     // Header separator
     Image hSep = new Image(MyGdxGame.skin.newDrawable("white", SEP_COLOR));
-    table.add(hSep).colspan(6).growX().height(1f).padBottom(5f).padTop(3f);
+    table.add(hSep).colspan(9).growX().height(1f).padBottom(5f).padTop(3f);
     table.row();
 
-    // Sub-header "(S/F)" hint row
-    addCell(table, "",      colPlace,  INACTIVE_COLOR, false);
-    addCell(table, "",      colName,   INACTIVE_COLOR, true);
-    addCell(table, "",      colRounds, INACTIVE_COLOR, false);
-    addCell(table, "(S/F)", colPlund,  INACTIVE_COLOR, false);
-    addCell(table, "(S/F)", colAtk,    INACTIVE_COLOR, false);
-    addCell(table, "",      colHero,   INACTIVE_COLOR, false);
+    // Sub-header hint row
+    addCell(table, "",      colPlace,    INACTIVE_COLOR, false);
+    addCell(table, "",      colName,     INACTIVE_COLOR, true);
+    addCell(table, "",      colRounds,   INACTIVE_COLOR, false);
+    addCell(table, "(S/F)", colPlund,    INACTIVE_COLOR, false);
+    addCell(table, "(S/F)", colAtk,      INACTIVE_COLOR, false);
+    addCell(table, "",      colDefeated, INACTIVE_COLOR, false);
+    addCell(table, "",      colKing,     INACTIVE_COLOR, false);
+    addCell(table, "(T/P)", colMobilise, INACTIVE_COLOR, false);
+    addCell(table, "",      colHero,     INACTIVE_COLOR, false);
     table.row();
 
     if (players == null || players.length() == 0) {
@@ -213,23 +222,30 @@ public class StatsScreen extends AbstractScreen {
           int plundFail   = p.optInt("plundersFailed", 0);
           int atkOk       = p.optInt("attacksSuccess", 0);
           int atkFail     = p.optInt("attacksFailed", 0);
+          int defeated    = p.optInt("defeated", 0);
+          int kingUsed    = p.optInt("kingUsed", 0);
+          int takeActs    = p.optInt("takeActions", 0);
+          int putActs     = p.optInt("putActions", 0);
           int heroes      = p.optInt("heroesReceived", 0);
 
           Color rowColor = (placement == 1)
               ? new Color(1f, 0.90f, 0.30f, 1f)  // gold for winner
               : Color.WHITE;
 
-          addCell(table, ordinal(placement), colPlace,  rowColor, false);
-          addCell(table, truncate(name, 10), colName,   rowColor, true);
-          addCell(table, String.valueOf(roundsOut),     colRounds, rowColor, false);
-          addCell(table, plundOk + "/" + plundFail,     colPlund,  rowColor, false);
-          addCell(table, atkOk   + "/" + atkFail,       colAtk,    rowColor, false);
-          addCell(table, String.valueOf(heroes),         colHero,   rowColor, false);
+          addCell(table, ordinal(placement),        colPlace,    rowColor, false);
+          addCell(table, truncate(name, 10),         colName,     rowColor, true);
+          addCell(table, String.valueOf(roundsOut),  colRounds,   rowColor, false);
+          addCell(table, plundOk + "/" + plundFail,  colPlund,    rowColor, false);
+          addCell(table, atkOk   + "/" + atkFail,    colAtk,      rowColor, false);
+          addCell(table, String.valueOf(defeated),   colDefeated, rowColor, false);
+          addCell(table, String.valueOf(kingUsed),   colKing,     rowColor, false);
+          addCell(table, takeActs + "/" + putActs,   colMobilise, rowColor, false);
+          addCell(table, String.valueOf(heroes),     colHero,     rowColor, false);
           table.row();
 
           if (i < players.length() - 1) {
             Image rowSep = new Image(MyGdxGame.skin.newDrawable("white", DIM_SEP_COLOR));
-            table.add(rowSep).colspan(6).growX().height(1f).padTop(2f).padBottom(4f);
+            table.add(rowSep).colspan(9).growX().height(1f).padTop(2f).padBottom(4f);
             table.row();
           }
         } catch (JSONException e) { /* skip malformed row */ }
@@ -238,14 +254,15 @@ public class StatsScreen extends AbstractScreen {
 
     table.pack();
 
-    // Wrap in a ScrollPane in case many players don't fit
+    // Wrap in a ScrollPane — vertical for many players, horizontal for wide tables
     ScrollPane scroll = new ScrollPane(table, MyGdxGame.skin);
     scroll.setFadeScrollBars(false);
-    scroll.setScrollingDisabled(true, false);
+    scroll.setScrollingDisabled(false, false);
 
-    float maxH = 0.70f * MyGdxGame.HEIGHT;
+    float maxH    = 0.70f * MyGdxGame.HEIGHT;
+    float maxW    = 0.96f * MyGdxGame.WIDTH;
     float scrollH = Math.min(table.getPrefHeight(), maxH);
-    float scrollW = table.getPrefWidth();
+    float scrollW = Math.min(table.getPrefWidth(),  maxW);
 
     scroll.setSize(scrollW, scrollH);
     scroll.setPosition(Math.round(cx - scrollW / 2f),

--- a/core/src/com/mygdx/game/StatsScreen.java
+++ b/core/src/com/mygdx/game/StatsScreen.java
@@ -265,7 +265,7 @@ public class StatsScreen extends AbstractScreen {
 
     scroll.setSize(scrollW, scrollH);
     scroll.setPosition(Math.round(cx - scrollW / 2f),
-        Math.round(0.14f * MyGdxGame.HEIGHT + (scrollH - scrollH) / 2f));
+        Math.round(0.4875f * MyGdxGame.HEIGHT - scrollH / 2f));
     stage.addActor(scroll);
   }
 

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -772,6 +772,8 @@ class GameState {
     } else {
       attacker.statAttacksFailed = (attacker.statAttacksFailed || 0) + 1;
       this.pushLog(`${this.pname(attackerIdx)} king assault on ${this.pname(defenderIdx)} failed`, false);
+      // Expose the defending king so it remains visible after a failed assault
+      defender.kingCovered = false;
       if (kingUsed) {
         attacker.isOut = true;
         attacker.statRoundEliminatedAt = this.roundNumber;

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -25,6 +25,8 @@ class GameState {
     this.pendingPlunder = null; // current plunder preview broadcast, cleared on plunderResolved
     this.setupPhase = manualSetup;
     this.setupSubmitted = {}; // { playerIdx: true } — tracks who confirmed during manual setup
+    this.roundNumber = 1;     // incremented each time the full turn order wraps around
+    this.eliminationOrder = []; // player indices in elimination order (first out = index 0)
     this.dealCards(startingCards);
     if (manualSetup) {
       this.initPlayerStats(); // init combat counters without placing king/def/cemetery
@@ -55,6 +57,12 @@ class GameState {
       p.batteryTowerCharges = 0;
       p.attackingSymbol = 'none';
       p.attackingSymbol2 = 'none';
+      p.statHeroesReceived = 0;
+      p.statPlundersSuccess = 0;
+      p.statPlundersFailed = 0;
+      p.statAttacksSuccess = 0;
+      p.statAttacksFailed = 0;
+      p.statRoundEliminatedAt = 0;
     }
   }
 
@@ -505,6 +513,7 @@ class GameState {
     }
     if (kingUsed) attacker.kingCovered = false;
     if (success) {
+      attacker.statPlundersSuccess = (attacker.statPlundersSuccess || 0) + 1;
       this.pushLog(`${this.pname(attackerIdx)} plundered deck ${deckIdx + 1}!`, true);
       // Move all cards from plundered deck into attacker's hand
       for (const c of this.pickingDecks[deckIdx]) attacker.hand.push(c.id);
@@ -516,8 +525,13 @@ class GameState {
       const c2 = this.pickCard(); if (c2 !== null) this.pickingDecks[deckIdx].push({ id: c2, covered: false });
       const c3 = this.pickCard(); if (c3 !== null) this.pickingDecks[deckIdx].push({ id: c3, covered: true });
     } else {
+      attacker.statPlundersFailed = (attacker.statPlundersFailed || 0) + 1;
       this.pushLog(`${this.pname(attackerIdx)} plunder on deck ${deckIdx + 1} failed`, false);
-      if (kingUsed) attacker.isOut = true;
+      if (kingUsed) {
+        attacker.isOut = true;
+        attacker.statRoundEliminatedAt = this.roundNumber;
+        this.eliminationOrder.push(attacker.index);
+      }
       // Keep the attacked (top) card face-up after a failed plunder,
       // then add a new face-down card on top.
       const deck = this.pickingDecks[deckIdx];
@@ -548,6 +562,7 @@ class GameState {
     }
     if (kingUsed) attacker.kingCovered = false;
     if (success) {
+      attacker.statAttacksSuccess = (attacker.statAttacksSuccess || 0) + 1;
       this.pushLog(`${this.pname(attackerIdx)} broke ${this.pname(defenderIdx)}'s shield [${positionId}]`, true);
       // If the slot was sabotaged, clear it (saboteur destroyed when card is removed by attack)
       if (defender.sabotaged && defender.sabotaged[positionId] !== undefined) {
@@ -567,8 +582,13 @@ class GameState {
         if (defender.topDefCardsBoost) delete defender.topDefCardsBoost[positionId];
       }
     } else {
+      attacker.statAttacksFailed = (attacker.statAttacksFailed || 0) + 1;
       this.pushLog(`${this.pname(attackerIdx)} missed ${this.pname(defenderIdx)}'s shield [${positionId}]`, false);
-      if (kingUsed) attacker.isOut = true;
+      if (kingUsed) {
+        attacker.isOut = true;
+        attacker.statRoundEliminatedAt = this.roundNumber;
+        this.eliminationOrder.push(attacker.index);
+      }
       // Mark attacked card(s) as revealed (face-up) — they stay in defCards but must remain visible
       if (!defender.defCardsCovered) defender.defCardsCovered = {};
       if (!defender.topDefCardsCovered) defender.topDefCardsCovered = {};
@@ -612,6 +632,10 @@ class GameState {
       next = (next + 1) % n;
     }
     this.currentPlayerIndex = next;
+    // A round completes whenever the turn order wraps back (next index < previous index).
+    if (next < currentPlayerIndex) {
+      this.roundNumber = (this.roundNumber || 1) + 1;
+    }
   }
 
   exposeDefCard(playerIdx, slot) {
@@ -638,6 +662,43 @@ class GameState {
   checkWinner() {
     const alive = this.players.filter(p => !p.isOut);
     return alive.length === 1 ? alive[0].index : -1;
+  }
+
+  /** Build a statistics summary to send to clients at game end. */
+  getGameStats() {
+    const alive = this.players.filter(p => !p.isOut);
+    const winner = alive.length === 1 ? alive[0] : null;
+    const playerResults = [];
+    if (winner) {
+      playerResults.push({
+        index: winner.index,
+        name: winner.name,
+        placement: 1,
+        roundsUntilOut: this.roundNumber,
+        heroesReceived: winner.statHeroesReceived || 0,
+        plundersSuccess: winner.statPlundersSuccess || 0,
+        plundersFailed: winner.statPlundersFailed || 0,
+        attacksSuccess: winner.statAttacksSuccess || 0,
+        attacksFailed: winner.statAttacksFailed || 0,
+      });
+    }
+    // Eliminated players: last out = 2nd place (reverse eliminationOrder)
+    for (let i = this.eliminationOrder.length - 1; i >= 0; i--) {
+      const idx = this.eliminationOrder[i];
+      const p = this.players[idx];
+      playerResults.push({
+        index: p.index,
+        name: p.name,
+        placement: playerResults.length + 1,
+        roundsUntilOut: p.statRoundEliminatedAt || this.roundNumber,
+        heroesReceived: p.statHeroesReceived || 0,
+        plundersSuccess: p.statPlundersSuccess || 0,
+        plundersFailed: p.statPlundersFailed || 0,
+        attacksSuccess: p.statAttacksSuccess || 0,
+        attacksFailed: p.statAttacksFailed || 0,
+      });
+    }
+    return { rounds: this.roundNumber, players: playerResults };
   }
 
   /**
@@ -669,9 +730,12 @@ class GameState {
     }
     if (kingUsed) attacker.kingCovered = false;
     if (success) {
+      attacker.statAttacksSuccess = (attacker.statAttacksSuccess || 0) + 1;
       this.pushLog(`${this.pname(attackerIdx)} defeated ${this.pname(defenderIdx)}!`, true);
       // Defender loses their king and is eliminated; attacker gains their cards as prey
       defender.isOut = true;
+      defender.statRoundEliminatedAt = this.roundNumber;
+      this.eliminationOrder.push(defender.index);
       if (!attacker.preyCards) attacker.preyCards = [];
       for (const cardId of defender.hand) {
         attacker.hand.push(cardId);
@@ -691,8 +755,13 @@ class GameState {
         this.pendingHeroSelection = { attackerIdx, defenderIdx, options: [...defHeroes] };
       }
     } else {
+      attacker.statAttacksFailed = (attacker.statAttacksFailed || 0) + 1;
       this.pushLog(`${this.pname(attackerIdx)} king assault on ${this.pname(defenderIdx)} failed`, false);
-      if (kingUsed) attacker.isOut = true;
+      if (kingUsed) {
+        attacker.isOut = true;
+        attacker.statRoundEliminatedAt = this.roundNumber;
+        this.eliminationOrder.push(attacker.index);
+      }
     }
   }
 
@@ -815,6 +884,7 @@ class GameState {
     const target = this.players[playerIdx];
     if (!target.heroes) target.heroes = [];
     target.heroes.push(heroName);
+    target.statHeroesReceived = (target.statHeroesReceived || 0) + 1;
     // Give an immediate charge when Battery Tower is acquired
     if (heroName === 'Battery Tower') target.batteryTowerCharges = 1;
   }

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -63,6 +63,10 @@ class GameState {
       p.statAttacksSuccess = 0;
       p.statAttacksFailed = 0;
       p.statRoundEliminatedAt = 0;
+      p.statDefeated = 0;
+      p.statKingUsed = 0;
+      p.statTakeActions = 0;
+      p.statPutActions = 0;
     }
   }
 
@@ -331,6 +335,7 @@ class GameState {
     }
     if (p.defCardsBoost) delete p.defCardsBoost[positionId];
     if (p.topDefCardsBoost) delete p.topDefCardsBoost[positionId];
+    p.statTakeActions = (p.statTakeActions || 0) + 1;
     this.pushLog(`${this.pname(playerIdx)} took shield [${positionId}] to hand`, true, true);
   }
 
@@ -342,6 +347,7 @@ class GameState {
     if (!p.defCardsCovered) p.defCardsCovered = {};
     p.defCardsCovered[positionId] = true; // newly placed card is always face-down
     if (p.defCardsBoost) delete p.defCardsBoost[positionId];
+    p.statPutActions = (p.statPutActions || 0) + 1;
     this.pushLog(`${this.pname(playerIdx)} placed shield at [${positionId}]`, true, true);
   }
 
@@ -511,7 +517,7 @@ class GameState {
       }
       this.cemetery.push(cardId);
     }
-    if (kingUsed) attacker.kingCovered = false;
+    if (kingUsed) { attacker.kingCovered = false; attacker.statKingUsed = (attacker.statKingUsed || 0) + 1; }
     if (success) {
       attacker.statPlundersSuccess = (attacker.statPlundersSuccess || 0) + 1;
       this.pushLog(`${this.pname(attackerIdx)} plundered deck ${deckIdx + 1}!`, true);
@@ -560,7 +566,7 @@ class GameState {
       }
       this.cemetery.push(cardId);
     }
-    if (kingUsed) attacker.kingCovered = false;
+    if (kingUsed) { attacker.kingCovered = false; attacker.statKingUsed = (attacker.statKingUsed || 0) + 1; }
     if (success) {
       attacker.statAttacksSuccess = (attacker.statAttacksSuccess || 0) + 1;
       this.pushLog(`${this.pname(attackerIdx)} broke ${this.pname(defenderIdx)}'s shield [${positionId}]`, true);
@@ -680,6 +686,10 @@ class GameState {
         plundersFailed: winner.statPlundersFailed || 0,
         attacksSuccess: winner.statAttacksSuccess || 0,
         attacksFailed: winner.statAttacksFailed || 0,
+        defeated: winner.statDefeated || 0,
+        kingUsed: winner.statKingUsed || 0,
+        takeActions: winner.statTakeActions || 0,
+        putActions: winner.statPutActions || 0,
       });
     }
     // Eliminated players: last out = 2nd place (reverse eliminationOrder)
@@ -696,6 +706,10 @@ class GameState {
         plundersFailed: p.statPlundersFailed || 0,
         attacksSuccess: p.statAttacksSuccess || 0,
         attacksFailed: p.statAttacksFailed || 0,
+        defeated: p.statDefeated || 0,
+        kingUsed: p.statKingUsed || 0,
+        takeActions: p.statTakeActions || 0,
+        putActions: p.statPutActions || 0,
       });
     }
     return { rounds: this.roundNumber, players: playerResults };
@@ -728,9 +742,10 @@ class GameState {
       if (i !== -1) attacker.hand.splice(i, 1);
       this.cemetery.push(cardId);
     }
-    if (kingUsed) attacker.kingCovered = false;
+    if (kingUsed) { attacker.kingCovered = false; attacker.statKingUsed = (attacker.statKingUsed || 0) + 1; }
     if (success) {
       attacker.statAttacksSuccess = (attacker.statAttacksSuccess || 0) + 1;
+      attacker.statDefeated = (attacker.statDefeated || 0) + 1;
       this.pushLog(`${this.pname(attackerIdx)} defeated ${this.pname(defenderIdx)}!`, true);
       // Defender loses their king and is eliminated; attacker gains their cards as prey
       defender.isOut = true;

--- a/server/index.js
+++ b/server/index.js
@@ -233,10 +233,12 @@ function checkAndHandleWinner(sess) {
   const winner = sess.gameState.checkWinner();
   if (winner >= 0) {
     sess.winnerHandled = true;
-    console.log("Session " + sess.id + " winner: player " + winner + " — closing session in 5 seconds");
+    console.log("Session " + sess.id + " winner: player " + winner + " — sending gameStats, closing in 5 minutes");
+    // Immediately send stats so clients can show the stats screen
+    io.to(sess.id).emit('gameStats', sess.gameState.getGameStats());
     setTimeout(function() {
       var sessId = sess.id;
-      // Notify all participants to return to the session list
+      // Safety-net: return clients to lobby if they haven't navigated away yet
       io.to(sessId).emit('returnToLobby');
       // Remove all socket→session mappings so these sockets are session-less again
       sess.users.forEach(function(u) {
@@ -253,7 +255,7 @@ function checkAndHandleWinner(sess) {
       delete sessions[sessId];
       broadcastSessionList();
       broadcastPlayerList();
-    }, 5000);
+    }, 5 * 60 * 1000); // 5 minutes — gives players time to read the stats screen
   }
 }
 


### PR DESCRIPTION
Closes #184\n\n## What changed\n\n### Server (`server/gameState.js`)\n- Added per-player stat counters (`statHeroesReceived`, `statPlundersSuccess`, `statPlundersFailed`, `statAttacksSuccess`, `statAttacksFailed`, `statRoundEliminatedAt`) — initialised in `initPlayerStats()`, incremented in `plunderResolved`, `defAttackResolved`, `kingAttackResolved`, and `heroAcquired`\n- Added `eliminationOrder[]` array and `roundNumber` counter; round increments each time the turn order wraps around\n- Added `getGameStats()` method\n- All paths that set `isOut = true` now record the player in `eliminationOrder` and stamp `statRoundEliminatedAt`\n\n### Server (`server/index.js`)\n- `checkAndHandleWinner()` emits `gameStats` immediately when a winner is found\n- Session cleanup delay increased from 5 s → 5 min to give players time to read stats\n\n### Client — new (`core/src/com/mygdx/game/StatsScreen.java`)\n- Two-tab screen ("General" / "Players") styled like the session list\n- General tab: total rounds played\n- Players tab: winner → last eliminated; columns: placement, name, rounds survived, plunders (S/F), attacks (S/F), heroes received\n- "Return to Lobby" button\n\n### Client (`core/src/com/mygdx/game/GameScreen.java`)\n- Added `gameStats` socket listener → navigates to `StatsScreen`