### PR TITLE
Fix expose-defence-card penalty: plundering must not exempt the player from exposing

### DIFF
--- a/server/gameState.js
+++ b/server/gameState.js
@@ -500,7 +500,7 @@ class GameState {
     const lockedHandCards = this.pendingPlunder ? (this.pendingPlunder._lockedHandCards || []) : [];
     this.pendingPlunder = null;
     const attacker = this.players[attackerIdx];
-    attacker.attackCount = (attacker.attackCount || 0) + 1;
+    // NOTE: plundering does NOT increment attackCount — only real attacks (defAttack/kingAttack/warlord) do.
     const handCardsToProcess = lockedHandCards.length > 0 ? lockedHandCards : attackCardIds;
     for (const cardId of handCardsToProcess) {
       const i = attacker.hand.indexOf(cardId);

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -629,6 +629,7 @@ class GameState {
       }
       this.players[currentPlayerIndex].attackingSymbol = 'none';
       this.players[currentPlayerIndex].attackingSymbol2 = 'none';
+      this.players[currentPlayerIndex].didExposeThisTurn = false; // reset expose flag for next turn
     }
     // Advance to the next non-eliminated player (server is authoritative)
     const n = this.players.length;
@@ -655,6 +656,7 @@ class GameState {
     } else if (p.defCards[slot] !== undefined) {
       p.defCardsCovered[slot] = false;
     }
+    p.didExposeThisTurn = true;
     this.pushLog(`${this.pname(playerIdx)} exposed slot ${slot} (no attack)`, false, true);
   }
 
@@ -662,6 +664,7 @@ class GameState {
     const p = this.players[playerIdx];
     if (!p) return;
     p.kingCovered = false;
+    p.didExposeThisTurn = true;
     this.pushLog(`${this.pname(playerIdx)} exposed their king (no attack)`, false, true);
   }
 

--- a/server/index.js
+++ b/server/index.js
@@ -1156,10 +1156,36 @@ io.on('connection', function(socket) {
   socket.on('finishTurn', function(data) {
     var sess = getSession(socket.id);
     if (!sess || !sess.gameState) return;
-    console.log("Turn finished by player index: " + data.currentPlayerIndex);
-    if (data.currentPlayerIndex !== sess.gameState.currentPlayerIndex) {
-      console.log("finishTurn rejected: server currentPlayerIndex=" + sess.gameState.currentPlayerIndex + ", client sent=" + data.currentPlayerIndex);
+    // Verify by socket identity rather than trusting the client-sent currentPlayerIndex.
+    // This is more robust and prevents rejection when the client sends a stale or wrong index
+    // (recurring bug: "nothing happens" after selecting the card to expose on a plunder-only turn).
+    var socketPlayerIdx = sess.users.findIndex(function(u) { return u.id === socket.id; });
+    if (socketPlayerIdx !== sess.gameState.currentPlayerIndex) {
+      console.log("finishTurn rejected: server currentPlayerIndex=" + sess.gameState.currentPlayerIndex + ", socket player=" + socketPlayerIdx + " (client sent " + data.currentPlayerIndex + ")");
       return;
+    }
+    console.log("Turn finished by player index: " + socketPlayerIdx);
+    // Safety net: if no attack was made this turn and the expose-defence-card penalty
+    // was not fulfilled (client did not emit exposeDefCard / exposeKingCard), auto-expose
+    // the first covered card here.  Handles the edge case where the client emits finishTurn
+    // without a preceding exposeDefCard (recurring bug after the #187 plunder-only-turn fix).
+    var p = sess.gameState.players[socketPlayerIdx];
+    if (p && (p.attackCount || 0) === 0 && !p.didExposeThisTurn) {
+      var exposedDef = false;
+      for (var s = 1; s <= 3; s++) {
+        var hasTop = p.topDefCards && p.topDefCards[s] !== undefined;
+        var hasDef = p.defCards && p.defCards[s] !== undefined;
+        var topCovered = hasTop && (!p.topDefCardsCovered || p.topDefCardsCovered[s] !== false);
+        var defCovered = !hasTop && hasDef && (!p.defCardsCovered || p.defCardsCovered[s] !== false);
+        if (topCovered || defCovered) {
+          sess.gameState.exposeDefCard(socketPlayerIdx, s);
+          exposedDef = true;
+          break;
+        }
+      }
+      if (!exposedDef && p.kingCard !== undefined && p.kingCovered !== false) {
+        sess.gameState.exposeKingCard(socketPlayerIdx);
+      }
     }
     sess.gameState.finishTurn();
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());


### PR DESCRIPTION
Closes #187

## Summary

Removes the erroneous `attackCount` increment from `plunderResolved()` in `server/gameState.js`.

A plunder is not an attack for the purpose of the expose-defence-card penalty. With this increment in place, a plunder-only turn would skip the expose overlay entirely — the client saw `attackCounter > 0` and treated the turn as if the player had attacked.

## Change

**`server/gameState.js` — `plunderResolved()`**

Removed:
```js
attacker.attackCount = (attacker.attackCount || 0) + 1;
```

`attackCount` is still correctly incremented in `defAttackResolved`, `kingAttackResolved`, and `warlordDirectAttack`.
