### PR TITLE
Fix give-up (stay): clear session + hand, prevent refresh reconnect loop

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -4724,6 +4724,8 @@ public class GameScreen extends ScreenAdapter {
       data.put("playerIndex", playerIndex);
       socket.emit("giveUp", data);
     } catch (JSONException e) { e.printStackTrace(); }
+    // Clear the saved session so a page-refresh does not auto-reconnect to the running game.
+    MyGdxGame.playerStorage.clearSessionId();
   }
 
   private void emitGiveUpAndLeave() {
@@ -5003,8 +5005,13 @@ public class GameScreen extends ScreenAdapter {
           p.setKingCard(null);
         }
 
-        // Apply out flag
+        // Apply out flag; if this client's own player just became eliminated, switch to spectator mode
+        // so game-action input is no longer processed.
+        boolean wasOut = p.isOut();
         p.setOut(pj.optBoolean("isOut", false));
+        if (!wasOut && p.isOut() && p == currentPlayer && !isSpectator) {
+          isSpectator = true;
+        }
 
         // Sync slot sabotage state from server-authoritative state
         for (int sl = 1; sl <= 3; sl++) p.clearSlotSabotaged(sl);

--- a/server/index.js
+++ b/server/index.js
@@ -1729,14 +1729,30 @@ io.on('connection', function(socket) {
     if (playerIdx < 0 || playerIdx >= sess.gameState.players.length) return;
     var player = sess.gameState.players[playerIdx];
     if (player.isOut) return;
-    console.log("Player " + playerIdx + " (" + player.name + ") gave up in session " + sess.id);
+    console.log("Player " + playerIdx + " (" + player.name + ") gave up (stay) in session " + sess.id);
     player.isOut = true;
-    if (sess.gameState.currentPlayerIndex === playerIdx) {
+    sess.gameState.eliminationOrder.push(playerIdx);
+    // Move hand cards to cemetery (same as other elimination paths).
+    for (var ci = 0; ci < player.hand.length; ci++) {
+      sess.gameState.cemetery.push(player.hand[ci]);
+    }
+    player.hand = [];
+    var wasCurrentPlayer = sess.gameState.currentPlayerIndex === playerIdx;
+    if (wasCurrentPlayer) {
       sess.gameState.finishTurn();
+    }
+    // Clear token map so a page-refresh does not ghost-reconnect the player.
+    var token = findTokenBySocketId(socket.id);
+    if (token && tokenMap[token]) {
+      delete tokenMap[token].sessionId;
+      delete tokenMap[token].playerIdx;
     }
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
     checkAndHandleWinner(sess);
-    bot.playBotTurnIfNeeded(sess);
+    // Only restart bot chain if we advanced the turn.
+    if (wasCurrentPlayer) {
+      bot.playBotTurnIfNeeded(sess);
+    }
   });
 
   socket.on('giveUpAndLeave', function(data) {


### PR DESCRIPTION
Closes #198

## Root cause

`giveUp` (Stay) did not clear the server-side `tokenMap` session binding or the client's stored `sessionId`. Every page refresh or socket reconnect sent the player back into the game as an eliminated participant — a loop with no way out.

## Changes

### `server/index.js` — `giveUp` socket handler
- Clears `tokenMap[token].sessionId` and `.playerIdx`, same as `giveUpAndLeave` already did.
- Adds player to `eliminationOrder` so they appear correctly in end-of-game stats.
- Moves player's hand cards to the cemetery (consistent with all other elimination paths).
- Fixed `wasCurrentPlayer` / conditional bot-chain restart (matches `giveUpAndLeave` pattern).

### `core/…/GameScreen.java` — `emitGiveUp()`
- Calls `MyGdxGame.playerStorage.clearSessionId()` after emitting, so a page refresh lands on the lobby rather than reconnecting to the running game.

### `core/…/GameScreen.java` — `applyStateUpdate()`
- When the server confirms the own player is now `isOut`, sets `isSpectator = true` so game-action input is no longer processed for the eliminated player.