### PR TITLE
Replace music text button with animated GIF icon

### DIFF
--- a/.agents/skills/premium-frontend-ui/SKILL.md
+++ b/.agents/skills/premium-frontend-ui/SKILL.md
@@ -1,0 +1,116 @@
+---
+description: A comprehensive guide for GitHub Copilot to craft immersive, high-performance web experiences with advanced motion, typography, and architectural craftsmanship.
+metadata:
+    author: Utkarsh Patrikar
+    author_url: https://github.com/utkarsh232005
+    github-path: skills/premium-frontend-ui
+    github-ref: refs/heads/main
+    github-repo: https://github.com/github/awesome-copilot
+    github-tree-sha: 11ed1a3f37de027eaa81ed003541846491f6815c
+name: premium-frontend-ui
+---
+# Immersive Frontend UI Craftsmanship
+
+As an AI engineering assistant, your role when building premium frontend experiences goes beyond outputting functional HTML and CSS. You must architect **immersive digital environments**. This skill provides the blueprint for generating highly intentional, award-level web applications that prioritize aesthetic quality, deep interactivity, and flawless performance.
+
+When a user requests a high-end landing page, an interactive portfolio, or a specialized component that requires top-tier visual polish, apply the following rigorous standards to every line of code you generate.
+
+---
+
+## 1. Establishing the Creative Foundation
+
+Before generating layout code, ensure you understand the core emotional resonance the UI should deliver. Do not default to generic, unopinionated code. 
+
+Commit to a strong visual identity in your CSS and component structure:
+- **Editorial Brutalism**: High-contrast monochromatic palettes, oversized typography, sharp rectangular edges, and raw grid structures.
+- **Organic Fluidity**: Soft gradients, deeply rounded corners, glassmorphism overlays, and bouncy spring-based physics.
+- **Cyber / Technical**: Dark mode dominance, glowing neon accents, monospaced typography, and rapid, staggered reveal animations.
+- **Cinematic Pacing**: Full-viewport imagery, slow cross-fades, profound use of negative space, and scroll-dependent storytelling.
+
+---
+
+## 2. Structural Requirements for Immersive UI
+
+When scaffolding a page or generating core components, include the following architectural layers to transform a standard page into an experience.
+
+### 2.1 The Entry Sequence (Preloading & Initialization)
+A blank screen is unacceptable. The user's first interaction must set expectations.
+- **Implementation**: Generate a lightweight preloader component that handles asset resolution (fonts, initial images, 3D models).
+- **Animation**: Output code that transitions the preloader away fluidly—such as a split-door reveal, a scale-up zoom, or a staggered text sweep.
+
+### 2.2 The Hero Architecture
+The top fold must command attention immediately.
+- **Visuals**: Output code that implements full-bleed containers (`100vh`/`100dvh`).
+- **Typography Engine**: Ensure headlines are broken down syntactically (e.g., span wrapping by word or character) to allow for cascading entrance animations.
+- **Depth**: Utilize subtle floating elements or background clipping paths to create a sense of scale and depth behind the primary copy.
+
+### 2.3 Fluid & Contextual Navigation
+- **Implementation**: Do not generate standard static navbars. Output sticky headers that react toscroll direction (hide on scroll down, reveal on scroll up).
+- **Interactivity**: Include hover states that reveal rich content (e.g., mega-menus that display image previews of the hovered link).
+
+---
+
+## 3. The Motion Design System
+
+Animation is not an afterthought; it is the connective tissue of a premium site. Always implement the following motion principles:
+
+### 3.1 Scroll-Driven Narratives
+Generate code utilizing modern scroll libraries (like GSAP's ScrollTrigger) to tie animations to user progress.
+- **Pinned Containers**: Create sections that lock into the viewport while secondary content flows past or reveals itself.
+- **Horizontal Journeys**: Translate vertical scroll data into horizontal movement for specific galleries or showcases.
+- **Parallax Mapping**: Assign subtle, varying scroll-speeds to background elements, midground text, and foreground imagery.
+
+### 3.2 High-Fidelity Micro-Interactions
+The cursor is the user's avatar. Build interactions around it.
+- **Magnetic Components**: Write logic that calculates the distance between the mouse pointer and a button, pulling the button towards the cursor dynamically.
+- **Custom Tracking Elements**: Generate custom cursor components that follow the mouse with calculated interpolation (lerp) for a smooth drag effect.
+- **Dimensional Hover States**: Use CSS Transforms (`scale`, `rotateX`, `translate3d`) to give interactive elements weight and tactile feedback.
+
+---
+
+## 4. Typography & Visual Texture
+
+The aesthetics of your generated code must reflect premium craftsmanship.
+
+- **Type Hierarchy**: Enforce massive contrast in scale. Headlines should utilize extreme sizing (`clamp()` functions spanning up to `12vw`), while body copy remains incredibly crisp (`16px-18px` minimum). 
+- **Font Selection**: Always recommend or implement highly specified variable fonts or premium typefaces over system defaults.
+- **Atmospheric Filters**: Implement CSS/SVG noise overlays (`mix-blend-mode: overlay`, opacity `0.02 - 0.05`) to remove digital sterility and add photographic grain.
+- **Lighting & Glass**: Utilize `backdrop-filter: blur(x)` combined with ultra-thin, semi-transparent borders to create modern, frosted-glass depth.
+
+---
+
+## 5. The Performance Imperative
+
+A beautiful site that stutters is a failure. Enforce strict performance guardrails in all generated code:
+
+- **Hardware Acceleration**: Only animate properties that do not trigger layout recalculations: `transform` and `opacity`. Code that animates `width`, `height`, `top`, or `margin` should be fiercely avoided.
+- **Render Optimization**: Apply `will-change: transform` intelligently on complex moving elements, but remove it post-animation to conserve memory.
+- **Responsive Degradation**: Wrap custom cursor logic and heavy hover animations in `@media (hover: hover) and (pointer: fine)` to ensure pristine performance on touch devices.
+- **Accessibility**: Wrap heavy continuous animations in `@media (prefers-reduced-motion: no-preference)`. Never sacrifice user accessibility for aesthetic flair.
+
+---
+
+## 6. Implementation Ecosystem
+
+When the user asks you to implement these patterns, leverage industry-standard libraries tailored to their framework:
+
+### For React / Next.js Targets
+- Structure the application to support **Framer Motion** for layout transitions and spring physics.
+- Recommend **Lenis** (`@studio-freight/lenis`) for smooth scrolling context.
+- Implement **React Three Fiber** (`@react-three/fiber`) if webGL or 3D interactions are requested.
+
+### For Vanilla / HTML / Astro Targets
+- Rely heavily on **GSAP** (GreenSock Animation Platform) for timeline sequencing.
+- Utilize vanilla **Lenis** via CDN for scroll hijacking and smoothing.
+- Use **SplitType** for safe, accessible typography chunking.
+
+---
+
+## Summary of Action
+
+Whenever you receive a prompt to "Build a premium landing page," "Create an Awwwards-style component," or "Design an immersive UI," you must automatically:
+1. Wrap the output in a robust, scroll-smoothed architecture.
+2. Provide CSS that guarantees perfect performance using composited layers.
+3. Integrate sweeping, staggered component entrances.
+4. Elevate the typography using fluid scales.
+5. Create an intentional, memorable aesthetic footprint.

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,8 @@ RUN --mount=type=cache,target=/root/.gradle \
     mkdir -p /workspace/html/war/assets/data/sounds && \
     cp /workspace/android/assets/data/sounds/*.mp3 /workspace/html/war/assets/data/sounds/ && \
     cp -r /workspace/html/webapp/. /workspace/html/build/gwt/out/ && \
-    cp -r /workspace/html/war/assets /workspace/html/build/gwt/out/assets
+    cp -r /workspace/html/war/assets /workspace/html/build/gwt/out/assets && \
+    cp /workspace/html/war/music.gif /workspace/html/build/gwt/out/music.gif
 
 # ── Stage 2: Node.js server ──────────────────────────────────────────────────
 FROM node:18-alpine

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -877,6 +877,8 @@ public class MenuScreen extends AbstractScreen {
    * (works around browser autoplay restrictions).
    */
   private void addMusicToggleButton(final Stage stage) {
+    // On the web platform the HTML/GWT layer injects an animated GIF button instead.
+    if (MyGdxGame.nativeMusicButton) return;
     final boolean enabled = MyGdxGame.playerStorage.getMusicEnabled();
     final TextButton musicBtn = new TextButton(enabled ? "Music ON" : "Music OFF", MyGdxGame.skin);
     musicBtn.pack();

--- a/core/src/com/mygdx/game/MyGdxGame.java
+++ b/core/src/com/mygdx/game/MyGdxGame.java
@@ -41,6 +41,23 @@ public class MyGdxGame extends Game implements InputProcessor {
   /** True once a user gesture has occurred — required to unblock browser autoplay. */
   static boolean musicStarted = false;
 
+  /**
+   * When true, the HTML/GWT layer provides its own animated GIF music button and
+   * {@link MenuScreen#addMusicToggleButton} skips adding the LibGDX TextButton.
+   * Set to {@code true} by HtmlLauncher before the first screen is shown.
+   */
+  public static boolean nativeMusicButton = false;
+
+  /**
+   * Called whenever the music enabled-state changes so the platform layer can
+   * update its visual music indicator (e.g. start/stop the animated GIF).
+   * Set by HtmlLauncher; null on non-web platforms.
+   */
+  public static Runnable onMusicUiUpdate = null;
+
+  /** Singleton reference — set in {@link #create()} for JSNI callbacks. */
+  public static MyGdxGame INSTANCE;
+
   private static Music loadTrack(String path) {
     try {
       Music m = Gdx.audio.newMusic(Gdx.files.internal(path));
@@ -104,10 +121,25 @@ public class MyGdxGame extends Game implements InputProcessor {
     } else {
       if (activeMusic != null) activeMusic.pause();
     }
+    if (onMusicUiUpdate != null) onMusicUiUpdate.run();
+  }
+
+  /**
+   * Called from the HTML music GIF button (via JSNI) when the user clicks it.
+   * Toggles the music state and refreshes the current menu screen if needed.
+   */
+  public static void handleMusicButtonClick() {
+    boolean newEnabled = !playerStorage.getMusicEnabled();
+    setMusicEnabled(newEnabled);
+    if (INSTANCE != null) {
+      com.badlogic.gdx.Screen scr = INSTANCE.getScreen();
+      if (scr instanceof MenuScreen) ((MenuScreen) scr).show();
+    }
   }
 
   @Override
   public void create() {
+    INSTANCE = this;
 
     // camera = new OrthographicCamera(Gdx.graphics.getWidth(),
     // Gdx.graphics.getHeight());

--- a/html/src/com/mygdx/game/client/HtmlLauncher.java
+++ b/html/src/com/mygdx/game/client/HtmlLauncher.java
@@ -84,12 +84,9 @@ public class HtmlLauncher extends GwtApplication {
     /**
      * Injects a fixed-position animated GIF music toggle button into the DOM.
      *
-     * Two sibling elements are created:
-     *   #baisch-music-img    — the animated GIF (shown when music is ON)
-     *   #baisch-music-canvas — a canvas showing the GIF's first frame (shown when OFF)
-     *
-     * The first frame is captured once the image loads.  Subsequent toggles swap
-     * visibility between the two elements via window._baischSetMusicBtn(bool).
+     * A single <img> element is always visible. When music is ON the GIF plays
+     * at full colour; when OFF it is shown greyed-out (grayscale + reduced opacity)
+     * so the button is always findable regardless of localStorage state or load order.
      *
      * Clicks call MyGdxGame.handleMusicButtonClick() via JSNI so that the LibGDX
      * music state and the current menu screen re-render stay in sync.
@@ -98,40 +95,21 @@ public class HtmlLauncher extends GwtApplication {
         var SIZE = '54px';
         var img = $doc.createElement('img');
         img.id  = 'baisch-music-img';
-        img.src = 'music.gif';
+        img.src = '/music.gif';
         img.style.cssText =
             'position:fixed;top:6px;right:6px;width:' + SIZE + ';height:' + SIZE + ';' +
             'cursor:pointer;z-index:9999;border-radius:50%;display:block;';
 
-        var canvas = $doc.createElement('canvas');
-        canvas.id  = 'baisch-music-canvas';
-        canvas.style.cssText =
-            'position:fixed;top:6px;right:6px;width:' + SIZE + ';height:' + SIZE + ';' +
-            'cursor:pointer;z-index:9999;border-radius:50%;display:none;';
-
         $doc.body.appendChild(img);
-        $doc.body.appendChild(canvas);
-
-        var firstFrameCaptured = false;
-        function captureFirstFrame() {
-            if (firstFrameCaptured) return;
-            firstFrameCaptured = true;
-            canvas.width  = img.naturalWidth  || 100;
-            canvas.height = img.naturalHeight || 100;
-            canvas.getContext('2d').drawImage(img, 0, 0);
-        }
-        if (img.complete) { captureFirstFrame(); }
-        else { img.addEventListener('load', captureFirstFrame); }
 
         // Public setter used by the Java onMusicUiUpdate callback.
         $wnd._baischSetMusicBtn = function(on) {
-            if (!on) {
-                captureFirstFrame();        // ensure first frame is ready
-                img.style.display    = 'none';
-                canvas.style.display = 'block';
+            if (on) {
+                img.style.opacity = '1';
+                img.style.filter  = 'none';
             } else {
-                img.style.display    = 'block';
-                canvas.style.display = 'none';
+                img.style.opacity = '0.4';
+                img.style.filter  = 'grayscale(100%)';
             }
         };
 
@@ -140,11 +118,9 @@ public class HtmlLauncher extends GwtApplication {
         $wnd._baischSetMusicBtn(enabled);
 
         // Click: delegate to Java so LibGDX music state and screen refresh stay in sync.
-        function handleClick() {
+        img.addEventListener('click', function() {
             @com.mygdx.game.MyGdxGame::handleMusicButtonClick()();
-        }
-        img.addEventListener('click',    handleClick);
-        canvas.addEventListener('click', handleClick);
+        });
     }-*/;
 
     /** Called from the onMusicUiUpdate Runnable to keep the GIF in sync with Java state. */

--- a/html/src/com/mygdx/game/client/HtmlLauncher.java
+++ b/html/src/com/mygdx/game/client/HtmlLauncher.java
@@ -25,6 +25,17 @@ public class HtmlLauncher extends GwtApplication {
         MyGdxGame.turnNotifier = new BrowserTurnNotifier();
         MyGdxGame.playerStorage = new BrowserPlayerStorage();
         MyGdxGame app = new MyGdxGame();
+        // Tell the core that the HTML layer owns the music button visual.
+        MyGdxGame.nativeMusicButton = true;
+        // Inject the animated GIF music button into the DOM and wire up callbacks.
+        installMusicButton(app);
+        // Register the UI-update callback so setMusicEnabled() keeps the GIF in sync.
+        MyGdxGame.onMusicUiUpdate = new Runnable() {
+            @Override
+            public void run() {
+                refreshMusicButton(MyGdxGame.playerStorage.getMusicEnabled());
+            }
+        };
         installAudioUnlocker(app);
         return app;
     }
@@ -68,5 +79,76 @@ public class HtmlLauncher extends GwtApplication {
             return $wnd.location.protocol + '//' + hostname + ':8082';
         }
         return $wnd.location.protocol + '//' + $wnd.location.host;
+    }-*/;
+
+    /**
+     * Injects a fixed-position animated GIF music toggle button into the DOM.
+     *
+     * Two sibling elements are created:
+     *   #baisch-music-img    — the animated GIF (shown when music is ON)
+     *   #baisch-music-canvas — a canvas showing the GIF's first frame (shown when OFF)
+     *
+     * The first frame is captured once the image loads.  Subsequent toggles swap
+     * visibility between the two elements via window._baischSetMusicBtn(bool).
+     *
+     * Clicks call MyGdxGame.handleMusicButtonClick() via JSNI so that the LibGDX
+     * music state and the current menu screen re-render stay in sync.
+     */
+    private static native void installMusicButton(MyGdxGame app) /*-{
+        var SIZE = '54px';
+        var img = $doc.createElement('img');
+        img.id  = 'baisch-music-img';
+        img.src = 'music.gif';
+        img.style.cssText =
+            'position:fixed;top:6px;right:6px;width:' + SIZE + ';height:' + SIZE + ';' +
+            'cursor:pointer;z-index:9999;border-radius:50%;display:block;';
+
+        var canvas = $doc.createElement('canvas');
+        canvas.id  = 'baisch-music-canvas';
+        canvas.style.cssText =
+            'position:fixed;top:6px;right:6px;width:' + SIZE + ';height:' + SIZE + ';' +
+            'cursor:pointer;z-index:9999;border-radius:50%;display:none;';
+
+        $doc.body.appendChild(img);
+        $doc.body.appendChild(canvas);
+
+        var firstFrameCaptured = false;
+        function captureFirstFrame() {
+            if (firstFrameCaptured) return;
+            firstFrameCaptured = true;
+            canvas.width  = img.naturalWidth  || 100;
+            canvas.height = img.naturalHeight || 100;
+            canvas.getContext('2d').drawImage(img, 0, 0);
+        }
+        if (img.complete) { captureFirstFrame(); }
+        else { img.addEventListener('load', captureFirstFrame); }
+
+        // Public setter used by the Java onMusicUiUpdate callback.
+        $wnd._baischSetMusicBtn = function(on) {
+            if (!on) {
+                captureFirstFrame();        // ensure first frame is ready
+                img.style.display    = 'none';
+                canvas.style.display = 'block';
+            } else {
+                img.style.display    = 'block';
+                canvas.style.display = 'none';
+            }
+        };
+
+        // Initialise visual state from localStorage.
+        var enabled = ($wnd.localStorage.getItem('baisch_music_enabled') !== '0');
+        $wnd._baischSetMusicBtn(enabled);
+
+        // Click: delegate to Java so LibGDX music state and screen refresh stay in sync.
+        function handleClick() {
+            @com.mygdx.game.MyGdxGame::handleMusicButtonClick()();
+        }
+        img.addEventListener('click',    handleClick);
+        canvas.addEventListener('click', handleClick);
+    }-*/;
+
+    /** Called from the onMusicUiUpdate Runnable to keep the GIF in sync with Java state. */
+    private static native void refreshMusicButton(boolean enabled) /*-{
+        if ($wnd._baischSetMusicBtn) $wnd._baischSetMusicBtn(enabled);
     }-*/;
 }


### PR DESCRIPTION
Closes #208

## What changed

- `html/war/music.gif` — the animated GIF asset (800×800, ~194 KB)
- `HtmlLauncher.java` — injects a fixed-position `<img>` + `<canvas>` pair into the DOM; click delegate calls `MyGdxGame.handleMusicButtonClick()` via JSNI; visual state is initialised from localStorage on page load
- `MyGdxGame.java` — adds `nativeMusicButton` flag, `onMusicUiUpdate` Runnable hook (fired by `setMusicEnabled`), `INSTANCE` ref, and `handleMusicButtonClick()` static entry point
- `MenuScreen.java` — `addMusicToggleButton` early-returns when `nativeMusicButton` is true (HTML layer owns the button)

## Behaviour

| Music state | Visual |
|---|---|
| ON  | Animated GIF plays |
| OFF | GIF frozen on first frame (canvas snapshot) |

The `<canvas>` captures the GIF's first frame the moment the image loads (before animation advances) for a reliable "still" display.

## Notes
- The in-game hamburger-menu "Music ON/OFF" TextButton is kept as-is (it's inside an overlay, not on the main screen).
- Changing music state via the in-game menu also updates the GIF via `onMusicUiUpdate`.