### PR TITLE
Fix: hand count label blocks Priest hero deck click

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -1214,6 +1214,7 @@ public class GameScreen extends ScreenAdapter {
         if (i != playerIndex) {
           Label handCountLabel = new Label(String.valueOf(handCards.size()), MyGdxGame.skin);
           handCountLabel.setColor(Color.BLACK);
+          handCountLabel.setTouchable(com.badlogic.gdx.scenes.scene2d.Touchable.disabled);
           float lw = handCountLabel.getPrefWidth();
           float lh = handCountLabel.getPrefHeight();
           handCountLabel.setPosition(deckX + cardW / 2f - lw / 2f, deckY + cardH / 2f - lh / 2f);


### PR DESCRIPTION
## Problem

When the Priest hero is selected and the player tries to click on an enemy hand card deck, the hand-count label (the number shown on top of the deck) was blocking the click. The label sits above the deck card in the actor Z-order and is touchable by default, so it consumed the input event before it could reach the deck card's listener.

## Fix

Set `handCountLabel.setTouchable(Touchable.disabled)` — same pattern already used for `boostCountLabel` and `handHighlight`. The number still renders on top of the deck but no longer intercepts clicks.