### PR TITLE
Add MCTS-based bot personality

### DIFF
--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -689,8 +689,8 @@ public class MenuScreen extends AbstractScreen {
     cardsBox.setSelected(String.valueOf(pendingStartingCards));
 
     // ── Per-bot personality selectors (Bot 1 / 2 / 3) ───────────────────────
-    final String[] BOT_DISPLAY = {"Off", "Passive", "Balanced", "Aggressive", "Tactician"};
-    final String[] BOT_KEYS    = {"off", "passive", "balanced", "aggressive", "tactician"};
+    final String[] BOT_DISPLAY = {"Off", "Passive", "Balanced", "Aggressive", "Tactician", "MCTS"};
+    final String[] BOT_KEYS    = {"off", "passive", "balanced", "aggressive", "tactician", "mcts"};
     final Label[] botLabels = new Label[3];
     @SuppressWarnings("unchecked")
     final SelectBox<String>[] botBoxes = new SelectBox[3];

--- a/server/bot.js
+++ b/server/bot.js
@@ -2,6 +2,8 @@
 // Factory: call createBotAI(io, checkAndHandleWinner) once to get a bot instance
 // with two public methods: isBot(player) and playBotTurnIfNeeded(sess).
 
+var mctsModule = require('./mcts-sim');
+
 module.exports = function createBotAI(io, checkAndHandleWinner) {
 
   // How long overlays stay visible (ms) — matches human player experience
@@ -105,11 +107,24 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     }
   }
 
