### PR TITLE
History overlay: show all events with scrollbar and don't close when game updates

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -132,6 +132,7 @@ public class GameScreen extends ScreenAdapter {
   private SocketClient socket;
   private Game game;
   private boolean menuOpen = false;
+  private boolean logOpen = false;
   private InputMultiplexer menuAndGameMulti;
   // Battery Tower: stored when this local player is the defender and must allow/deny
   private JSONObject pendingBatteryDefCheck = null;
@@ -779,7 +780,11 @@ public class GameScreen extends ScreenAdapter {
     }
 
     if (menuOpen) {
-      buildMenuOverlay();
+      if (logOpen) {
+        showLogOverlay();
+      } else {
+        buildMenuOverlay();
+      }
     } else {
       addMenuButtonToOverlay();
       if (isTutorial && tutorialStep >= 0) {
@@ -4035,6 +4040,7 @@ public class GameScreen extends ScreenAdapter {
   }
 
   private void buildMenuOverlay() {
+    logOpen = false;
     overlayStage.clear();
 
     Image bg = new Image(MyGdxGame.skin, "white");
@@ -4120,6 +4126,7 @@ public class GameScreen extends ScreenAdapter {
   }
 
   private void showLogOverlay() {
+    logOpen = true;
     overlayStage.clear();
 
     Image bg = new Image(MyGdxGame.skin, "white");
@@ -4195,6 +4202,7 @@ public class GameScreen extends ScreenAdapter {
 
   private void closeMenu() {
     menuOpen = false;
+    logOpen = false;
     overlayStage.clear();
     addMenuButtonToOverlay();
     // render() will set the correct input processor next frame

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -611,7 +611,7 @@ public class GameScreen extends ScreenAdapter {
           @Override
           public void run() {
             screenDisposed = true;
-            theGame.setScreen(new StatsScreen(theGame, theSocket, statsJson));
+            theGame.setScreen(new StatsScreen(theGame, theSocket, statsJson, activityLog));
           }
         });
       }

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -734,7 +734,7 @@ public class GameScreen extends ScreenAdapter {
 
     gameStage.clear();
     handStage.clear();
-    overlayStage.clear();
+    if (!logOpen) overlayStage.clear();
 
     gameStage.addActor(gameBck);
     handStage.addActor(handBck);
@@ -779,13 +779,9 @@ public class GameScreen extends ScreenAdapter {
       heroTutorialPrevPlayerIdx = curIdx;
     }
 
-    if (menuOpen) {
-      if (logOpen) {
-        showLogOverlay();
-      } else {
-        buildMenuOverlay();
-      }
-    } else {
+    if (menuOpen && !logOpen) {
+      buildMenuOverlay();
+    } else if (!menuOpen) {
       addMenuButtonToOverlay();
       if (isTutorial && tutorialStep >= 0) {
         buildTutorialOverlay();

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -177,6 +177,10 @@ public class GameScreen extends ScreenAdapter {
   // from bot back to player and fire the MY_TURN_START hook exactly once.
   private int heroTutorialPrevPlayerIdx = -1;
   private JSONArray activityLog = new JSONArray();
+  // Log overlay live-update state
+  private ScrollPane logScrollPane = null;
+  private Table logInnerTable = null;
+  private int logLastRenderedCount = 0;
   // Emit Reservists count to other clients once on first render (before any stateUpdate fires)
   private boolean initialReservistsBroadcastDone = false;
 
@@ -779,9 +783,11 @@ public class GameScreen extends ScreenAdapter {
       heroTutorialPrevPlayerIdx = curIdx;
     }
 
-    if (menuOpen && !logOpen) {
+    if (menuOpen && logOpen) {
+      refreshLogOverlay();
+    } else if (menuOpen) {
       buildMenuOverlay();
-    } else if (!menuOpen) {
+    } else {
       addMenuButtonToOverlay();
       if (isTutorial && tutorialStep >= 0) {
         buildTutorialOverlay();
@@ -4121,6 +4127,31 @@ public class GameScreen extends ScreenAdapter {
     overlayStage.addActor(table);
   }
 
+  private void refreshLogOverlay() {
+    if (logScrollPane == null || logInnerTable == null) return;
+    int count = activityLog.length();
+    if (count <= logLastRenderedCount) return;
+    boolean wasAtBottom = logScrollPane.getScrollPercentY() >= 0.95f;
+    try {
+      for (int i = logLastRenderedCount; i < count; i++) {
+        JSONObject entry = activityLog.getJSONObject(i);
+        String text = entry.optString("text", "");
+        boolean neutral = entry.optBoolean("neutral", false);
+        boolean success = entry.optBoolean("success", true);
+        Label lbl = new Label(text, MyGdxGame.skin);
+        lbl.setWrap(true);
+        Color lc = neutral
+            ? new Color(0.85f, 0.85f, 0.85f, 1f)
+            : (success ? new Color(0.3f, 0.95f, 0.3f, 1f) : new Color(0.95f, 0.3f, 0.25f, 1f));
+        lbl.setColor(lc);
+        logInnerTable.add(lbl).left().padBottom(4f).expandX().fillX().row();
+      }
+    } catch (JSONException e) { e.printStackTrace(); }
+    logLastRenderedCount = count;
+    logScrollPane.layout();
+    if (wasAtBottom) logScrollPane.setScrollPercentY(1f);
+  }
+
   private void showLogOverlay() {
     logOpen = true;
     overlayStage.clear();
@@ -4140,11 +4171,13 @@ public class GameScreen extends ScreenAdapter {
     // Scrollable inner table holds all log entries
     final Table inner = new Table();
     inner.top().left().pad(6f);
+    logInnerTable = inner;
 
     if (activityLog.length() == 0) {
       Label emptyLabel = new Label("No history yet.", MyGdxGame.skin);
       emptyLabel.setColor(Color.GRAY);
       inner.add(emptyLabel).row();
+      logLastRenderedCount = 0;
     } else {
       try {
         for (int i = 0; i < activityLog.length(); i++) {
@@ -4161,9 +4194,11 @@ public class GameScreen extends ScreenAdapter {
           inner.add(lbl).left().padBottom(4f).expandX().fillX().row();
         }
       } catch (JSONException e) { e.printStackTrace(); }
+      logLastRenderedCount = activityLog.length();
     }
 
     ScrollPane scroll = new ScrollPane(inner, MyGdxGame.skin);
+    logScrollPane = scroll;
     scroll.setFadeScrollBars(false);
     scroll.setScrollingDisabled(true, false);
     scroll.layout();

--- a/core/src/com/mygdx/game/StatsScreen.java
+++ b/core/src/com/mygdx/game/StatsScreen.java
@@ -37,13 +37,15 @@ public class StatsScreen extends AbstractScreen {
 
   private final SocketClient socket;
   private final JSONObject stats;
+  private final JSONArray log;
   private Stage stage;
-  private boolean showPlayersTab = false;
+  private int activeTab = 0; // 0=General, 1=Players, 2=History
 
-  public StatsScreen(Game game, SocketClient socket, JSONObject stats) {
+  public StatsScreen(Game game, SocketClient socket, JSONObject stats, JSONArray log) {
     super(game);
     this.socket = socket;
     this.stats  = stats;
+    this.log    = (log != null) ? log : new JSONArray();
   }
 
   @Override
@@ -68,26 +70,31 @@ public class StatsScreen extends AbstractScreen {
     // ── Tab bar ──────────────────────────────────────────────────────────────
     Label generalTab = new Label("General", MyGdxGame.skin);
     Label playersTab = new Label("Players", MyGdxGame.skin);
+    Label historyTab = new Label("History", MyGdxGame.skin);
     generalTab.pack();
     playersTab.pack();
+    historyTab.pack();
 
-    float tabGap    = 32f;
-    float tabsWidth = generalTab.getWidth() + tabGap + playersTab.getWidth();
+    float tabGap    = 28f;
+    float tabsWidth = generalTab.getWidth() + tabGap + playersTab.getWidth() + tabGap + historyTab.getWidth();
     float tabY      = 0.855f * MyGdxGame.HEIGHT;
     float underlineH = 3f;
 
     generalTab.setPosition(Math.round(cx - tabsWidth / 2f), tabY);
     playersTab.setPosition(Math.round(cx - tabsWidth / 2f + generalTab.getWidth() + tabGap), tabY);
+    historyTab.setPosition(Math.round(cx - tabsWidth / 2f + generalTab.getWidth() + tabGap + playersTab.getWidth() + tabGap), tabY);
 
-    generalTab.setColor(!showPlayersTab ? ACTIVE_COLOR : INACTIVE_COLOR);
-    playersTab.setColor( showPlayersTab ? ACTIVE_COLOR : INACTIVE_COLOR);
+    generalTab.setColor(activeTab == 0 ? ACTIVE_COLOR : INACTIVE_COLOR);
+    playersTab.setColor(activeTab == 1 ? ACTIVE_COLOR : INACTIVE_COLOR);
+    historyTab.setColor(activeTab == 2 ? ACTIVE_COLOR : INACTIVE_COLOR);
     generalTab.setTouchable(Touchable.disabled);
     playersTab.setTouchable(Touchable.disabled);
+    historyTab.setTouchable(Touchable.disabled);
 
-    Label activeTab = !showPlayersTab ? generalTab : playersTab;
+    Label activeTabLabel = (activeTab == 0) ? generalTab : (activeTab == 1) ? playersTab : historyTab;
     Image underline = new Image(MyGdxGame.skin.newDrawable("white", UNDERLINE_COLOR));
-    underline.setSize(activeTab.getWidth(), underlineH);
-    underline.setPosition(activeTab.getX(), activeTab.getY() - underlineH - 2f);
+    underline.setSize(activeTabLabel.getWidth(), underlineH);
+    underline.setPosition(activeTabLabel.getX(), activeTabLabel.getY() - underlineH - 2f);
 
     // Invisible hit actors for generous tap targets
     com.badlogic.gdx.scenes.scene2d.Actor generalHit = new com.badlogic.gdx.scenes.scene2d.Actor();
@@ -95,7 +102,7 @@ public class StatsScreen extends AbstractScreen {
         generalTab.getWidth() + 16f, generalTab.getHeight() + 16f);
     generalHit.addListener(new ClickListener() {
       @Override public void clicked(InputEvent event, float x, float y) {
-        showPlayersTab = false; show();
+        activeTab = 0; show();
       }
     });
 
@@ -104,21 +111,34 @@ public class StatsScreen extends AbstractScreen {
         playersTab.getWidth() + 16f, playersTab.getHeight() + 16f);
     playersHit.addListener(new ClickListener() {
       @Override public void clicked(InputEvent event, float x, float y) {
-        showPlayersTab = true; show();
+        activeTab = 1; show();
+      }
+    });
+
+    com.badlogic.gdx.scenes.scene2d.Actor historyHit = new com.badlogic.gdx.scenes.scene2d.Actor();
+    historyHit.setBounds(historyTab.getX() - 8f, tabY - 8f,
+        historyTab.getWidth() + 16f, historyTab.getHeight() + 16f);
+    historyHit.addListener(new ClickListener() {
+      @Override public void clicked(InputEvent event, float x, float y) {
+        activeTab = 2; show();
       }
     });
 
     stage.addActor(generalHit);
     stage.addActor(playersHit);
+    stage.addActor(historyHit);
     stage.addActor(underline);
     stage.addActor(generalTab);
     stage.addActor(playersTab);
+    stage.addActor(historyTab);
 
     // ── Tab content ──────────────────────────────────────────────────────────
-    if (!showPlayersTab) {
+    if (activeTab == 0) {
       buildGeneralTab(cx);
-    } else {
+    } else if (activeTab == 1) {
       buildPlayersTab(cx);
+    } else {
+      buildHistoryTab(cx);
     }
 
     // ── Return to Lobby button ───────────────────────────────────────────────
@@ -270,6 +290,46 @@ public class StatsScreen extends AbstractScreen {
   }
 
   // ── Helpers ─────────────────────────────────────────────────────────────────
+  private void buildHistoryTab(float cx) {
+    float contentTop    = 0.825f * MyGdxGame.HEIGHT;
+    float contentBottom = 0.14f  * MyGdxGame.HEIGHT;
+    float contentH = contentTop - contentBottom;
+    float contentW = 0.92f * MyGdxGame.WIDTH;
+
+    Table inner = new Table();
+    inner.top().left().pad(6f);
+
+    if (log.length() == 0) {
+      Label empty = new Label("No history yet.", MyGdxGame.skin);
+      empty.setColor(INACTIVE_COLOR);
+      inner.add(empty).row();
+    } else {
+      try {
+        for (int i = 0; i < log.length(); i++) {
+          JSONObject entry = log.getJSONObject(i);
+          String text    = entry.optString("text", "");
+          boolean neutral = entry.optBoolean("neutral", false);
+          boolean success = entry.optBoolean("success", true);
+          Label lbl = new Label(text, MyGdxGame.skin);
+          lbl.setWrap(true);
+          Color lc = neutral
+              ? new Color(0.85f, 0.85f, 0.85f, 1f)
+              : (success ? new Color(0.3f, 0.95f, 0.3f, 1f) : new Color(0.95f, 0.3f, 0.25f, 1f));
+          lbl.setColor(lc);
+          inner.add(lbl).left().padBottom(4f).width(contentW - 24f).row();
+        }
+      } catch (JSONException e) { e.printStackTrace(); }
+    }
+
+    ScrollPane scroll = new ScrollPane(inner, MyGdxGame.skin);
+    scroll.setFadeScrollBars(false);
+    scroll.setScrollingDisabled(true, false);
+    scroll.setSize(contentW, contentH);
+    scroll.setPosition(Math.round(cx - contentW / 2f), Math.round(contentBottom));
+    scroll.layout();
+    scroll.setScrollPercentY(1f);
+    stage.addActor(scroll);
+  }
 
   private static void addCell(Table table, String text, float minWidth, Color color, boolean leftAlign) {
     Label lbl = new Label(text, MyGdxGame.skin);

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -20,7 +20,7 @@ class GameState {
     }));
     this.pickingDecks = [[], []]; // each entry: { id, covered }
     this.currentPlayerIndex = 0;
-    this.log = []; // activity log: [{ text, success }, ...], max 5 entries
+    this.log = []; // activity log: [{ text, success }, ...], max 100 entries
     this.lastMerchantReveal = null; // set during 2nd-try, cleared on finishTurn
     this.pendingAttack = null; // current attack preview broadcast, cleared on defAttackResolved
     this.pendingPlunder = null; // current plunder preview broadcast, cleared on plunderResolved
@@ -206,7 +206,7 @@ class GameState {
 
   pushLog(text, success, neutral = false) {
     this.log.push({ text, success, neutral });
-    if (this.log.length > 5) this.log.shift();
+    if (this.log.length > 100) this.log.shift();
   }
 
   cardStrength(cardId) {


### PR DESCRIPTION
Closes #196

## Changes

### Server (`server/gameState.js`)
- Increased the log cap from 5 to 100 entries. Players can now see the full game history, not just the last 5 actions.

### Client (`core/src/com/mygdx/game/GameScreen.java`)
- Added `logOpen` boolean field that is set to `true` when the history overlay is shown and `false` when the main menu or close is triggered.
- In `applyStateUpdate()`, when a state update arrives while the history is open (`menuOpen && logOpen`), the history overlay is refreshed with the latest log data instead of being replaced by the main menu.
