### PR TITLE
Fix bot aggression on covered defenses, enrich history log with combat details, and add log export

### DIFF
--- a/.github/instructions/game-rules.instructions.md
+++ b/.github/instructions/game-rules.instructions.md
@@ -48,7 +48,8 @@ The turn ends when the player clicks **Finish Turn**.
 - Server: `attackCount` per player is incremented only in `defAttackResolved`, `kingAttackResolved`, and `warlordDirectAttack`.
 - `plunderResolved` must **not** increment `attackCount`.
 - Client: `playerTurn.attackCounter == 0` triggers the expose prompt in `FinishTurnButtonListener`.
-- Client: `increaseAttackCounter()` is called locally for Warlord direct attack (before the server's `stateUpdate` arrives) to prevent a race-condition false-trigger.
+- Client: `increaseAttackCounter()` **must** be called locally for **every** attack type (including regular defence-card attacks and king assaults) when the attack overlay is confirmed — before `setUpdateState(true)` fires the re-render. This prevents a race-condition where the user clicks "Finish Turn" before the server's `stateUpdate` arrives with the updated `attackCount`, which would falsely trigger the expose-card penalty.
+- The sole exception is Warlord direct attacks: `increaseAttackCounter()` is called at commit time (in `EnemyDefCardListener`) rather than at overlay-confirm time — the pattern is therefore `if (!apt.isPendingAttackIsWarlord()) apt.increaseAttackCounter();` in the overlay click handler.
 
 ---
 
@@ -59,8 +60,15 @@ The turn ends when the player clicks **Finish Turn**.
 - The combined strength of selected cards must **exceed** (not equal) the defence card's strength (plus top defence card if present — Fortified Tower).
 - The attacker's king card can be used instead of hand cards (but cannot be combined with hand cards).
 - The attacking symbol is **locked** after the first attack of a turn; all subsequent attacks in the same turn must use the same suit (or same-colour pair if Banneret).
-- On **success**: the attacker gains the captured defence card(s) as prey cards.
+- On **success**: the attacker gains the captured defence card(s) as **prey cards**.
 - On **failure** (attacker used the king): the attacker is eliminated.
+
+### Prey Cards
+- A prey card is a defence card (or king card) captured by the current player during their current turn.
+- Prey cards are placed in the attacker's hand but are **locked** (greyed-out) for the rest of the turn — they cannot be used in attacks, placed as defence, or discarded until the turn ends.
+- `finishTurn()` on the server clears `preyCards = []` so captured cards become normal hand cards next turn.
+- **Client implementation**: When a successful defence-card attack is confirmed in the overlay click handler, the captured card IDs **must** be added to `atkPlayer.getPlayerTurn().getPreyCardIds()` locally — before `setUpdateState(true)` triggers the re-render. If this is omitted, the first re-render fires before the server's `stateUpdate` arrives with `preyCards`, so the card briefly appears as usable (race-condition bug). The server's `stateUpdate` will confirm the prey list on arrival.
+- Cards gained from a **plunder** are NOT prey cards — they become immediately usable (by design).
 
 ### King Assault
 - The defender's king must be **exposed** (face-up) for a king assault to be possible.

--- a/.github/instructions/game-rules.instructions.md
+++ b/.github/instructions/game-rules.instructions.md
@@ -50,6 +50,7 @@ The turn ends when the player clicks **Finish Turn**.
 - Client: `playerTurn.attackCounter == 0` triggers the expose prompt in `FinishTurnButtonListener`.
 - Client: `increaseAttackCounter()` **must** be called locally for **every** attack type (including regular defence-card attacks and king assaults) when the attack overlay is confirmed — before `setUpdateState(true)` fires the re-render. This prevents a race-condition where the user clicks "Finish Turn" before the server's `stateUpdate` arrives with the updated `attackCount`, which would falsely trigger the expose-card penalty.
 - The sole exception is Warlord direct attacks: `increaseAttackCounter()` is called at commit time (in `EnemyDefCardListener`) rather than at overlay-confirm time — the pattern is therefore `if (!apt.isPendingAttackIsWarlord()) apt.increaseAttackCounter();` in the overlay click handler.
+- Client `applyStateUpdate` **must** be race-safe: a stale `stateUpdate` from `setAttackPreview` (emitted before the user confirmed the attack) can arrive AFTER the local optimistic increment. The handler therefore takes `Math.max(serverAttackCount, localAttackCount)` for the player whose turn it currently is. After the turn ends (current player index moves on) the server's value is authoritative.
 
 ---
 
@@ -68,6 +69,7 @@ The turn ends when the player clicks **Finish Turn**.
 - Prey cards are placed in the attacker's hand but are **locked** (greyed-out) for the rest of the turn — they cannot be used in attacks, placed as defence, or discarded until the turn ends.
 - `finishTurn()` on the server clears `preyCards = []` so captured cards become normal hand cards next turn.
 - **Client implementation**: When a successful defence-card attack is confirmed in the overlay click handler, the captured card IDs **must** be added to `atkPlayer.getPlayerTurn().getPreyCardIds()` locally — before `setUpdateState(true)` triggers the re-render. If this is omitted, the first re-render fires before the server's `stateUpdate` arrives with `preyCards`, so the card briefly appears as usable (race-condition bug). The server's `stateUpdate` will confirm the prey list on arrival.
+- **Client implementation**: `applyStateUpdate` **must** take the UNION of server `preyCards` and local `preyCardIds` while it is still this player's turn. A stale `stateUpdate` from `setAttackPreview` may arrive after the local optimistic update and would otherwise clobber the locally-known captures. After the turn ends, server is authoritative.
 - Cards gained from a **plunder** are NOT prey cards — they become immediately usable (by design).
 
 ### King Assault

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,9 @@ WORKDIR /app
 COPY server/package*.json ./
 RUN npm install --omit=dev
 
+# ARG-based cache bust: pass --build-arg CACHEBUST=$(date +%s) to force
+# re-evaluation of all layers below this line when server code changes.
+ARG CACHEBUST=1
 COPY server/ ./
 
 # Pull the compiled GWT assets into the public/ directory that express.static

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -5089,14 +5089,37 @@ public class GameScreen extends ScreenAdapter {
           }
         }
 
-        // Sync prey cards (captured this turn, locked until turn ends)
+        // Sync prey cards (captured this turn, locked until turn ends).
+        // RACE-SAFE: a stale stateUpdate from setAttackPreview can arrive AFTER the client has
+        // optimistically added the captured card IDs in the attack overlay handler. Taking the
+        // UNION of server and local prey IDs (only while it is still this player's turn)
+        // prevents the stale update from clobbering the locally-known captures. After the turn
+        // ends (currentPlayerIndex moves on), the server's value is authoritative.
         ArrayList<Integer> newPreyIds = new ArrayList<Integer>();
         JSONArray preyJson = pj.optJSONArray("preyCards");
         if (preyJson != null) {
           for (int pr = 0; pr < preyJson.length(); pr++) newPreyIds.add(preyJson.getInt(pr));
         }
+        boolean isThisPlayersTurn = (pj.getInt("index") == serverCurrentIdx);
+        if (isThisPlayersTurn) {
+          for (Integer localId : p.getPlayerTurn().getPreyCardIds()) {
+            if (!newPreyIds.contains(localId)) newPreyIds.add(localId);
+          }
+        }
         p.getPlayerTurn().setPreyCardIds(newPreyIds);