+  /**
+   * MCTS — Monte Carlo Tree Search bot.
+   * Uses statistical simulation to choose the best action each turn.
+   * Falls back to balanced heuristics for setup steps.
+   */
+  class MctsPersonality extends BotPersonality {
+    constructor() { super('mcts'); }
+    maxAttacksPerTurn()     { return 2; }
+    allowScouting()         { return true; }
+    sacrificeJokerForHero() { return true; }
+  }
+
   var PERSONALITIES = {
     balanced:   new BalancedPersonality(),
     passive:    new PassivePersonality(),
     aggressive: new AggressivePersonality(),
     tactician:  new TacticianPersonality(),
+    mcts:       new MctsPersonality(),
   };
 
   function getPersonality(mode) {
@@ -829,7 +844,129 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     if (!p || p.isOut) return;
 
     var personality = getPersonality(p.botMode || 'balanced');
+    if (personality.name === 'mcts') {
+      executeMctsTurnAsync(sess, gs, idx);
+      return;
+    }
     executeBotTurnWithPersonality(sess, gs, idx, personality);
+  }
+
+  // ── MCTS Bot Turn ────────────────────────────────────────────────────────────
+  // Runs balanced setup steps, then uses Monte Carlo Tree Search to select
+  // the best first action (plunder, defense attack, or king attack).
+  function executeMctsTurnAsync(sess, gs, idx) {
+    var p = gs.players[idx];
+    if (!p || p.isOut) return;
+
+    // Setup: same heuristics as balanced bot
+    botTryJokerSacrifice(sess, gs, idx);
+    botFillDefense(gs, idx, getPersonality('balanced'));
+    if (botReplaceExposedDefense(gs, idx)) {
+      io.to(sess.id).emit('stateUpdate', gs.serialize());
+    }
+    if (botUseActiveHeroes(gs, idx)) {
+      io.to(sess.id).emit('stateUpdate', gs.serialize());
+    }
+
+    // MCTS action selection (synchronous)
+    var action = null;
+    try {
+      action = mctsModule.mctsSearch(gs, idx, 300);
+    } catch (e) {
+      console.log('[MCTS bot] search error:', e.message);
+    }
+
+    if (!action) {
+      botFinishTurn(sess, gs, idx, false);
+      return;
+    }
+
+    if (action.type === 'plunder') {
+      var plDeck = gs.pickingDecks[action.deckIndex];
+      var plTopCard = plDeck && plDeck.length > 0 ? plDeck[plDeck.length - 1] : null;
+      var plAtkSum = action.symbol === 'joker' ? 999
+        : action.cardIds.reduce(function(s, id) { return s + gs.cardStrength(id); }, 0);
+      var plDefStrength = plTopCard ? gs.cardStrength(plTopCard.id) : 0;
+      var plSuccess = plAtkSum > plDefStrength;
+      gs.setPlunderPreview({
+        attackerIdx: idx, deckIndex: action.deckIndex,
+        attackCardIds: action.cardIds,
+        attackingSymbol: action.symbol, attackingSymbol2: 'none',
+        success: plSuccess, attackSum: plAtkSum,
+        defCardId: plTopCard ? plTopCard.id : -1,
+        defStrength: plDefStrength
+      });
+      io.to(sess.id).emit('stateUpdate', gs.serialize());
+      var plAction = action;
+      setTimeout(function() {
+        gs.plunderResolved(idx, plAction.deckIndex, plSuccess, plAction.cardIds, false, []);
+        io.to(sess.id).emit('stateUpdate', gs.serialize());
+        checkAndHandleWinner(sess);
+        botFinishTurn(sess, gs, idx, false);
+      }, BOT_ACTION_DELAY);
+      return;
+    }
+
+    if (action.type === 'defAttack') {
+      var daDefender = gs.players[action.defenderIdx];
+      var daDefCardId = daDefender.defCards[action.positionId];
+      var daDefBoost = (daDefender.defCardsBoost && daDefender.defCardsBoost[action.positionId]) || 0;
+      var daTopCardId = (daDefender.topDefCards && daDefender.topDefCards[action.positionId]) || null;
+      var daTopBoost = daTopCardId ? ((daDefender.topDefCardsBoost && daDefender.topDefCardsBoost[action.positionId]) || 0) : 0;
+      var daThreshold = gs.cardStrength(daDefCardId) + daDefBoost + (daTopCardId ? gs.cardStrength(daTopCardId) + daTopBoost : 0);
+      var daAtkSum = action.cardIds.reduce(function(s, id) { return s + gs.cardStrength(id); }, 0);
+      var daSuccess = daAtkSum > daThreshold;
+      var daPreview = {
+        attackerIdx: idx, defenderIdx: action.defenderIdx,
+        positionId: action.positionId, level: 0,
+        attackingSymbol: action.symbol, attackingSymbol2: 'none',
+        success: daSuccess, attackCardIds: action.cardIds,
+        defCardIds: daDefCardId != null ? [daDefCardId] : []
+      };
+      gs.setAttackPreview(daPreview);
+      io.to(sess.id).emit('stateUpdate', gs.serialize());
+      var daChoice = {
+        defenderIdx: action.defenderIdx,
+        positionId: action.positionId,
+        cardIds: action.cardIds,
+        symbol: action.symbol,
+        success: daSuccess
+      };
+      botDoDefAttackWithBatteryCheck(sess, gs, daChoice, daPreview, function() {
+        botFinishTurn(sess, gs, idx, true);
+      });
+      return;
+    }
+
+    if (action.type === 'kingAttack') {
+      var kaDefender = gs.players[action.defenderIdx];
+      var kaKingStr = gs.cardStrength(kaDefender.kingCard) + (kaDefender.kingCardBoost || 0);
+      var kaAtkSum = action.symbol === 'joker' ? 999
+        : action.cardIds.reduce(function(s, id) { return s + gs.cardStrength(id); }, 0);
+      var kaSuccess = kaAtkSum > kaKingStr;
+      gs.setAttackPreview({
+        attackerIdx: idx, defenderIdx: action.defenderIdx, positionId: 0, level: 0,
+        attackingSymbol: action.symbol, attackingSymbol2: 'none',
+        success: kaSuccess, attackCardIds: action.cardIds,
+        defCardIds: kaDefender.kingCard != null ? [kaDefender.kingCard] : []
+      });
+      io.to(sess.id).emit('stateUpdate', gs.serialize());
+      var kaDi = action.defenderIdx;
+      var kaCards = action.cardIds;
+      setTimeout(function() {
+        gs.kingAttackResolved(idx, kaDi, kaSuccess, kaCards, false);
+        if (gs.pendingHeroSelection && gs.pendingHeroSelection.attackerIdx === idx) {
+          gs.resolveHeroSelection(gs.pendingHeroSelection.options[0]);
+        }
+        io.to(sess.id).emit('stateUpdate', gs.serialize());
+        checkAndHandleWinner(sess);
+        botFinishTurn(sess, gs, idx, true);
+      }, BOT_ACTION_DELAY);
+      return;
+    }
+
+    // Fallback: pass
+    botFinishTurn(sess, gs, idx, false);
   }
 
   function executeBotTurnWithPersonality(sess, gs, idx, personality) {

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -538,6 +538,9 @@ class GameState {
         attacker.isOut = true;
         attacker.statRoundEliminatedAt = this.roundNumber;
         this.eliminationOrder.push(attacker.index);
+        // Remaining hand cards go to cemetery when eliminated
+        for (const cardId of attacker.hand) this.cemetery.push(cardId);
+        attacker.hand = [];
       }
       // Keep the attacked (top) card face-up after a failed plunder,
       // then add a new face-down card on top.
@@ -595,6 +598,9 @@ class GameState {
         attacker.isOut = true;
         attacker.statRoundEliminatedAt = this.roundNumber;
         this.eliminationOrder.push(attacker.index);
+        // Remaining hand cards go to cemetery when eliminated
+        for (const cardId of attacker.hand) this.cemetery.push(cardId);
+        attacker.hand = [];
       }
       // Mark attacked card(s) as revealed (face-up) — they stay in defCards but must remain visible
       if (!defender.defCardsCovered) defender.defCardsCovered = {};
@@ -783,6 +789,9 @@ class GameState {
         attacker.isOut = true;
         attacker.statRoundEliminatedAt = this.roundNumber;
         this.eliminationOrder.push(attacker.index);
+        // Remaining hand cards go to cemetery when eliminated
+        for (const cardId of attacker.hand) this.cemetery.push(cardId);
+        attacker.hand = [];
       }
     }
   }

