### PR TITLE
Fix: auto-deselect king card after using it to attack or plunder

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -1703,6 +1703,7 @@ public class GameScreen extends ScreenAdapter {
           pt.getPendingAttackOwnDefCards().clear();
           pt.resetReservistAttackBonus();
           pt.resetPendingAttackMercenaryBonus();
+          if (currentPlayer.getKingCard() != null) currentPlayer.getKingCard().setSelected(false);
           gameState.setUpdateState(true);
         }
       });
@@ -2047,6 +2048,7 @@ public class GameScreen extends ScreenAdapter {
           // Clear own def card selections
           for (Card c : atkPlayer.getDefCards().values()) c.setSelected(false);
           for (Card c : atkPlayer.getTopDefCards().values()) c.setSelected(false);
+          if (atkPlayer.getKingCard() != null) atkPlayer.getKingCard().setSelected(false);
           gameState.setUpdateState(true);
         }
       });


### PR DESCRIPTION
Closes #197

## Problem
After using the king card to attack or plunder, the king remained visually selected (highlighted). Hand cards were already cleared on overlay dismiss, but the king card was not.

## Fix
Added `kingCard.setSelected(false)` in two places on overlay dismiss:
- After the plunder result overlay is confirmed (`plunderResolved` path)
- After the attack result overlay is confirmed (`defAttackResolved` / `kingAttackResolved` path)