-        p.getPlayerTurn().setAttackCounter(pj.optInt("attackCount", 0));
+
+        // Sync attack counter. RACE-SAFE: same reasoning as preyCardIds — a stale stateUpdate
+        // from setAttackPreview can arrive after the client locally incremented the counter in
+        // the attack overlay handler. While it is still this player's turn, take MAX(server, local).
+        // After the turn ends, server is authoritative (server resets attackCount=0 on finishTurn,
+        // so the next stateUpdate naturally syncs the value down).
+        int serverAttackCount = pj.optInt("attackCount", 0);
+        if (isThisPlayersTurn) {
+          int localAttackCount = p.getPlayerTurn().getAttackCounter();
+          p.getPlayerTurn().setAttackCounter(Math.max(serverAttackCount, localAttackCount));
+        } else {
+          p.getPlayerTurn().setAttackCounter(serverAttackCount);
+        }
 
         // Restore per-turn client counters from server-authoritative state so they survive page refresh
         if (p == currentPlayer) {

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -1988,6 +1988,9 @@ public class GameScreen extends ScreenAdapter {
               for (Card dc : apt.getPendingAttackDefCards()) {
                 dc.setRemoved(true);
                 atkPlayer.addHandCard(dc);
+                // Lock captured card as a prey card immediately (before server stateUpdate arrives)
+                // so the re-render does not show it as usable. Server confirms on stateUpdate.
+                atkPlayer.getPlayerTurn().getPreyCardIds().add(dc.getCardId());
               }
               if (apt.isKingUsed()) atkPlayer.getKingCard().setCovered(false);
             } else {
@@ -2039,6 +2042,9 @@ public class GameScreen extends ScreenAdapter {
           // are an additional action granted by the hero and must NOT consume the
           // regular once-per-turn king attack/plunder.
           if (apt.isKingUsed() && !apt.isPendingAttackIsWarlord()) apt.setKingUsedThisTurn(true);
+          // Count this attack locally (same pattern as Warlord) so the expose-card penalty
+          // check in FinishTurnButtonListener never falsely fires before the server stateUpdate arrives.
+          if (!apt.isPendingAttackIsWarlord()) apt.increaseAttackCounter();
           apt.setPendingAttackIsWarlord(false);
           // Clear hand card attack boost visuals after attack resolves
           for (Card c : atkPlayer.getHandCards()) {

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -72,7 +72,9 @@ public class MenuScreen extends AbstractScreen {
   private int pendingStartingCards = 8;
   // Per-bot personality selections: "off" means no bot in that slot.
   // Values map to server bot mode keys: "passive", "balanced", "aggressive", "tactician", "llm".
-  private String[] pendingBotModes = {"off", "off", "off"};
+  private String[] pendingBotModes = {"off", "off", "off", "off"};
+  // Whether the creator joins as a spectator (4th bot slot enabled in this mode)
+  private boolean pendingSpectator = false;
 
   // The session list received from the server
   private java.util.List<SessionInfo> sessionList = new java.util.ArrayList<SessionInfo>();
@@ -688,13 +690,14 @@ public class MenuScreen extends AbstractScreen {
     cardsBox.setItems(cardOptions);
     cardsBox.setSelected(String.valueOf(pendingStartingCards));
 
-    // ── Per-bot personality selectors (Bot 1 / 2 / 3) ───────────────────────
+    // ── Per-bot personality selectors (Bot 1 / 2 / 3, plus Bot 4 in spectator mode) ──
     final String[] BOT_DISPLAY = {"Off", "Passive", "Balanced", "Aggressive", "Tactician", "MCTS"};
     final String[] BOT_KEYS    = {"off", "passive", "balanced", "aggressive", "tactician", "mcts"};
-    final Label[] botLabels = new Label[3];
+    final int totalBotSlots = 4;
+    final Label[] botLabels = new Label[totalBotSlots];
     @SuppressWarnings("unchecked")
-    final SelectBox<String>[] botBoxes = new SelectBox[3];
-    for (int bi = 0; bi < 3; bi++) {
+    final SelectBox<String>[] botBoxes = new SelectBox[totalBotSlots];
+    for (int bi = 0; bi < totalBotSlots; bi++) {
       botLabels[bi] = new Label("Bot " + (bi + 1) + ":", MyGdxGame.skin);
       botBoxes[bi] = new SelectBox<String>(MyGdxGame.skin);
       Array<String> botOpts = new Array<String>();
@@ -707,6 +710,11 @@ public class MenuScreen extends AbstractScreen {
         if (BOT_KEYS[ki].equals(currentMode)) { displayVal = BOT_DISPLAY[ki]; break; }
       }
       botBoxes[bi].setSelected(displayVal);
+      // Bot 4 is read-only unless spectator mode is enabled
+      if (bi == 3 && !pendingSpectator) {
+        botBoxes[bi].setDisabled(true);
+        botLabels[bi].setColor(1f, 1f, 1f, 0.35f);
+      }
       final int botSlot = bi;
       botBoxes[bi].addListener(new com.badlogic.gdx.scenes.scene2d.utils.ChangeListener() {
         @Override
@@ -721,6 +729,18 @@ public class MenuScreen extends AbstractScreen {
     }
 
     // ── Checkboxes ───────────────────────────────────────────────────────────
+    final CheckBox spectatorCheckbox = new CheckBox(" Spectator mode (watch bots only)", MyGdxGame.skin);
+    spectatorCheckbox.setChecked(pendingSpectator);
+    spectatorCheckbox.addListener(new com.badlogic.gdx.scenes.scene2d.utils.ChangeListener() {
+      @Override
+      public void changed(ChangeEvent event, com.badlogic.gdx.scenes.scene2d.Actor actor) {
+        pendingSpectator = spectatorCheckbox.isChecked();
+        // Reset Bot 4 selection when spectator is unchecked
+        if (!pendingSpectator) pendingBotModes[3] = "off";
+        Gdx.app.postRunnable(new Runnable() { @Override public void run() { show(); } });
+      }
+    });
+
     final CheckBox manualSetupCheckbox = new CheckBox(" Manual setup", MyGdxGame.skin);
     manualSetupCheckbox.setChecked(pendingManualSetup);
 
@@ -736,12 +756,14 @@ public class MenuScreen extends AbstractScreen {
             ? menuState.getMyName() + "'s game" : pendingSessionName;
         sessionAllowHeroSelection = heroCheckbox.isChecked();
         pendingManualSetup = manualSetupCheckbox.isChecked();
+        boolean isSpectator = spectatorCheckbox.isChecked();
         try {
           pendingStartingCards = Integer.parseInt(cardsBox.getSelected());
         } catch (NumberFormatException ex) { pendingStartingCards = 8; }
-        // Collect non-"off" bot modes into a JSONArray
+        // Collect non-"off" bot modes (up to 3 normally, up to 4 in spectator mode)
+        int maxBots = isSpectator ? 4 : 3;
         JSONArray botModesArr = new JSONArray();
-        for (int bi = 0; bi < 3; bi++) {
+        for (int bi = 0; bi < maxBots; bi++) {
           if (!"off".equals(pendingBotModes[bi])) botModesArr.put(pendingBotModes[bi]);
         }
         JSONObject data = new JSONObject();
@@ -752,13 +774,15 @@ public class MenuScreen extends AbstractScreen {
           data.put("startingCards", pendingStartingCards);
           data.put("manualSetup", pendingManualSetup);
           data.put("botModes", botModesArr);
+          data.put("spectator", isSpectator);
           data.put("token", MyGdxGame.playerStorage.getToken());
         } catch (JSONException e) { /* ignore */ }
         socket.emit("createSession", data);
         pendingSessionName = "";
         pendingManualSetup = false;
         pendingStartingCards = 8;
-        pendingBotModes = new String[]{"off", "off", "off"};
+        pendingSpectator = false;
+        pendingBotModes = new String[]{"off", "off", "off", "off"};
         inSessionCreate = false;
       }
     });
@@ -775,11 +799,13 @@ public class MenuScreen extends AbstractScreen {
     form.row();
     form.add(cardsLabel).left().padRight(12f).padBottom(14f);
     form.add(cardsBox).width(colW * 0.38f).left().padBottom(14f);
-    for (int bi = 0; bi < 3; bi++) {
+    for (int bi = 0; bi < totalBotSlots; bi++) {
       form.row();
       form.add(botLabels[bi]).left().padRight(12f).padBottom(8f);
       form.add(botBoxes[bi]).width(colW * 0.5f).left().padBottom(8f);
     }
+    form.row();
+    form.add(spectatorCheckbox).colspan(2).left().padBottom(6f);
     form.row();
     form.add(manualSetupCheckbox).colspan(2).left().padBottom(10f);
     form.row();

--- a/core/src/com/mygdx/game/StatsScreen.java
+++ b/core/src/com/mygdx/game/StatsScreen.java
@@ -292,9 +292,11 @@ public class StatsScreen extends AbstractScreen {
   // ── Helpers ─────────────────────────────────────────────────────────────────
   private void buildHistoryTab(float cx) {
     float contentTop    = 0.825f * MyGdxGame.HEIGHT;
-    float contentBottom = 0.14f  * MyGdxGame.HEIGHT;
+    float contentBottom = 0.19f  * MyGdxGame.HEIGHT;
     float contentH = contentTop - contentBottom;
     float contentW = 0.92f * MyGdxGame.WIDTH;
+
+    final StringBuilder logText = new StringBuilder();
 
     Table inner = new Table();
     inner.top().left().pad(6f);
@@ -310,6 +312,8 @@ public class StatsScreen extends AbstractScreen {
           String text    = entry.optString("text", "");
           boolean neutral = entry.optBoolean("neutral", false);
           boolean success = entry.optBoolean("success", true);
+          if (logText.length() > 0) logText.append("\n");
+          logText.append(text);
           Label lbl = new Label(text, MyGdxGame.skin);
           lbl.setWrap(true);
           Color lc = neutral
@@ -329,6 +333,19 @@ public class StatsScreen extends AbstractScreen {
     scroll.layout();
     scroll.setScrollPercentY(1f);
     stage.addActor(scroll);
+
+    // "Copy log" button — copies all history entries to the system clipboard
+    TextButton copyBtn = new TextButton("Copy log", MyGdxGame.skin);
+    copyBtn.pack();
+    copyBtn.setPosition(Math.round(cx - copyBtn.getWidth() / 2f),
+        Math.round(0.11f * MyGdxGame.HEIGHT));
+    copyBtn.addListener(new ClickListener() {
+      @Override
+      public void clicked(InputEvent event, float x, float y) {
+        Gdx.app.getClipboard().setContents(logText.toString());
+      }
+    });
+    stage.addActor(copyBtn);
   }
 
   private static void addCell(Table table, String text, float minWidth, Color color, boolean leftAlign) {

--- a/server/.cachebust
+++ b/server/.cachebust
@@ -1,0 +1,1 @@
+# cache bust

--- a/server/bot.js
+++ b/server/bot.js
@@ -666,11 +666,15 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
       });
     } else {
       setTimeout(function() {
-        gs.defAttackResolved(atkPreviewData.attackerIdx, defenderIdx, atkChoice.positionId,
-                             0, atkChoice.success, atkChoice.cardIds, false, []);
-        io.to(sess.id).emit('stateUpdate', gs.serialize());
-        checkAndHandleWinner(sess);
-        resolveCallback();
+        try {
+          gs.defAttackResolved(atkPreviewData.attackerIdx, defenderIdx, atkChoice.positionId,
+                               0, atkChoice.success, atkChoice.cardIds, false, []);
+          io.to(sess.id).emit('stateUpdate', gs.serialize());
+          checkAndHandleWinner(sess);
+          resolveCallback();
+        } catch (e) {
+          console.error('[defAttackResolved setTimeout] uncaught error:', e && e.message, e && e.stack);
+        }
       }, BOT_ACTION_DELAY);
     }
   }
@@ -893,17 +897,21 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
   }
 
   function executeBotTurn(sess) {
-    var gs = sess.gameState;
-    var idx = gs.currentPlayerIndex;
-    var p = gs.players[idx];
-    if (!p || p.isOut) return;
+    try {
+      var gs = sess.gameState;
+      var idx = gs.currentPlayerIndex;
+      var p = gs.players[idx];
+      if (!p || p.isOut) return;
 
-    var personality = getPersonality(p.botMode || 'balanced');
-    if (personality.name === 'mcts') {
-      executeMctsTurnAsync(sess, gs, idx);
-      return;
+      var personality = getPersonality(p.botMode || 'balanced');
+      if (personality.name === 'mcts') {
+        executeMctsTurnAsync(sess, gs, idx);
+        return;
+      }
+      executeBotTurnWithPersonality(sess, gs, idx, personality);
+    } catch (e) {
+      console.error('[executeBotTurn] uncaught error:', e && e.message, e && e.stack);
     }
-    executeBotTurnWithPersonality(sess, gs, idx, personality);
   }
 
   // ── MCTS Bot Turn ────────────────────────────────────────────────────────────
@@ -1074,17 +1082,21 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
         io.to(sess.id).emit('stateUpdate', gs.serialize());
         var captured = plunderChoice;
         setTimeout(function() {
-          gs.plunderResolved(idx, captured.deckIndex, captured.success,
-                             captured.cardIds, false, []);
-          io.to(sess.id).emit('stateUpdate', gs.serialize());
-          checkAndHandleWinner(sess);
-          // 6. After plunder: optional follow-up attack chain (personality-controlled)
-          if (personality.attackAfterPlunder()) {
-            botAttackChainAsync(sess, gs, idx, personality, function(attacked) {
-              botFinishTurn(sess, gs, idx, attacked);
-            });
-          } else {
-            botFinishTurn(sess, gs, idx, false);
+          try {
+            gs.plunderResolved(idx, captured.deckIndex, captured.success,
+                               captured.cardIds, false, []);
+            io.to(sess.id).emit('stateUpdate', gs.serialize());
+            checkAndHandleWinner(sess);
+            // 6. After plunder: optional follow-up attack chain (personality-controlled)
+            if (personality.attackAfterPlunder()) {
+              botAttackChainAsync(sess, gs, idx, personality, function(attacked) {
+                botFinishTurn(sess, gs, idx, attacked);
+              });
+            } else {
+              botFinishTurn(sess, gs, idx, false);
+            }
+          } catch (e) {
+            console.error('[plunderResolved setTimeout] uncaught error:', e && e.message, e && e.stack);
           }
         }, BOT_ACTION_DELAY);
         return;

--- a/server/bot.js
+++ b/server/bot.js
@@ -299,8 +299,8 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
             var rDefBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
             var rTopId = defender.topDefCards ? defender.topDefCards[slot] : null;
             var rTopBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
-            var rActual = botDefCardStrength(gs, defCardId) + rDefBoost
-                        + (rTopId != null ? botDefCardStrength(gs, rTopId) + rTopBoost : 0);
+            var rActual = gs.cardStrength(defCardId) + rDefBoost
+                        + (rTopId != null ? gs.cardStrength(rTopId) + rTopBoost : 0);
             var rSuccess = (rSum > rActual);
             var rShields = 0;
             for (var rs = 1; rs <= 3; rs++) {
@@ -401,8 +401,8 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
             var prDefBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
             var prTopId = defender.topDefCards ? defender.topDefCards[slot] : null;
             var prTopBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
-            var prActual = botDefCardStrength(gs, defCardId) + prDefBoost
-                         + (prTopId != null ? botDefCardStrength(gs, prTopId) + prTopBoost : 0);
+            var prActual = gs.cardStrength(defCardId) + prDefBoost
+                         + (prTopId != null ? gs.cardStrength(prTopId) + prTopBoost : 0);
             var prSuccess = (prSum > prActual);
             var prShields = 0;
             for (var prs = 1; prs <= 3; prs++) {

--- a/server/bot.js
+++ b/server/bot.js
@@ -528,12 +528,14 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
       var defender = gs.players[di];
       if (defender.isOut) continue;
 
-      // All 3 defense slots must be empty (king exposed)
+      // All 3 defense slots must be empty AND king must be face-up for a king assault.
       var allEmpty = true;
       for (var s = 1; s <= 3; s++) {
         if (defender.defCards[s] != null || defender.topDefCards[s] != null) { allEmpty = false; break; }
       }
       if (!allEmpty) continue;
+      // King still covered — can't assault yet (rule: king must be exposed/face-up).
+      if (defender.kingCovered !== false) continue;
 
       var kingStr = gs.cardStrength(defender.kingCard) + (defender.kingCardBoost || 0);
       var suits = Object.keys(groups);
@@ -776,7 +778,7 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     var jokers = p.hand.filter(function(id) { return id > 52; });
     if (jokers.length === 0) return false;
 
-    // Exception 1: save joker to eliminate a player whose king is exposed
+    // Exception 1: save joker to eliminate a player whose king is already face-up
     for (var di = 0; di < gs.players.length; di++) {
       if (di === playerIdx || gs.players[di].isOut) continue;
       var defender = gs.players[di];
@@ -784,7 +786,8 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
       for (var s = 1; s <= 3; s++) {
         if (defender.defCards[s] != null || defender.topDefCards[s] != null) { allEmpty = false; break; }
       }
-      if (allEmpty) {
+      // Only worth saving joker if we can legally king-assault this turn (king face-up).
+      if (allEmpty && defender.kingCovered === false) {
         var nonJokerHand = p.hand.filter(function(id) { return id <= 52; });
         var bestCombo = botBestSuitCombo(gs, nonJokerHand);
         if (bestCombo.sum < gs.cardStrength(defender.kingCard)) return false; // need joker for kill
@@ -872,7 +875,8 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
       }
     }
 
-    // Merchant trade: discard weakest hand card and draw top deck card if it's an improvement
+    // Merchant trade: discard weakest hand card if it's below average expected card strength.
+    // The deck is hidden — the bot trades on the assumption a random card is better than a weak known card.
     if (heroes.indexOf('Merchant') !== -1 && (p.merchantTrades || 0) > 0 && gs.deck.length > 0) {
       var nonJokerHand2 = p.hand.filter(function(id) { return id <= 52; });
       if (nonJokerHand2.length > 0) {
@@ -881,15 +885,15 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
           var s = gs.cardStrength(nonJokerHand2[i]);
           if (s < weakestStr2) { weakestStr2 = s; weakestId = nonJokerHand2[i]; }
         }
-        var topDeckId = gs.deck[gs.deck.length - 1];
-        var topDeckStr = gs.cardStrength(topDeckId);
-        if (weakestId !== null && topDeckStr > weakestStr2) {
+        // Only trade if the card is clearly below average (expected random draw = 8).
+        // The bot cannot see the top of the deck, so it takes the gamble if the card is weak.
+        if (weakestId !== null && weakestStr2 < BOT_UNKNOWN_CARD_STRENGTH) {
+          var topDeckId = gs.deck[gs.deck.length - 1]; // server resolves which card is drawn
           gs.merchantTrade(playerIdx, weakestId, topDeckId);
           // If the drawn card is a joker, do a second try with the next deck card
           var justDrawnIdx = p.hand.indexOf(topDeckId);
           var justDrawn = justDrawnIdx !== -1 ? topDeckId : null;
           if (justDrawn !== null && justDrawn > 52 && (p.merchantTrades === 0) && gs.deck.length > 0) {
-            // merchantTrades was decremented — use merchantSecondTry to replace the joker
             var secondDeckId = gs.deck[gs.deck.length - 1];
             gs.merchantSecondTry(playerIdx, justDrawn, secondDeckId, false);
           }

--- a/server/bot.js
+++ b/server/bot.js
@@ -48,10 +48,18 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
      */
     targetBonus(/*gs, defenderIdx*/) { return 0; }
     /**
-     * Maximum hand size before the bot skips plundering.
-     * Keeps bots from hoarding cards when they already have plenty.
+     * How many attacks per turn when the hand has many cards.
+     * Returns the effective max attacks given the current hand size, so bots
+     * burn through surplus cards instead of hoarding them.
      */
-    maxHandSizeBeforePlunder()       { return 12; }
+    dynamicMaxAttacks(handSize) {
+      var base = this.maxAttacksPerTurn();
+      if (base === -1) return -1;          // already unlimited
+      if (handSize >= 14) return Math.max(base, 4);
+      if (handSize >= 10) return Math.max(base, 3);
+      if (handSize >= 7)  return Math.max(base, 2);
+      return base;
+    }
   }
 
   /** Balanced — current default behaviour: fill weakest, two attacks, scout disabled. */
@@ -398,12 +406,13 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     return bestChoice;
   }
 
-  // Chain multiple defense-card attacks for a personality (aggressive = unlimited, tactician = 2, etc.)
+  // Chain multiple defense-card attacks for a personality (aggressive = unlimited, tactician = 3, etc.)
   // attackCount: how many attacks have been done so far in this chain (start with 0).
   // fixedSymbol: the suit committed to after the first attack (prevents switching symbols mid-turn).
   function botAttackChainAsync(sess, gs, idx, personality, callback, attackCount, fixedSymbol) {
     attackCount = attackCount || 0;
-    var maxAtks = personality.maxAttacksPerTurn();
+    var handSize = gs.players[idx] ? gs.players[idx].hand.length : 0;
+    var maxAtks = personality.dynamicMaxAttacks ? personality.dynamicMaxAttacks(handSize) : personality.maxAttacksPerTurn();
 
     if (maxAtks !== -1 && attackCount >= maxAtks) {
       callback(attackCount > 0);
@@ -432,6 +441,27 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     var nextSymbol = fixedSymbol || (atkChoice.success ? atkChoice.symbol : null);
 
     botDoDefAttackWithBatteryCheck(sess, gs, atkChoice, atkPreview, function() {
+      // After a successful attack: if this cleared the last defense slot of that enemy,
+      // immediately try a king attack before continuing the defense chain.
+      if (atkChoice.success) {
+        var tgt = gs.players[atkChoice.defenderIdx];
+        if (tgt && !tgt.isOut) {
+          var tgtAllEmpty = true;
+          for (var _s = 1; _s <= 3; _s++) {
+            if ((tgt.defCards && tgt.defCards[_s] != null) || (tgt.topDefCards && tgt.topDefCards[_s] != null)) {
+              tgtAllEmpty = false; break;
+            }
+          }
+          if (tgtAllEmpty) {
+            // King is now exposed — try to finish them off
+            botTryKingAttackAsync(sess, gs, idx, function(didKing) {
+              if (didKing) { callback(true); return; }
+              botAttackChainAsync(sess, gs, idx, personality, callback, attackCount + 1, nextSymbol);
+            });
+            return;
+          }
+        }
+      }
       botAttackChainAsync(sess, gs, idx, personality, callback, attackCount + 1, nextSymbol);
     });
   }
@@ -1045,9 +1075,8 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
         return;
       }
 
-      // 5. Smart plunder — skip if hand is already too large
-      var maxHandBeforePlunder = (personality.maxHandSizeBeforePlunder ? personality.maxHandSizeBeforePlunder() : 12);
-      var plunderChoice = (p.hand.length < maxHandBeforePlunder) ? botChoosePlunder(gs, idx) : null;
+      // 5. Smart plunder — always attempt
+      var plunderChoice = botChoosePlunder(gs, idx);
       if (plunderChoice) {
         var plAtkSum = 0;
         for (var pci = 0; pci < plunderChoice.cardIds.length; pci++) plAtkSum += gs.cardStrength(plunderChoice.cardIds[pci]);

--- a/server/bot.js
+++ b/server/bot.js
@@ -206,6 +206,43 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
 
   // Choose the best plunder: smart multi-card combo, preferring bigger decks with larger margin.
   // Returns { deckIndex, cardIds, symbol, success } or null.
+  // Score how attractive a picking deck is as plunder prey.
+  // Returns { value, hasJoker, totalStrength, visibleCount, visibleStrength }
+  function botEvaluateDeck(gs, deck) {
+    var totalStrength = 0;
+    var visibleStrength = 0;
+    var visibleCount = 0;
+    var hasJoker = false;
+    var foundFirstVisible = false;
+
+    for (var i = 0; i < deck.length; i++) {
+      var card = deck[i];
+      var isJoker = card.id > 52;
+      if (isJoker) hasJoker = true;
+      // Cap joker at 15 for strength summing (actual attack value is 999,
+      // but for deck comparison we don't want it to drown out everything else).
+      var str = isJoker ? 15 : gs.cardStrength(card.id);
+      totalStrength += str;
+      if (!card.covered) {
+        visibleCount++;
+        if (!foundFirstVisible) { visibleStrength = str; foundFirstVisible = true; }
+      }
+    }
+
+    // Deck attractiveness:
+    //   totalStrength  — stronger cards received = more future attack power
+    //   hasJoker bonus — joker is extremely powerful in attack (+25)
+    //   size bonus     — more cards = more flexibility (+3 per card)
+    //   visible bonus  — visible cards are confirmed value (+2 per visible card)
+    var value = totalStrength
+              + (hasJoker ? 25 : 0)
+              + deck.length * 3
+              + visibleCount * 2;
+
+    return { value: value, hasJoker: hasJoker, totalStrength: totalStrength,
+             visibleCount: visibleCount, visibleStrength: visibleStrength };
+  }
+
   function botChoosePlunder(gs, attackerIdx) {
     var p = gs.players[attackerIdx];
     if (!p || !p.hand || p.hand.length === 0 || (p.pickingDeckAttacks || 0) <= 0) return null;
@@ -218,26 +255,25 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
       var deck = gs.pickingDecks[d];
       if (deck.length === 0) continue;
 
-      // Find any face-up card in the deck — that's what the player can see as a hint.
-      var visibleStrength = 0;
-      for (var fi = 0; fi < deck.length; fi++) {
-        if (!deck[fi].covered) { visibleStrength = gs.cardStrength(deck[fi].id); break; }
-      }
-      if (visibleStrength === 0) continue; // entire deck is covered, skip
+      // Skip decks where no card is visible (bot can't legally attack them).
+      var hasVisible = false;
+      for (var vi = 0; vi < deck.length; vi++) { if (!deck[vi].covered) { hasVisible = true; break; } }
+      if (!hasVisible) continue;
 
-      // Bot is server-side so it can read the actual threshold (top covered card).
+      // Evaluate how much this deck is worth receiving.
+      var deckEval = botEvaluateDeck(gs, deck);
+
+      // Bot is server-side: read the actual top card (threshold for plunder success).
       var topCard = deck[deck.length - 1];
       var actualThreshold = gs.cardStrength(topCard.id);
       var deckSize = deck.length;
 
-      // Target: aim for 12-15 total, at least meeting the real threshold.
-      // Larger decks deserve a safer margin; smaller decks keep it economical.
+      // Safe target: beat threshold with a small margin to handle uncertainty.
       var safeTarget = Math.max(actualThreshold, deckSize >= 4 ? 14 : (deckSize >= 3 ? 13 : 12));
 
       var suits = Object.keys(groups);
       for (var si = 0; si < suits.length; si++) {
         var suit = suits[si];
-        // Try to reach safeTarget; if impossible, just try to meet the actual threshold.
         var combo = botMinimalSubset(gs, groups[suit], safeTarget)
                  || botMinimalSubset(gs, groups[suit], actualThreshold);
         if (!combo) continue;
@@ -247,8 +283,8 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
         if (comboSum > actualThreshold + 6 && comboSum > 15) continue;
         var success = (comboSum > actualThreshold);
         var waste = Math.max(0, comboSum - actualThreshold);
-        // Prefer success > bigger deck > less waste > fewer cards
-        var score = (success ? 1000 : -500) + deckSize * 10 - waste * 2 - combo.length;
+        // Score: success dominates, then deck attractiveness, then efficiency
+        var score = (success ? 1000 : -500) + deckEval.value - waste * 2 - combo.length;
         if (score > bestScore) {
           bestScore = score;
           bestChoice = { deckIndex: d, cardIds: combo, symbol: suit, success: success };

--- a/server/bot.js
+++ b/server/bot.js
@@ -206,41 +206,53 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
 
   // Choose the best plunder: smart multi-card combo, preferring bigger decks with larger margin.
   // Returns { deckIndex, cardIds, symbol, success } or null.
+  // Expected strength of an unknown (covered) card — mean of all 52 regular card ranks.
+  // Ace=14, 2-13 face value → (14+2+3+…+13) * 4 suits / 52 = 8.0 exactly.
+  var BOT_UNKNOWN_CARD_STRENGTH = 8;
+
   // Score how attractive a picking deck is as plunder prey.
-  // Returns { value, hasJoker, totalStrength, visibleCount, visibleStrength }
+  // Only uses information a human player would have: face-up (visible) cards are
+  // read exactly; covered cards are estimated at the deck-average expected value.
+  // Returns { value, hasJoker, totalStrength, visibleCount, visibleStrength, coveredCount }
   function botEvaluateDeck(gs, deck) {
     var totalStrength = 0;
     var visibleStrength = 0;
     var visibleCount = 0;
-    var hasJoker = false;
+    var coveredCount = 0;
+    var hasJoker = false;   // only set when the joker is actually visible
     var foundFirstVisible = false;
 
     for (var i = 0; i < deck.length; i++) {
       var card = deck[i];
-      var isJoker = card.id > 52;
-      if (isJoker) hasJoker = true;
-      // Cap joker at 15 for strength summing (actual attack value is 999,
-      // but for deck comparison we don't want it to drown out everything else).
-      var str = isJoker ? 15 : gs.cardStrength(card.id);
-      totalStrength += str;
-      if (!card.covered) {
+      var str;
+      if (card.covered) {
+        // Unknown card — use expected value, don't peek at card.id
+        str = BOT_UNKNOWN_CARD_STRENGTH;
+        coveredCount++;
+      } else {
+        var isJoker = card.id > 52;
+        if (isJoker) hasJoker = true;
+        // Cap joker at 15 for summing (its 999 attack value would swamp the score)
+        str = isJoker ? 15 : gs.cardStrength(card.id);
         visibleCount++;
         if (!foundFirstVisible) { visibleStrength = str; foundFirstVisible = true; }
       }
+      totalStrength += str;
     }
 
     // Deck attractiveness:
-    //   totalStrength  — stronger cards received = more future attack power
-    //   hasJoker bonus — joker is extremely powerful in attack (+25)
+    //   totalStrength  — confirmed + estimated card value to be received
+    //   hasJoker bonus — a visible joker is extremely powerful in attack (+25)
     //   size bonus     — more cards = more flexibility (+3 per card)
-    //   visible bonus  — visible cards are confirmed value (+2 per visible card)
+    //   visible bonus  — visible cards are confirmed value, not estimates (+2 each)
     var value = totalStrength
               + (hasJoker ? 25 : 0)
               + deck.length * 3
               + visibleCount * 2;
 
     return { value: value, hasJoker: hasJoker, totalStrength: totalStrength,
-             visibleCount: visibleCount, visibleStrength: visibleStrength };
+             visibleCount: visibleCount, coveredCount: coveredCount,
+             visibleStrength: visibleStrength };
   }
 
   function botChoosePlunder(gs, attackerIdx) {
@@ -263,9 +275,13 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
       // Evaluate how much this deck is worth receiving.
       var deckEval = botEvaluateDeck(gs, deck);
 
-      // Bot is server-side: read the actual top card (threshold for plunder success).
+      // Estimate the plunder threshold from the top card.
+      // If the top card is covered, a human can't see it — use the expected value.
+      // If it's visible, read it directly.
       var topCard = deck[deck.length - 1];
-      var actualThreshold = gs.cardStrength(topCard.id);
+      var actualThreshold = topCard.covered
+          ? BOT_UNKNOWN_CARD_STRENGTH
+          : gs.cardStrength(topCard.id);
       var deckSize = deck.length;
 
       // Safe target: beat threshold with a small margin to handle uncertainty.

--- a/server/bot.js
+++ b/server/bot.js
@@ -8,6 +8,8 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
 
   // How long overlays stay visible (ms) — matches human player experience
   var BOT_ACTION_DELAY = 1500;
+  // Estimated strength threshold used when attacking a covered (unknown) defense card
+  var BOT_UNKNOWN_CARD_STRENGTH = 8;
 
   function isBot(player) {
     return player && player.id.indexOf('bot_') === 0;

--- a/server/bot.js
+++ b/server/bot.js
@@ -286,20 +286,45 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
               bestChoice = { defenderIdx: di, positionId: slot, cardIds: combo, symbol: suit, success: success };
             }
           }
-        } else if (allowScout && attacker.hand.length > 1) {
-          // Scout: probe with weakest non-joker card to reveal the defense card
-          var nonJokerHand = attacker.hand.filter(function(id) { return id <= 52; });
-          var weakestId = null, weakestStr = 9999;
-          for (var ci = 0; ci < nonJokerHand.length; ci++) {
-            var s = gs.cardStrength(nonJokerHand[ci]);
-            if (s < weakestStr) { weakestStr = s; weakestId = nonJokerHand[ci]; }
+        } else {
+          // Covered card: attempt a real attack using BOT_UNKNOWN_CARD_STRENGTH as estimated threshold.
+          // The decision is made without knowing the actual card; outcome is resolved against the real value.
+          var covSuits = Object.keys(groups);
+          for (var rsi = 0; rsi < covSuits.length; rsi++) {
+            var rSuit = covSuits[rsi];
+            var rCombo = botMinimalSubset(gs, groups[rSuit], BOT_UNKNOWN_CARD_STRENGTH);
+            if (!rCombo) continue;
+            var rSum = 0;
+            for (var rci = 0; rci < rCombo.length; rci++) rSum += gs.cardStrength(rCombo[rci]);
+            var rDefBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
+            var rTopId = defender.topDefCards ? defender.topDefCards[slot] : null;
+            var rTopBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
+            var rActual = botDefCardStrength(gs, defCardId) + rDefBoost
+                        + (rTopId != null ? botDefCardStrength(gs, rTopId) + rTopBoost : 0);
+            var rSuccess = (rSum > rActual);
+            var rShields = 0;
+            for (var rs = 1; rs <= 3; rs++) {
+              if (defender.defCards[rs] != null || (defender.topDefCards && defender.topDefCards[rs] != null)) rShields++;
+            }
+            // Score lower than known face-up attacks (1000) so visible targets are always preferred.
+            var rScore = 300 + (rShields === 1 ? 100 : 0) - rCombo.length;
+            if (rScore > bestScore) {
+              bestScore = rScore;
+              bestChoice = { defenderIdx: di, positionId: slot, cardIds: rCombo, symbol: rSuit, success: rSuccess };
+            }
           }
-          if (weakestId !== null) {
-            var scoutScore = 1; // low priority vs face-up attacks
-            if (scoutScore > bestScore) {
-              bestScore = scoutScore;
+          // Scout fallback: probe with weakest card when no combo can beat the expected strength.
+          if (allowScout && attacker.hand.length > 1) {
+            var scoutHand = attacker.hand.filter(function(id) { return id <= 52; });
+            var scoutId = null, scoutStr = 9999;
+            for (var sci = 0; sci < scoutHand.length; sci++) {
+              var ss = gs.cardStrength(scoutHand[sci]);
+              if (ss < scoutStr) { scoutStr = ss; scoutId = scoutHand[sci]; }
+            }
+            if (scoutId !== null && 1 > bestScore) {
+              bestScore = 1;
               bestChoice = { defenderIdx: di, positionId: slot,
-                             cardIds: [weakestId], symbol: botCardSuit(weakestId), success: false };
+                             cardIds: [scoutId], symbol: botCardSuit(scoutId), success: false };
             }
           }
         }
@@ -363,20 +388,48 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
               bestChoice = { defenderIdx: di, positionId: slot, cardIds: combo, symbol: suit, success: success };
             }
           }
-        } else if (allowScout && !fixedSymbol && attacker.hand.length > 1) {
-          // Scout: probe covered card with weakest non-joker to reveal it
-          var nonJokerHand = attacker.hand.filter(function(id) { return id <= 52; });
-          var weakestId = null, weakestStr = 9999;
-          for (var ci2 = 0; ci2 < nonJokerHand.length; ci2++) {
-            var str = gs.cardStrength(nonJokerHand[ci2]);
-            if (str < weakestStr) { weakestStr = str; weakestId = nonJokerHand[ci2]; }
+        } else {
+          // Covered card: attempt a real attack using BOT_UNKNOWN_CARD_STRENGTH as estimated threshold.
+          // The decision is made without knowing the actual card; outcome is resolved against the real value.
+          var pCovSuits = Object.keys(groups);
+          for (var prsi = 0; prsi < pCovSuits.length; prsi++) {
+            var prSuit = pCovSuits[prsi];
+            var prCombo = botMinimalSubset(gs, groups[prSuit], BOT_UNKNOWN_CARD_STRENGTH);
+            if (!prCombo) continue;
+            var prSum = 0;
+            for (var prci = 0; prci < prCombo.length; prci++) prSum += gs.cardStrength(prCombo[prci]);
+            var prDefBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
+            var prTopId = defender.topDefCards ? defender.topDefCards[slot] : null;
+            var prTopBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
+            var prActual = botDefCardStrength(gs, defCardId) + prDefBoost
+                         + (prTopId != null ? botDefCardStrength(gs, prTopId) + prTopBoost : 0);
+            var prSuccess = (prSum > prActual);
+            var prShields = 0;
+            for (var prs = 1; prs <= 3; prs++) {
+              if (defender.defCards[prs] != null || (defender.topDefCards && defender.topDefCards[prs] != null)) prShields++;
+            }
+            // Score lower than known face-up attacks (1000) so visible targets are always preferred.
+            var prScore = 300 + (prShields === 1 ? 100 : 0) - prCombo.length + bonus;
+            if (prScore > bestScore) {
+              bestScore = prScore;
+              bestChoice = { defenderIdx: di, positionId: slot, cardIds: prCombo, symbol: prSuit, success: prSuccess };
+            }
           }
-          if (weakestId !== null) {
-            var scoutScore = 1 + Math.floor(bonus * 0.1);
-            if (scoutScore > bestScore) {
-              bestScore = scoutScore;
-              bestChoice = { defenderIdx: di, positionId: slot,
-                             cardIds: [weakestId], symbol: botCardSuit(weakestId), success: false };
+          // Scout fallback (first attack only, no locked symbol): probe with weakest card.
+          if (allowScout && !fixedSymbol && attacker.hand.length > 1) {
+            var pScoutHand = attacker.hand.filter(function(id) { return id <= 52; });
+            var pScoutId = null, pScoutStr = 9999;
+            for (var psci = 0; psci < pScoutHand.length; psci++) {
+              var pss = gs.cardStrength(pScoutHand[psci]);
+              if (pss < pScoutStr) { pScoutStr = pss; pScoutId = pScoutHand[psci]; }
+            }
+            if (pScoutId !== null) {
+              var pScoutScore = 1 + Math.floor(bonus * 0.1);
+              if (pScoutScore > bestScore) {
+                bestScore = pScoutScore;
+                bestChoice = { defenderIdx: di, positionId: slot,
+                               cardIds: [pScoutId], symbol: botCardSuit(pScoutId), success: false };
+              }
             }
           }
         }

--- a/server/bot.js
+++ b/server/bot.js
@@ -47,12 +47,17 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
      * Tactician uses this to focus-fire the weakest opponent.
      */
     targetBonus(/*gs, defenderIdx*/) { return 0; }
+    /**
+     * Maximum hand size before the bot skips plundering.
+     * Keeps bots from hoarding cards when they already have plenty.
+     */
+    maxHandSizeBeforePlunder()       { return 12; }
   }
 
-  /** Balanced — current default behaviour: fill weakest, one attack, scout disabled. */
+  /** Balanced — current default behaviour: fill weakest, two attacks, scout disabled. */
   class BalancedPersonality extends BotPersonality {
     constructor() { super('balanced'); }
-    // All defaults are already balanced behaviour.
+    maxAttacksPerTurn()     { return 2; }  // was 1; increased so bots don't hoard cards
   }
 
   /**
@@ -92,7 +97,7 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
   class TacticianPersonality extends BotPersonality {
     constructor() { super('tactician'); }
     attackAfterPlunder()    { return true; }
-    maxAttacksPerTurn()     { return 2; }
+    maxAttacksPerTurn()     { return 3; }  // was 2; focus-fire harder
     allowScouting()         { return true; }
     sacrificeJokerForHero() { return true; }
     targetBonus(gs, defenderIdx) {
@@ -129,6 +134,14 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
 
   function getPersonality(mode) {
     return PERSONALITIES[mode] || PERSONALITIES.balanced;
+  }
+
+  // Defense card strength as seen by the BOT's attack evaluator.
+  // Game rule: a joker in DEFENSE has strength 1, not unlimited.
+  function botDefCardStrength(gs, cardId) {
+    if (cardId == null) return 0;
+    if (cardId > 52) return 1; // joker in defense slot = strength 1
+    return gs.cardStrength(cardId);
   }
 
   // Returns the card suit name for a card ID
@@ -265,8 +278,8 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
           var defBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
           var topCardId = defender.topDefCards ? defender.topDefCards[slot] : null;
           var topBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
-          var threshold = gs.cardStrength(defCardId) + defBoost
-                        + (topCardId != null ? gs.cardStrength(topCardId) + topBoost : 0);
+          var threshold = botDefCardStrength(gs, defCardId) + defBoost
+                        + (topCardId != null ? botDefCardStrength(gs, topCardId) + topBoost : 0);
           var suits = Object.keys(groups);
           for (var si = 0; si < suits.length; si++) {
             var suit = suits[si];
@@ -343,8 +356,8 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
           var defBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
           var topCardId = defender.topDefCards ? defender.topDefCards[slot] : null;
           var topBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
-          var threshold = gs.cardStrength(defCardId) + defBoost
-                        + (topCardId != null ? gs.cardStrength(topCardId) + topBoost : 0);
+          var threshold = botDefCardStrength(gs, defCardId) + defBoost
+                        + (topCardId != null ? botDefCardStrength(gs, topCardId) + topBoost : 0);
           var suits = Object.keys(groups);
           for (var si = 0; si < suits.length; si++) {
             var suit = suits[si];
@@ -537,6 +550,28 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     io.to(sess.id).emit('stateUpdate', gs.serialize());
     checkAndHandleWinner(sess);
     playBotTurnIfNeeded(sess);
+  }
+
+  // If the bot has a joker in a defense slot, take it back to hand immediately.
+  // Jokers have strength 1 in defense but are extremely powerful in attack.
+  // Returns true if a joker was retrieved.
+  function botRetrieveJokerFromDefense(gs, playerIdx) {
+    var p = gs.players[playerIdx];
+    if (!p) return false;
+    // Check take-action budget (Marshal = 3 combined, else 1 take)
+    var hasMarshal = (p.heroes || []).indexOf('Marshal') !== -1;
+    var takeActionsLeft = hasMarshal ? 3 : 1;
+    var retrieved = false;
+    for (var slot = 1; slot <= 3; slot++) {
+      if (takeActionsLeft <= 0) break;
+      var cardId = p.defCards && p.defCards[slot];
+      if (cardId != null && cardId > 52) { // joker in defense slot
+        gs.takeDefCard(playerIdx, slot);
+        takeActionsLeft--;
+        retrieved = true;
+      }
+    }
+    return retrieved;
   }
 
   // Replace an exposed (face-up) defense card with a face-down card from hand.
@@ -861,6 +896,9 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     // Setup: same heuristics as balanced bot
     botTryJokerSacrifice(sess, gs, idx);
     botFillDefense(gs, idx, getPersonality('balanced'));
+    if (botRetrieveJokerFromDefense(gs, idx)) {
+      io.to(sess.id).emit('stateUpdate', gs.serialize());
+    }
     if (botReplaceExposedDefense(gs, idx)) {
       io.to(sess.id).emit('stateUpdate', gs.serialize());
     }
@@ -973,7 +1011,12 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     var p = gs.players[idx];
     if (!p || p.isOut) return;
 
-    // 1. Sacrifice joker for hero (unless personality saves it for king kills)
+    // 1. Retrieve own jokers from defense — joker defense value is 1, wasteful
+    if (botRetrieveJokerFromDefense(gs, idx)) {
+      io.to(sess.id).emit('stateUpdate', gs.serialize());
+    }
+
+    // 2. Sacrifice joker for hero (unless personality saves it for king kills)
     if (personality.sacrificeJokerForHero()) {
       botTryJokerSacrifice(sess, gs, idx);
     }
@@ -1002,8 +1045,9 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
         return;
       }
 
-      // 5. Smart plunder — multi-card, economical combo
-      var plunderChoice = botChoosePlunder(gs, idx);
+      // 5. Smart plunder — skip if hand is already too large
+      var maxHandBeforePlunder = (personality.maxHandSizeBeforePlunder ? personality.maxHandSizeBeforePlunder() : 12);
+      var plunderChoice = (p.hand.length < maxHandBeforePlunder) ? botChoosePlunder(gs, idx) : null;
       if (plunderChoice) {
         var plAtkSum = 0;
         for (var pci = 0; pci < plunderChoice.cardIds.length; pci++) plAtkSum += gs.cardStrength(plunderChoice.cardIds[pci]);

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -499,10 +499,16 @@ class GameState {
   plunderResolved(attackerIdx, deckIdx, success, attackCardIds, kingUsed, attackerOwnDefCardIds) {
     // Use cards pre-locked in setPlunderPreview if available (prevents reappearance on refresh)
     const lockedHandCards = this.pendingPlunder ? (this.pendingPlunder._lockedHandCards || []) : [];
+    // Capture deck top card strength BEFORE any deck modification (for log display)
+    const deck = this.pickingDecks[deckIdx];
+    const topDeckCard = deck.length > 0 ? deck[deck.length - 1].id : null;
+    const deckDefStrength = topDeckCard ? this.cardStrength(topDeckCard) : 0;
     this.pendingPlunder = null;
     const attacker = this.players[attackerIdx];
     // NOTE: plundering does NOT increment attackCount — only real attacks (defAttack/kingAttack/warlord) do.
     const handCardsToProcess = lockedHandCards.length > 0 ? lockedHandCards : attackCardIds;
+    const plunderAtkSum = handCardsToProcess.reduce((sum, id) => sum + this.cardStrength(id), 0)
+      + (attackerOwnDefCardIds || []).reduce((sum, id) => sum + this.cardStrength(id), 0);
     for (const cardId of handCardsToProcess) {
       const i = attacker.hand.indexOf(cardId);
       if (i !== -1) attacker.hand.splice(i, 1); // already removed from hand if locking was used
@@ -521,7 +527,7 @@ class GameState {
     if (kingUsed) { attacker.kingCovered = false; attacker.statKingUsed = (attacker.statKingUsed || 0) + 1; }
     if (success) {
       attacker.statPlundersSuccess = (attacker.statPlundersSuccess || 0) + 1;
-      this.pushLog(`${this.pname(attackerIdx)} plundered deck ${deckIdx + 1}!`, true);
+      this.pushLog(`${this.pname(attackerIdx)} plundered deck ${deckIdx + 1}! (${plunderAtkSum} vs ${deckDefStrength})`, true);
       // Move all cards from plundered deck into attacker's hand
       for (const c of this.pickingDecks[deckIdx]) attacker.hand.push(c.id);
       this.pickingDecks[deckIdx] = [];
@@ -533,7 +539,7 @@ class GameState {
       const c3 = this.pickCard(); if (c3 !== null) this.pickingDecks[deckIdx].push({ id: c3, covered: true });
     } else {
       attacker.statPlundersFailed = (attacker.statPlundersFailed || 0) + 1;
-      this.pushLog(`${this.pname(attackerIdx)} plunder on deck ${deckIdx + 1} failed`, false);
+      this.pushLog(`${this.pname(attackerIdx)} plunder on deck ${deckIdx + 1} failed (${plunderAtkSum} vs ${deckDefStrength})`, false);
       if (kingUsed) {
         attacker.isOut = true;
         attacker.statRoundEliminatedAt = this.roundNumber;
@@ -571,9 +577,18 @@ class GameState {
       this.cemetery.push(cardId);
     }
     if (kingUsed) { attacker.kingCovered = false; attacker.statKingUsed = (attacker.statKingUsed || 0) + 1; }
+    // Capture defense values before the card may be removed (for log display)
+    const _defCardId = defender.defCards[positionId];
+    const _defBoost = (defender.defCardsBoost && defender.defCardsBoost[positionId]) || 0;
+    const _topDefId = defender.topDefCards ? defender.topDefCards[positionId] : null;
+    const _topBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[positionId]) || 0;
+    const defStrength = this.cardStrength(_defCardId) + _defBoost
+      + (_topDefId != null ? this.cardStrength(_topDefId) + _topBoost : 0);
+    const atkSum = attackCardIds.reduce((sum, id) => sum + this.cardStrength(id), 0)
+      + (attackerOwnDefCardIds || []).reduce((sum, id) => sum + this.cardStrength(id), 0);
     if (success) {
       attacker.statAttacksSuccess = (attacker.statAttacksSuccess || 0) + 1;
-      this.pushLog(`${this.pname(attackerIdx)} broke ${this.pname(defenderIdx)}'s shield [${positionId}]`, true);
+      this.pushLog(`${this.pname(attackerIdx)} broke ${this.pname(defenderIdx)}'s shield [${positionId}] (${atkSum} vs ${defStrength})`, true);
       // If the slot was sabotaged, clear it (saboteur destroyed when card is removed by attack)
       if (defender.sabotaged && defender.sabotaged[positionId] !== undefined) {
         delete defender.sabotaged[positionId];
@@ -593,7 +608,7 @@ class GameState {
       }
     } else {
       attacker.statAttacksFailed = (attacker.statAttacksFailed || 0) + 1;
-      this.pushLog(`${this.pname(attackerIdx)} missed ${this.pname(defenderIdx)}'s shield [${positionId}]`, false);
+      this.pushLog(`${this.pname(attackerIdx)} missed ${this.pname(defenderIdx)}'s shield [${positionId}] (${atkSum} vs ${defStrength})`, false);
       if (kingUsed) {
         attacker.isOut = true;
         attacker.statRoundEliminatedAt = this.roundNumber;
@@ -754,10 +769,12 @@ class GameState {
       this.cemetery.push(cardId);
     }
     if (kingUsed) { attacker.kingCovered = false; attacker.statKingUsed = (attacker.statKingUsed || 0) + 1; }
+    const kingStrength = this.cardStrength(defender.kingCard);
+    const kingAtkSum = attackCardIds.reduce((sum, id) => sum + this.cardStrength(id), 0);
     if (success) {
       attacker.statAttacksSuccess = (attacker.statAttacksSuccess || 0) + 1;
       attacker.statDefeated = (attacker.statDefeated || 0) + 1;
-      this.pushLog(`${this.pname(attackerIdx)} defeated ${this.pname(defenderIdx)}!`, true);
+      this.pushLog(`${this.pname(attackerIdx)} defeated ${this.pname(defenderIdx)}! (${kingAtkSum} vs ${kingStrength})`, true);
       // Defender loses their king and is eliminated; attacker gains their cards as prey
       defender.isOut = true;
       defender.statRoundEliminatedAt = this.roundNumber;
@@ -782,7 +799,7 @@ class GameState {
       }
     } else {
       attacker.statAttacksFailed = (attacker.statAttacksFailed || 0) + 1;
-      this.pushLog(`${this.pname(attackerIdx)} king assault on ${this.pname(defenderIdx)} failed`, false);
+      this.pushLog(`${this.pname(attackerIdx)} king assault on ${this.pname(defenderIdx)} failed (${kingAtkSum} vs ${kingStrength})`, false);
       // Expose the defending king so it remains visible after a failed assault
       defender.kingCovered = false;
       if (kingUsed) {
@@ -918,6 +935,7 @@ class GameState {
     target.statHeroesReceived = (target.statHeroesReceived || 0) + 1;
     // Give an immediate charge when Battery Tower is acquired
     if (heroName === 'Battery Tower') target.batteryTowerCharges = 1;
+    this.pushLog(`${this.pname(playerIdx)} acquired hero: ${heroName}`, true, true);
   }
 
   heroLost(playerIdx, heroName) {

--- a/server/index.js
+++ b/server/index.js
@@ -991,19 +991,21 @@ io.on('connection', function(socket) {
     var allowHeroSelection = (data && data.allowHeroSelection !== false);
     var startingCards = (data && data.startingCards) ? parseInt(data.startingCards, 10) : 8;
     var manualSetup = !!(data && data.manualSetup);
+    var spectatorMode = !!(data && data.spectator);
     var sess = createSession(sessionName, allowHeroSelection, startingCards, manualSetup);
     // botModes: array of personality strings, e.g. ["aggressive","passive"].
     // Falls back to legacy botCount (numeric) for backward compat.
+    // Spectator mode allows up to 4 bots; normal mode allows up to 3.
     var VALID_MODES = ['passive', 'balanced', 'aggressive', 'tactician', 'mcts'];
+    var maxBots = spectatorMode ? 4 : 3;
     var botModes = [];
     if (data && Array.isArray(data.botModes)) {
-      botModes = data.botModes.filter(function(m) { return VALID_MODES.indexOf(String(m)) !== -1; }).slice(0, 3);
+      botModes = data.botModes.filter(function(m) { return VALID_MODES.indexOf(String(m)) !== -1; }).slice(0, maxBots);
     } else {
-      var legacyCount = Math.min(3, Math.max(0, parseInt(data && data.botCount) || 0));
+      var legacyCount = Math.min(maxBots, Math.max(0, parseInt(data && data.botCount) || 0));
       for (var li = 0; li < legacyCount; li++) botModes.push('balanced');
     }
     var cToken = (data && data.token) ? String(data.token).slice(0, 64) : null;
-    sess.users.push(makeUser(socket.id, name, cToken));
     var BOT_MODE_LABELS = { passive: 'Passive', balanced: 'Balanced', aggressive: 'Aggressive', tactician: 'Tactician', mcts: 'MCTS' };
     for (var bi = 0; bi < botModes.length; bi++) {
       var mode = botModes[bi];
@@ -1013,20 +1015,49 @@ io.on('connection', function(socket) {
       botUser.botMode = mode;
       sess.users.push(botUser);
     }
-    if (cToken) {
-      if (!tokenMap[cToken]) tokenMap[cToken] = {};
-      tokenMap[cToken].name = name;
-      tokenMap[cToken].socketId = socket.id;
-      tokenMap[cToken].sessionId = sess.id;
-    }
     socketToSession[socket.id] = sess.id;
     socket.join(sess.id);
-    console.log("Session created: " + sess.id + " '" + sess.name + "' by " + name + " (heroes: " + allowHeroSelection + ", startingCards: " + sess.startingCards + ", manualSetup: " + manualSetup + ", bots: [" + botModes.join(',') + "])");
-    socket.emit('sessionJoined', { sessionId: sess.id, allowHeroSelection: sess.allowHeroSelection, startingCards: sess.startingCards, manualSetup: sess.manualSetup });
-    io.to(sess.id).emit('getUsers', getUsersWithHeroes(sess));
-    socket.emit('gameStatus', { running: false });
-    broadcastSessionList();
-    broadcastPlayerList();
+
+    if (spectatorMode && sess.users.length >= 2) {
+      // Creator watches as spectator — all players are bots, start the game immediately.
+      sess.spectators.push(socket.id);
+      if (cToken) {
+        if (!tokenMap[cToken]) tokenMap[cToken] = {};
+        tokenMap[cToken].name = name;
+        tokenMap[cToken].socketId = socket.id;
+      }
+      console.log("Session created (spectator): " + sess.id + " '" + sess.name + "' by " + name + " (bots: [" + botModes.join(',') + "])");
+      // Start the game immediately — all users are bots and ready.
+      sess.gameState = new GameState(sess.users, { startingCards: sess.startingCards, manualSetup: sess.manualSetup });
+      if (sess.manualSetup && sess.gameState.setupPhase) {
+        sess.users.forEach(function(u, idx) {
+          if (bot.isBot(u)) {
+            var setup = bot.autoSetupBot(sess.gameState, idx);
+            if (setup) sess.gameState.applyManualSetup(idx, setup.kingId, setup.defIds, setup.discardIds);
+          }
+        });
+      }
+      // Send spectator gameState to creator (playerIndex -1)
+      socket.emit('gameState', { playerIndex: -1, gameState: sess.gameState.serialize() });
+      broadcastSessionList();
+      broadcastPlayerList();
+      bot.playBotTurnIfNeeded(sess);
+    } else {
+      // Normal mode: creator joins as player.
+      sess.users.unshift(makeUser(socket.id, name, cToken));
+      if (cToken) {
+        if (!tokenMap[cToken]) tokenMap[cToken] = {};
+        tokenMap[cToken].name = name;
+        tokenMap[cToken].socketId = socket.id;
+        tokenMap[cToken].sessionId = sess.id;
+      }
+      console.log("Session created: " + sess.id + " '" + sess.name + "' by " + name + " (heroes: " + allowHeroSelection + ", startingCards: " + sess.startingCards + ", manualSetup: " + manualSetup + ", bots: [" + botModes.join(',') + "])");
+      socket.emit('sessionJoined', { sessionId: sess.id, allowHeroSelection: sess.allowHeroSelection, startingCards: sess.startingCards, manualSetup: sess.manualSetup });
+      io.to(sess.id).emit('getUsers', getUsersWithHeroes(sess));
+      socket.emit('gameStatus', { running: false });
+      broadcastSessionList();
+      broadcastPlayerList();
+    }
   });
 
   socket.on('joinSession', function(data) {


### PR DESCRIPTION
Closes #206

Also includes spectator mode + 4th bot option from `fix/bot-aggression-issue-195` (all changes in one PR as requested).

## Changes

### Spectator mode + 4th bot option (`server/index.js`, `core/.../MenuScreen.java`)
- Creator can tick "Spectator" when creating a session → joins as spectator (`playerIndex: -1`), game starts immediately with up to 4 bots
- 4th bot slot enabled only when Spectator is checked

### Bot — aggressive attacks on covered defense cards (`server/bot.js`)

Previously `botChooseDefAttack` and `botChooseDefAttackP` only "scouted" covered defense cards (sent the weakest card to fail and reveal). Now they attempt a **real attack** first:

- Uses `BOT_UNKNOWN_CARD_STRENGTH = 8` as the estimated threshold for deciding which combo to commit.
- Actual success is computed server-side against the real card value — no cheating from the hidden value.
- Score 300 (lower than face-up success 1000) so known targets are always preferred; covered attacks win over the scout fallback (score 1).
- Scout kept as a fallback when no combo can beat the expected strength.

### History log — combat values (`server/gameState.js`)

| Event | Before | After |
|---|---|---|
| Defense attack success | `Alice broke Bob's shield [2]` | `Alice broke Bob's shield [2] (11 vs 9)` |
| Defense attack failure | `Alice missed Bob's shield [2]` | `Alice missed Bob's shield [2] (7 vs 9)` |
| Plunder success | `Alice plundered deck 1!` | `Alice plundered deck 1! (15 vs 10)` |
| Plunder failure | `Alice plunder on deck 1 failed` | `Alice plunder on deck 1 failed (8 vs 10)` |
| King assault success | `Alice defeated Bob!` | `Alice defeated Bob! (20 vs 15)` |
| King assault failure | `Alice king assault on Bob failed` | `Alice king assault on Bob failed (13 vs 15)` |
| Hero acquired | _(no log)_ | `Alice acquired hero: Merlin` |

### History tab — Copy log button (`core/src/com/mygdx/game/StatsScreen.java`)

Added a "Copy log" button to the History tab that copies all log entries as plain text to the system clipboard.