--- a/server/index.js
+++ b/server/index.js
@@ -994,7 +994,7 @@ io.on('connection', function(socket) {
     var sess = createSession(sessionName, allowHeroSelection, startingCards, manualSetup);
     // botModes: array of personality strings, e.g. ["aggressive","passive"].
     // Falls back to legacy botCount (numeric) for backward compat.
-    var VALID_MODES = ['passive', 'balanced', 'aggressive', 'tactician'];
+    var VALID_MODES = ['passive', 'balanced', 'aggressive', 'tactician', 'mcts'];
     var botModes = [];
     if (data && Array.isArray(data.botModes)) {
       botModes = data.botModes.filter(function(m) { return VALID_MODES.indexOf(String(m)) !== -1; }).slice(0, 3);
@@ -1004,7 +1004,7 @@ io.on('connection', function(socket) {
     }
     var cToken = (data && data.token) ? String(data.token).slice(0, 64) : null;
     sess.users.push(makeUser(socket.id, name, cToken));
-    var BOT_MODE_LABELS = { passive: 'Passive', balanced: 'Balanced', aggressive: 'Aggressive', tactician: 'Tactician' };
+    var BOT_MODE_LABELS = { passive: 'Passive', balanced: 'Balanced', aggressive: 'Aggressive', tactician: 'Tactician', mcts: 'MCTS' };
     for (var bi = 0; bi < botModes.length; bi++) {
       var mode = botModes[bi];
       var label = BOT_MODE_LABELS[mode] || 'Bot';

--- a/server/index.js
+++ b/server/index.js
@@ -1263,8 +1263,14 @@ io.on('connection', function(socket) {
     if (!sess || !sess.gameState) return;
     console.log("plunderResolved: attackerIdx=" + data.attackerIdx + " deckIndex=" + data.deckIndex + " success=" + data.success);
     sess.gameState.plunderResolved(data.attackerIdx, data.deckIndex, data.success, data.attackCardIds || [], data.kingUsed || false, data.attackerOwnDefCardIds || []);
+    // Auto-finish turn if attacker was eliminated (failed king-used plunder)
+    var plAttacker = sess.gameState.players[data.attackerIdx];
+    if (plAttacker && plAttacker.isOut && sess.gameState.currentPlayerIndex === data.attackerIdx) {
+      sess.gameState.finishTurn();
+    }
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
     checkAndHandleWinner(sess);
+    bot.playBotTurnIfNeeded(sess);
   });
 
   socket.on('attackPreview', function(data) {
@@ -1279,8 +1285,14 @@ io.on('connection', function(socket) {
     if (!sess || !sess.gameState) return;
     console.log("defAttackResolved: attackerIdx=" + data.attackerIdx + " targetPlayerIdx=" + data.targetPlayerIdx + " success=" + data.success);
     sess.gameState.defAttackResolved(data.attackerIdx, data.targetPlayerIdx, data.positionId, data.level, data.success, data.attackCardIds || [], data.kingUsed || false, data.attackerOwnDefCardIds || []);
+    // Auto-finish turn if attacker was eliminated (failed king-used attack)
+    var daAttacker = sess.gameState.players[data.attackerIdx];
+    if (daAttacker && daAttacker.isOut && sess.gameState.currentPlayerIndex === data.attackerIdx) {
+      sess.gameState.finishTurn();
+    }
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
     checkAndHandleWinner(sess);
+    bot.playBotTurnIfNeeded(sess);
   });
 
   socket.on('kingAttackResolved', function(data) {
@@ -1288,8 +1300,14 @@ io.on('connection', function(socket) {
     if (!sess || !sess.gameState) return;
     console.log("kingAttackResolved: attackerIdx=" + data.attackerIdx + " defenderIdx=" + data.defenderIdx + " success=" + data.success);
     sess.gameState.kingAttackResolved(data.attackerIdx, data.defenderIdx, data.success, data.attackCardIds || [], data.kingUsed || false);
+    // Auto-finish turn if attacker was eliminated (failed king-used attack)
+    var kaAttacker = sess.gameState.players[data.attackerIdx];
+    if (kaAttacker && kaAttacker.isOut && sess.gameState.currentPlayerIndex === data.attackerIdx) {
+      sess.gameState.finishTurn();
+    }
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
     checkAndHandleWinner(sess);
+    bot.playBotTurnIfNeeded(sess);
   });
 
   socket.on('heroSelectedFromKingDefeat', function(data) {

--- a/server/mcts-sim.js
+++ b/server/mcts-sim.js
@@ -1,0 +1,362 @@
+'use strict';
+/**
+ * Fast synchronous game simulator for MCTS.
+ * No I/O, no hero abilities, no socket events.
+ * Used by the MCTS bot personality to evaluate moves.
+ */
+
+function simCardStrength(cardId) {
+  if (!cardId || cardId > 52) return 999;
+  var idx = (cardId - 1) % 13 + 1;
+  return idx === 1 ? 14 : idx;
+}
+
+function simCardSuit(cardId) {
+  if (cardId > 52) return 'joker';
+  var si = Math.floor((cardId - 1) / 13);
+  return ['clubs', 'diamonds', 'hearts', 'spades'][si];
+}
+
+function simGroupBySuit(hand) {
+  var groups = {};
+  for (var i = 0; i < hand.length; i++) {
+    var id = hand[i];
+    if (id > 52) continue;
+    var suit = simCardSuit(id);
+    if (!groups[suit]) groups[suit] = [];
+    groups[suit].push(id);
+  }
+  return groups;
+}
+
+/**
+ * Find the minimal subset of `cards` whose combined strength is STRICTLY GREATER
+ * than `threshold`.  Returns an array of card IDs, or null if impossible.
+ */
+function simMinimalWinning(cards, threshold) {
+  if (!cards || cards.length === 0) return null;
+  var sorted = cards.slice().sort(function(a, b) {
+    return simCardStrength(a) - simCardStrength(b);
+  });
+  var total = 0;
+  for (var i = 0; i < sorted.length; i++) total += simCardStrength(sorted[i]);
+  if (total <= threshold) return null; // even all cards can't beat threshold
+  // Greedy: take strongest cards first until sum > threshold
+  var chosen = [];
+  var sum = 0;
+  for (var j = sorted.length - 1; j >= 0 && sum <= threshold; j--) {
+    chosen.push(sorted[j]);
+    sum += simCardStrength(sorted[j]);
+  }
+  return chosen;
+}
+
+/**
+ * Deep-clone the game state for simulation.
+ * Copies only the fields the simulator needs.
+ */
+function simClone(gs) {
+  return {
+    players: gs.players.map(function(p) {
+      return {
+        index: p.index,
+        hand: p.hand.slice(),
+        defCards: Object.assign({}, p.defCards),
+        topDefCards: Object.assign({}, p.topDefCards || {}),
+        defCardsCovered: Object.assign({}, p.defCardsCovered || {}),
+        topDefCardsCovered: Object.assign({}, p.topDefCardsCovered || {}),
+        defCardsBoost: Object.assign({}, p.defCardsBoost || {}),
+        topDefCardsBoost: Object.assign({}, p.topDefCardsBoost || {}),
+        kingCard: p.kingCard,
+        kingCardBoost: p.kingCardBoost || 0,
+        isOut: p.isOut,
+        pickingDeckAttacks: p.pickingDeckAttacks != null ? p.pickingDeckAttacks : 1,
+      };
+    }),
+    pickingDecks: gs.pickingDecks.map(function(deck) {
+      return deck.map(function(c) { return { id: c.id, covered: c.covered }; });
+    }),
+    deck: gs.deck.slice(),
+    cemetery: gs.cemetery.slice(),
+    currentPlayerIndex: gs.currentPlayerIndex,
+  };
+}
+
+/**
+ * Returns all legal actions for the current player.
+ * allowCovered: if true, also consider attacks on covered defense cards (used in rollouts).
+ */
+function simLegalActions(sim, allowCovered) {
+  var idx = sim.currentPlayerIndex;
+  var p = sim.players[idx];
+  if (!p || p.isOut) return [{ type: 'pass' }];
+
+  var actions = [];
+  var groups = simGroupBySuit(p.hand);
+  var jokers = p.hand.filter(function(id) { return id > 52; });
+  var suits = Object.keys(groups);
+
+  // ---- Plunder ----
+  if ((p.pickingDeckAttacks || 0) > 0) {
+    for (var di = 0; di < sim.pickingDecks.length; di++) {
+      var deck = sim.pickingDecks[di];
+      if (deck.length === 0) continue;
+      var topCard = deck[deck.length - 1];
+      var threshold = simCardStrength(topCard.id);
+      for (var si = 0; si < suits.length; si++) {
+        var combo = simMinimalWinning(groups[suits[si]], threshold);
+        if (combo) actions.push({ type: 'plunder', deckIndex: di, cardIds: combo, symbol: suits[si] });
+      }
+      if (jokers.length > 0) {
+        actions.push({ type: 'plunder', deckIndex: di, cardIds: [jokers[0]], symbol: 'joker' });
+      }
+    }
+  }
+
+  // ---- Defense card attacks ----
+  for (var dpi = 0; dpi < sim.players.length; dpi++) {
+    if (dpi === idx) continue;
+    var defender = sim.players[dpi];
+    if (defender.isOut) continue;
+    for (var slot = 1; slot <= 3; slot++) {
+      var defCardId = defender.defCards[slot];
+      if (defCardId == null) continue;
+      var isFaceUp = defender.defCardsCovered[slot] === false;
+      if (!isFaceUp && !allowCovered) continue;
+      var defBoost = defender.defCardsBoost[slot] || 0;
+      var topCardId = defender.topDefCards[slot];
+      var topBoost = topCardId ? (defender.topDefCardsBoost[slot] || 0) : 0;
+      var defThreshold = simCardStrength(defCardId) + defBoost
+        + (topCardId ? simCardStrength(topCardId) + topBoost : 0);
+      for (var ssi = 0; ssi < suits.length; ssi++) {
+        var defCombo = simMinimalWinning(groups[suits[ssi]], defThreshold);
+        if (defCombo) actions.push({ type: 'defAttack', defenderIdx: dpi, positionId: slot, cardIds: defCombo, symbol: suits[ssi] });
+      }
+    }
+  }
+
+  // ---- King attacks (all defense slots empty for target) ----
+  for (var kpi = 0; kpi < sim.players.length; kpi++) {
+    if (kpi === idx) continue;
+    var kDefender = sim.players[kpi];
+    if (kDefender.isOut) continue;
+    if (kDefender.kingCard == null) continue;
+    var allEmpty = true;
+    for (var ks = 1; ks <= 3; ks++) {
+      if (kDefender.defCards[ks] != null || kDefender.topDefCards[ks] != null) { allEmpty = false; break; }
+    }
+    if (!allEmpty) continue;
+    var kingStr = simCardStrength(kDefender.kingCard) + (kDefender.kingCardBoost || 0);
+    for (var ksi = 0; ksi < suits.length; ksi++) {
+      var kingCombo = simMinimalWinning(groups[suits[ksi]], kingStr);
+      if (kingCombo) actions.push({ type: 'kingAttack', defenderIdx: kpi, cardIds: kingCombo, symbol: suits[ksi] });
+    }
+    if (jokers.length > 0) {
+      actions.push({ type: 'kingAttack', defenderIdx: kpi, cardIds: [jokers[0]], symbol: 'joker' });
+    }
+  }
+
+  actions.push({ type: 'pass' });
+  return actions;
+}
+
+function simPickCard(sim) {
+  if (sim.deck.length === 0) {
+    if (sim.cemetery.length === 0) return null;
+    sim.deck = sim.cemetery.slice();
+    sim.cemetery = [];
+    // Shuffle
+    for (var i = sim.deck.length - 1; i > 0; i--) {
+      var j = Math.floor(Math.random() * (i + 1));
+      var tmp = sim.deck[i]; sim.deck[i] = sim.deck[j]; sim.deck[j] = tmp;
+    }
+  }
+  return sim.deck.pop();
+}
+
+function simFinishTurn(sim) {
+  var idx = sim.currentPlayerIndex;
+  if (sim.players[idx]) sim.players[idx].pickingDeckAttacks = 1;
+  var n = sim.players.length;
+  var next = (idx + 1) % n;
+  var safety = 0;
+  while (sim.players[next].isOut && next !== idx && ++safety < n) {
+    next = (next + 1) % n;
+  }
+  sim.currentPlayerIndex = next;
+}
+
+function simApplyAction(sim, action) {
+  var idx = sim.currentPlayerIndex;
+  var p = sim.players[idx];
+  var i, cardId;
+
+  if (action.type === 'plunder') {
+    p.pickingDeckAttacks = 0;
+    for (i = 0; i < action.cardIds.length; i++) {
+      cardId = action.cardIds[i];
+      var hi = p.hand.indexOf(cardId);
+      if (hi !== -1) p.hand.splice(hi, 1);
+      sim.cemetery.push(cardId);
+    }
+    var deck = sim.pickingDecks[action.deckIndex];
+    var topCard = deck[deck.length - 1];
+    var comboSum = action.symbol === 'joker' ? 999
+      : action.cardIds.reduce(function(s, id) { return s + simCardStrength(id); }, 0);
+    if (comboSum > simCardStrength(topCard.id)) {
+      // Success: take all picking deck cards
+      for (i = 0; i < deck.length; i++) p.hand.push(deck[i].id);
+      sim.pickingDecks[action.deckIndex] = [];
+      var other = 1 - action.deckIndex;
+      var c1 = simPickCard(sim); if (c1) sim.pickingDecks[other].push({ id: c1, covered: true });
+      var c2 = simPickCard(sim); if (c2) sim.pickingDecks[action.deckIndex].push({ id: c2, covered: false });
+      var c3 = simPickCard(sim); if (c3) sim.pickingDecks[action.deckIndex].push({ id: c3, covered: true });
+    } else {
+      // Failed: deck gets another card
+      var c4 = simPickCard(sim); if (c4) deck.push({ id: c4, covered: true });
+    }
+    simFinishTurn(sim);
+
+  } else if (action.type === 'defAttack') {
+    for (i = 0; i < action.cardIds.length; i++) {
+      cardId = action.cardIds[i];
+      var dhi = p.hand.indexOf(cardId);
+      if (dhi !== -1) p.hand.splice(dhi, 1);
+      sim.cemetery.push(cardId);
+    }
+    var defender = sim.players[action.defenderIdx];
+    // Reveal the card
+    defender.defCardsCovered[action.positionId] = false;
+    // Compute whether attack wins
+    var defCardId = defender.defCards[action.positionId];
+    var defBoost = defender.defCardsBoost[action.positionId] || 0;
+    var topCardId = defender.topDefCards[action.positionId];
+    var topBoost = topCardId ? (defender.topDefCardsBoost[action.positionId] || 0) : 0;
+    var threshold = simCardStrength(defCardId) + defBoost
+      + (topCardId ? simCardStrength(topCardId) + topBoost : 0);
+    var atkSum = action.cardIds.reduce(function(s, id) { return s + simCardStrength(id); }, 0);
+    if (atkSum > threshold) {
+      // Attacker takes defense card(s)
+      if (defCardId != null) { p.hand.push(defCardId); delete defender.defCards[action.positionId]; }
+      if (topCardId != null) { p.hand.push(topCardId); delete defender.topDefCards[action.positionId]; }
+      delete defender.defCardsCovered[action.positionId];
+      if (defender.topDefCardsCovered) delete defender.topDefCardsCovered[action.positionId];
+    }
+    simFinishTurn(sim);
+
+  } else if (action.type === 'kingAttack') {
+    for (i = 0; i < action.cardIds.length; i++) {
+      cardId = action.cardIds[i];
+      var khi = p.hand.indexOf(cardId);
+      if (khi !== -1) p.hand.splice(khi, 1);
+      sim.cemetery.push(cardId);
+    }
+    var kDefender = sim.players[action.defenderIdx];
+    // King attack: attacker takes all defender's cards; defender is out
+    for (i = 0; i < kDefender.hand.length; i++) p.hand.push(kDefender.hand[i]);
+    kDefender.hand = [];
+    if (kDefender.kingCard != null) { p.hand.push(kDefender.kingCard); kDefender.kingCard = null; }
+    kDefender.isOut = true;
+    simFinishTurn(sim);
+
+  } else {
+    // pass: expose first covered defense card to enable future attacks
+    var exposed = false;
+    for (var slot = 1; slot <= 3 && !exposed; slot++) {
+      if (p.defCards[slot] != null && p.defCardsCovered[slot] !== false) {
+        p.defCardsCovered[slot] = false;
+        exposed = true;
+      }
+    }
+    simFinishTurn(sim);
+  }
+}
+
+function simWinner(sim) {
+  var alive = sim.players.filter(function(p) { return !p.isOut; });
+  return alive.length === 1 ? alive[0].index : -1;
+}
+
+/**
+ * Run a random rollout from `sim` up to maxTurns, returning winning player index or -1.
+ * allowCovered=true: permits attacking covered defense cards to make rollouts richer.
+ */
+function simRandomPlayout(sim, maxTurns) {
+  maxTurns = maxTurns || 80;
+  for (var t = 0; t < maxTurns; t++) {
+    var winner = simWinner(sim);
+    if (winner !== -1) return winner;
+    var actions = simLegalActions(sim, true); // allow covered in rollouts
+    var active = actions.filter(function(a) { return a.type !== 'pass'; });
+    var chosen = active.length > 0
+      ? active[Math.floor(Math.random() * active.length)]
+      : actions[0];
+    simApplyAction(sim, chosen);
+  }
+  // Timeout heuristic: prefer the player with fewest remaining defense cards
+  var alive = sim.players.filter(function(p) { return !p.isOut; });
+  if (alive.length === 0) return -1;
+  var best = alive[0];
+  var bestShields = 99;
+  for (var pi = 0; pi < alive.length; pi++) {
+    var shields = 0;
+    for (var s = 1; s <= 3; s++) {
+      if (alive[pi].defCards[s] != null || alive[pi].topDefCards[s] != null) shields++;
+    }
+    if (shields < bestShields) { bestShields = shields; best = alive[pi]; }
+  }
+  return best.index;
+}
+
+var MCTS_C = Math.sqrt(2);
+
+/**
+ * Run MCTS from the perspective of `playerIdx` to select the best first action.
+ * Returns the chosen action object, or null if no active actions are available.
+ */
+function mctsSearch(gs, playerIdx, iterations) {
+  iterations = iterations || 300;
+
+  var sim0 = simClone(gs);
+  sim0.currentPlayerIndex = playerIdx;
+  var rootActions = simLegalActions(sim0, false);
+
+  // Only offer active (non-pass) actions at the root; fall back to pass if nothing else.
+  var searchActions = rootActions.filter(function(a) { return a.type !== 'pass'; });
+  if (searchActions.length === 0) return null; // signal caller to pass
+  if (searchActions.length === 1) return searchActions[0];
+
+  var wins = new Array(searchActions.length).fill(0);
+  var visits = new Array(searchActions.length).fill(0);
+  var totalVisits = 0;
+
+  for (var iter = 0; iter < iterations; iter++) {
+    // UCB1 selection
+    var chosen = 0;
+    var bestScore = -Infinity;
+    for (var i = 0; i < searchActions.length; i++) {
+      var score = visits[i] === 0
+        ? Infinity
+        : wins[i] / visits[i] + MCTS_C * Math.sqrt(Math.log(totalVisits + 1) / visits[i]);
+      if (score > bestScore) { bestScore = score; chosen = i; }
+    }
+    // Simulate
+    var sim = simClone(gs);
+    sim.currentPlayerIndex = playerIdx;
+    simApplyAction(sim, searchActions[chosen]);
+    var rolloutWinner = simRandomPlayout(sim, 80);
+    // Backpropagate
+    visits[chosen]++;
+    totalVisits++;
+    if (rolloutWinner === playerIdx) wins[chosen]++;
+  }
+
+  // Robust child selection: most visited
+  var bestIdx = 0;
+  for (var j = 1; j < searchActions.length; j++) {
+    if (visits[j] > visits[bestIdx]) bestIdx = j;
+  }
+  return searchActions[bestIdx];
+}
+
+module.exports = { mctsSearch, simClone, simLegalActions, simWinner };


### PR DESCRIPTION
Closes #192

## Summary

Adds a new **MCTS** (Monte Carlo Tree Search) bot personality that uses statistical simulation to choose its actions, rather than hand-coded heuristics.

## What's new

### `server/mcts-sim.js` (new file)
A fast, synchronous game simulator used exclusively for planning:
- Clones the live game state and runs thousands of simulated games
- Models plunder, defense attacks, and king attacks (strict `>` win condition)
- Random rollouts prefer attacking over passing; falls back to a heuristic when the turn limit is reached
- No I/O, no hero abilities modeled (acceptable simplification for v1)

### `server/bot.js`
- `MctsPersonality` class registered under key `mcts`
- `executeMctsTurnAsync`: runs balanced setup steps (fill defense, replace exposed, use heroes), then calls `mctsSearch(gs, idx, 300)` synchronously to pick the best first action, then executes it with the same preview/delay flow as other personalities

### `server/index.js`
- `'mcts'` added to `VALID_MODES`
- `mcts: 'MCTS'` added to `BOT_MODE_LABELS`

### `core/src/com/mygdx/game/MenuScreen.java`
- `"MCTS"` / `"mcts"` added to the bot mode selector arrays
