### PR TITLE
Fix: hand-area click regression caused by handHighlight overlay blocking input

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -672,6 +672,8 @@ public class GameScreen extends ScreenAdapter {
     handHighlight = new Image(whiteDrw);
     handHighlight.setFillParent(true);
     handHighlight.setColor(0.3f, 0.8f, 0.3f, 0f);
+    // Purely visual — must not consume input events that handBck's listener needs.
+    handHighlight.setTouchable(com.badlogic.gdx.scenes.scene2d.Touchable.disabled);
 
     // Clicking anywhere in the hand area takes the currently-selected defense card.
     handBck.addListener(new ClickListener() {


### PR DESCRIPTION
## Problem

After the wooden backgrounds PR (#200), clicking a defence card and then into the hand area to take it back no longer worked. The `handHighlight` overlay (a full-stage `Image` added above `handBck`) was intercepting all touch/click events, preventing `handBck`'s `ClickListener` from ever firing.

## Fix

Set `handHighlight.setTouchable(Touchable.disabled)` so the overlay is purely visual and all input falls through to `handBck`'s listener as before.