### PR TITLE
refactor: rename Plunder → Loot everywhere

### DIFF
--- a/.github/instructions/game-rules.instructions.md
+++ b/.github/instructions/game-rules.instructions.md
@@ -20,7 +20,7 @@ Each turn a player may perform any combination of the following actions in any o
 1. **Mobilise** (take/put defence cards) — 1 take and 1 put per turn by default (3 combined with Marshal)
 2. **Attack** enemy defence cards (with hand cards, own defence cards via Banneret, Reservists boost, or own king)
 3. **King assault** on an exposed enemy king card
-4. **Plunder** a picking deck
+4. **Loot** a picking deck
 5. **Use hero abilities** (Spy, Merchant, Priest, Warlord, etc.)
 
 The turn ends when the player clicks **Finish Turn**.
@@ -39,14 +39,14 @@ The turn ends when the player clicks **Finish Turn**.
 | Attacking an enemy defence card (Banneret own-def-cards) | ✅ Yes |
 | Attacking an enemy king card (king assault) | ✅ Yes |
 | Warlord direct attack | ✅ Yes |
-| **Plundering a picking deck** | ❌ **No** |
+| **Looting a picking deck** | ❌ **No** |
 | Taking or placing a defence card (mobilise) | ❌ No |
 | Using a hero ability (Spy, Merchant, Priest, etc.) | ❌ No |
 | Warlord king swap | ❌ No |
 
 ### Implementation details:
 - Server: `attackCount` per player is incremented only in `defAttackResolved`, `kingAttackResolved`, and `warlordDirectAttack`.
-- `plunderResolved` must **not** increment `attackCount`.
+- `lootResolved` must **not** increment `attackCount`.
 - Client: `playerTurn.attackCounter == 0` triggers the expose prompt in `FinishTurnButtonListener`.
 - Client: `increaseAttackCounter()` **must** be called locally for **every** attack type (including regular defence-card attacks and king assaults) when the attack overlay is confirmed — before `setUpdateState(true)` fires the re-render. This prevents a race-condition where the user clicks "Finish Turn" before the server's `stateUpdate` arrives with the updated `attackCount`, which would falsely trigger the expose-card penalty.
 - The sole exception is Warlord direct attacks: `increaseAttackCounter()` is called at commit time (in `EnemyDefCardListener`) rather than at overlay-confirm time — the pattern is therefore `if (!apt.isPendingAttackIsWarlord()) apt.increaseAttackCounter();` in the overlay click handler.
@@ -70,7 +70,7 @@ The turn ends when the player clicks **Finish Turn**.
 - `finishTurn()` on the server clears `preyCards = []` so captured cards become normal hand cards next turn.
 - **Client implementation**: When a successful defence-card attack is confirmed in the overlay click handler, the captured card IDs **must** be added to `atkPlayer.getPlayerTurn().getPreyCardIds()` locally — before `setUpdateState(true)` triggers the re-render. If this is omitted, the first re-render fires before the server's `stateUpdate` arrives with `preyCards`, so the card briefly appears as usable (race-condition bug). The server's `stateUpdate` will confirm the prey list on arrival.
 - **Client implementation**: `applyStateUpdate` **must** take the UNION of server `preyCards` and local `preyCardIds` while it is still this player's turn. A stale `stateUpdate` from `setAttackPreview` may arrive after the local optimistic update and would otherwise clobber the locally-known captures. After the turn ends, server is authoritative.
-- Cards gained from a **plunder** are NOT prey cards — they become immediately usable (by design).
+- Cards gained from a **loot** are NOT prey cards — they become immediately usable (by design).
 
 ### King Assault
 - The defender's king must be **exposed** (face-up) for a king assault to be possible.
@@ -79,11 +79,11 @@ The turn ends when the player clicks **Finish Turn**.
 - On **success**: the defender is eliminated; the attacker gains all of the defender's cards.
 - On **failure**: the defending king is exposed (flipped face-up) as a result of the attack. If the attacker used their king, the attacker is also eliminated.
 
-### Plunder
+### Loot
 - The attacker selects hand cards of the same suit whose combined strength exceeds the **top card** of the target picking deck.
 - On **success**: the attacker gains all cards in that picking deck; the deck is rebuilt.
 - On **failure** (attacker used their king): the attacker is eliminated. Otherwise no penalty for failure.
-- **Plundering does not count as an attack** for the expose-defence-card penalty check.
+- **Looting does not count as an attack** for the expose-defence-card penalty check.
 
 ---
 
@@ -124,7 +124,7 @@ The turn ends when the player clicks **Finish Turn**.
 
 ### Reservists
 - Up to 4 figures (starts with 2 ready). Each figure passively adds +1 to the owner's king card defence strength.
-- During an attack/plunder, the owner may spend figures to add +1 per figure to the **attack** strength.
+- During an attack/loot, the owner may spend figures to add +1 per figure to the **attack** strength.
 - Recovers 2 figures per turn.
 
 ### Banneret
@@ -166,7 +166,7 @@ The turn ends when the player clicks **Finish Turn**.
 
 A player is eliminated when:
 1. Their king card is successfully attacked in a **king assault**, OR
-2. They used their king card in an **attack that failed** (defence/plunder/assault), OR
+2. They used their king card in an **attack that failed** (defence/loot/assault), OR
 3. Their king card was targeted by a Warlord direct attack that succeeded.
 
 An eliminated player's hand cards, king card, and heroes go to the attacker. If the defender had multiple heroes, the attacker chooses one; the rest are lost.
@@ -181,7 +181,7 @@ The game ends when only **one player** remains. That player is the winner.
 
 ## Notes for Coding Agents
 
-- Never treat a plunder as an attack for the expose-defence-card penalty.
+- Never treat a loot as an attack for the expose-defence-card penalty.
 - `attackCount` on the server and `attackCounter` on the client track **real attacks** only (defence/king attacks and Warlord direct attacks).
 - The Banneret dual-symbol rule applies from the **first** attack of the turn; it does not require a prior symbol to have been locked.
 - Warlord direct attack and Warlord king swap use **separate** server-side counters (`warlordAttacks` and `warlordSwaps`).

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -40,7 +40,7 @@ This glossary defines the key terms used throughout the Baisch codebase, issues,
 |---|---|
 | **Card Deck** | The main draw pile. Cards are drawn from here during setup and gameplay. When empty it is automatically reshuffled from the Cemetery. |
 | **Cemetery Deck (Cemetery)** | The discard pile. Cards that are spent in attacks, discarded by heroes, or used in sacrifices go here. |
-| **Picking Deck** | One of two face-up/face-down stacks placed in the middle of the table. Players can *plunder* a picking deck to gain all its cards. There are always two picking decks (index 0 and 1). |
+| **Picking Deck** | One of two face-up/face-down stacks placed in the middle of the table. Players can *loot* a picking deck to gain all its cards. There are always two picking decks (index 0 and 1). |
 
 ---
 
@@ -57,7 +57,7 @@ This glossary defines the key terms used throughout the Baisch codebase, issues,
 | **Attack (Defence Card Attack)** | Selecting hand cards (and optionally own defence cards via Banneret) whose combined strength exceeds an enemy's defence card strength. On success the attacker gains the card(s); on failure the attacked card remains face-up. |
 | **King Attack (Royal Attack)** | Using the player's king card to attack an enemy defence card. The king's strength is compared directly against the defence card. Result: win (2), draw (1), or loss (0). |
 | **King Assault** | Using hand cards (or the king card) to attack an enemy's *king card* directly. Success eliminates the defender; failure with king used eliminates the attacker. |
-| **Plunder** | Attacking a picking deck. If the attack sum beats the top card's strength the attacker gains all cards in that picking deck; otherwise the deck grows by one new card. |
+| **Loot** | Attacking a picking deck. If the attack sum beats the top card's strength the attacker gains all cards in that picking deck; otherwise the deck grows by one new card. |
 | **Joker Sacrifice** | Discarding a joker card to draw one card from the top of the deck, which determines the type of hero awarded. |
 | **Coup (King Swap)** | Replacing the player's current king card with a hand card (without using the Warlord hero). The old king goes to hand and can immediately be used for an attack. |
 | **Hero Selection** | When a joker sacrifice results in an ace (or joker determines a free choice), the player selects their hero from a list of available options. |
@@ -70,8 +70,8 @@ This glossary defines the key terms used throughout the Baisch codebase, issues,
 |---|---|
 | **Game Lobby** | The waiting room where players join, set their name, mark themselves as ready, and optionally pre-select a starting hero before the game begins. |
 | **Game Screen** | The main in-game view showing both players' fields, hand cards, picking decks, heroes, dice, and action buttons. |
-| **Overlay** | A temporary UI layer shown during attacks or special hero actions (e.g. attack confirmation, plunder confirmation, Priest card selection, hero choice). |
-| **Activity Log** | A small scrollable area in the game screen that shows the last 5 game events (attacks, plunders, mobilisations, etc.) with colour-coded success/failure indicators. |
+| **Overlay** | A temporary UI layer shown during attacks or special hero actions (e.g. attack confirmation, loot confirmation, Priest card selection, hero choice). |
+| **Activity Log** | A small scrollable area in the game screen that shows the last 5 game events (attacks, loots, mobilisations, etc.) with colour-coded success/failure indicators. |
 | **Hand Area** | The bottom portion of the game screen displaying the current player's hand cards. |
 | **Field / Board** | The area showing a player's defence slots, king card, and heroes. |
 | **Defence Slot** | One of three positions (1, 2, 3) on a player's field where a defence card can be placed. |
@@ -91,7 +91,7 @@ Heroes are acquired by sacrificing a joker card. The drawn card (or player choic
 | **Battery Tower** | 5 | White | 1 charge per turn. When the owner's defence card or king is attacked, the owner can spend 1 charge to deny the attack: attacker's used hand cards are locked for the rest of their turn. |
 | **Merchant** | 6 | White | 1 trade per turn: discard a hand card (or defence card) and draw a replacement from the deck. On the last trade the drawn card is revealed to all players. |
 | **Priest** | 7 | White | 2 conversion attempts per turn. After committing an attack with the same suit, convert one of the target player's matching hand cards to your own hand. |
-| **Reservists** | 8 | Black | Up to 4 reservist figures (starts 2 ready). Each figure passively adds +1 to king card defence strength. During an attack/plunder overlay, spend figures to add +1 to attack. Recovers 2 per turn. |
+| **Reservists** | 8 | Black | Up to 4 reservist figures (starts 2 ready). Each figure passively adds +1 to king card defence strength. During an attack/loot overlay, spend figures to add +1 to attack. Recovers 2 per turn. |
 | **Banneret** | 9 | Black | Allows two attacking suits of the same colour (hearts + diamonds, or spades + clubs) in a single attack. Also allows own face-down defence cards to be used as additional attack cards. |
 | **Saboteurs** | 10 | Black | 2 saboteur figures. Deploy one onto an enemy defence slot to block that slot (cannot be taken or placed into). The defender can sacrifice the slot's card (or a hand card for an empty slot) to remove the saboteur. Saboteurs recover over 2 turns after being destroyed. |
 | **Fortified Tower** | J | Black | 1 fortify action per turn: stack an additional hand card face-down on top of an existing defence card (a *top defence card*). The combined strength of both cards must be beaten by an attacker. |
@@ -129,4 +129,4 @@ Heroes are acquired by sacrificing a joker card. The drawn card (or player choic
 | **Relict** | A legacy placeholder class for special game objects (currently not actively used in gameplay). |
 | **`isOut`** | Internal flag on a player marking them as eliminated. Eliminated players are skipped in turn order. |
 | **`preyCards`** | Cards captured by the current player during their turn. They are locked until the turn ends, after which they become usable hand cards. |
-| **`pendingAttack` / `pendingPlunder`** | Server-side state stored while waiting for the client to confirm an attack or plunder result. Cleared once the action is resolved. |
+| **`pendingAttack` / `pendingLoot`** | Server-side state stored while waiting for the client to confirm an attack or loot result. Cleared once the action is resolved. |

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -138,8 +138,8 @@ public class GameScreen extends ScreenAdapter {
   private JSONObject pendingBatteryDefCheck = null;
   // Attack preview broadcast: set from stateUpdate when another player has a pending attack
   private JSONObject pendingAttackBroadcast = null;
-  // Plunder preview broadcast: set from stateUpdate when another player has a pending plunder
-  private JSONObject pendingPlunderBroadcast = null;
+  // Loot preview broadcast: set from stateUpdate when another player has a pending loot
+  private JSONObject pendingLootBroadcast = null;
   // Pending hero selection after a successful king defeat (attacker must choose one hero)
   private java.util.ArrayList<String> pendingKingDefeatHeroOptions = null;
   // Hero auction: server-authoritative state (non-null when auction is in progress)
@@ -1625,11 +1625,11 @@ public class GameScreen extends ScreenAdapter {
       gameStage.addActor(lbl);
     }
 
-    // Plunder preview overlay — added LAST so it renders on top of everything
-    if (currentPlayer.getPlayerTurn().isPlunderPending()) {
-      final Player plunderPlayer = currentPlayer;
-      final PlayerTurn pt = plunderPlayer.getPlayerTurn();
-      final boolean plunderSuccess = pt.isPlunderSuccess();
+    // Loot preview overlay — added LAST so it renders on top of everything
+    if (currentPlayer.getPlayerTurn().isLootPending()) {
+      final Player lootPlayer = currentPlayer;
+      final PlayerTurn pt = lootPlayer.getPlayerTurn();
+      final boolean lootSuccess = pt.isLootSuccess();
 
       // Semi-transparent black tint over the whole board; catches any tap to confirm
       Image overlay = new Image(MyGdxGame.skin, "white");
@@ -1641,34 +1641,34 @@ public class GameScreen extends ScreenAdapter {
           final int deckIdx = pt.getPendingPickingDeckIndex();
           PickingDeck thisD = gameState.getPickingDecks().get(deckIdx);
           PickingDeck otherD = gameState.getPickingDecks().get(1 - deckIdx);
-          if (plunderSuccess) {
+          if (lootSuccess) {
             Iterator<Card> it = thisD.getCards().iterator();
-            while (it.hasNext()) { plunderPlayer.addHandCard(it.next()); it.remove(); }
+            while (it.hasNext()) { lootPlayer.addHandCard(it.next()); it.remove(); }
             otherD.addCard(gameState.getCardDeck().getCard(gameState.getCemeteryDeck()));
             thisD.addCard(gameState.getCardDeck().getCard(gameState.getCemeteryDeck()));
             thisD.getCards().get(thisD.getCards().size() - 1).setCovered(false);
             thisD.addCard(gameState.getCardDeck().getCard(gameState.getCemeteryDeck()));
-            if (pt.isKingUsed()) plunderPlayer.getKingCard().setCovered(false);
+            if (pt.isKingUsed()) lootPlayer.getKingCard().setCovered(false);
           } else {
             Card newPickCard = gameState.getCardDeck().getCard(gameState.getCemeteryDeck());
             newPickCard.setCovered(true);
             thisD.addCard(newPickCard);
             if (pt.isKingUsed()) {
-              plunderPlayer.getKingCard().setCovered(false);
-              plunderPlayer.setOut(true);
+              lootPlayer.getKingCard().setCovered(false);
+              lootPlayer.setOut(true);
             }
           }
           for (Card c : pt.getPendingAttackCards()) {
-            plunderPlayer.getHandCards().remove(c);
+            lootPlayer.getHandCards().remove(c);
             gameState.getCemeteryDeck().addCard(c);
           }
           for (Card c : pt.getPendingAttackOwnDefCards()) {
             int slot = c.getPositionId();
-            plunderPlayer.getDefCards().remove(slot);
-            plunderPlayer.getTopDefCards().remove(slot);
+            lootPlayer.getDefCards().remove(slot);
+            lootPlayer.getTopDefCards().remove(slot);
             gameState.getCemeteryDeck().addCard(c);
           }
-          pt.setPlunderPending(false);
+          pt.setLootPending(false);
           if (pt.isKingUsed()) pt.setKingUsedThisTurn(true);
           // Coup swap: if the old king (now a hand card) was used in this attack, mark king as spent
           int coupId = pt.getCoupSwapPendingCardId();
@@ -1686,7 +1686,7 @@ public class GameScreen extends ScreenAdapter {
             JSONObject emitData = new JSONObject();
             emitData.put("attackerIdx", gameState.getCurrentPlayerIndex());
             emitData.put("deckIndex", deckIdx);
-            emitData.put("success", plunderSuccess);
+            emitData.put("success", lootSuccess);
             emitData.put("kingUsed", pt.isKingUsed());
             JSONArray atkIdArr = new JSONArray();
             for (Card c : pt.getPendingAttackCards()) atkIdArr.put(c.getCardId());
@@ -1694,12 +1694,12 @@ public class GameScreen extends ScreenAdapter {
             JSONArray ownDefIdArr = new JSONArray();
             for (Card c : pt.getPendingAttackOwnDefCards()) ownDefIdArr.put(c.getCardId());
             emitData.put("attackerOwnDefCardIds", ownDefIdArr);
-            socket.emit("plunderResolved", emitData);
+            socket.emit("lootResolved", emitData);
           } catch (JSONException e) {
             e.printStackTrace();
           }
-          tutorialAdvance(TUTORIAL_STEP_PLUNDER);
-          tutorialAdvanceHook("PLUNDER");
+          tutorialAdvance(TUTORIAL_STEP_LOOT);
+          tutorialAdvanceHook("LOOT");
           pt.getPendingAttackCards().clear();
           pt.getPendingAttackOwnDefCards().clear();
           pt.resetReservistAttackBonus();
@@ -1717,16 +1717,16 @@ public class GameScreen extends ScreenAdapter {
       float plLeftX = 10f;
       float plRightX = MyGdxGame.WIDTH / 2f + 10f;
 
-      int plAtkSum = pt.getPendingPlunderAttackSum() + pt.getReservistAttackBonus();
-      int plDefStr = pt.getPendingPlunderDefStrength();
+      int plAtkSum = pt.getPendingLootAttackSum() + pt.getReservistAttackBonus();
+      int plDefStr = pt.getPendingLootDefStrength();
 
-      Label plunderResultLabel = new Label(
-          plunderSuccess ? "SUCCESS!  Tap to claim the cards."
-                        : "FAILED.  Tap to continue.",
+      Label lootResultLabel = new Label(
+          lootSuccess ? "SUCCESS!  Tap to claim the cards."
+                      : "FAILED.  Tap to continue.",
           MyGdxGame.skin);
-      plunderResultLabel.setColor(plunderSuccess ? Color.GREEN : Color.RED);
-      plunderResultLabel.setPosition(
-          MyGdxGame.WIDTH / 2f - plunderResultLabel.getPrefWidth() / 2f,
+      lootResultLabel.setColor(lootSuccess ? Color.GREEN : Color.RED);
+      lootResultLabel.setPosition(
+          MyGdxGame.WIDTH / 2f - lootResultLabel.getPrefWidth() / 2f,
           plBotY - 44f);
 
       gameStage.addActor(overlay);
@@ -1736,14 +1736,14 @@ public class GameScreen extends ScreenAdapter {
       plAtkHdr.setColor(Color.CYAN);
       plAtkHdr.setPosition(plLeftX, plBotY + plCH + 5f);
       gameStage.addActor(plAtkHdr);
-      Label plDefHdr = new Label("PLUNDER", MyGdxGame.skin);
+      Label plDefHdr = new Label("LOOT", MyGdxGame.skin);
       plDefHdr.setColor(Color.ORANGE);
       plDefHdr.setPosition(plRightX, plBotY + plCH + 5f);
       gameStage.addActor(plDefHdr);
 
       // Attack cards (left column)
-      if (pt.isKingUsed() && plunderPlayer.getKingCard() != null) {
-        Card kd = Card.fromCardId(plunderPlayer.getKingCard().getCardId());
+      if (pt.isKingUsed() && lootPlayer.getKingCard() != null) {
+        Card kd = Card.fromCardId(lootPlayer.getKingCard().getCardId());
         kd.setCovered(false); kd.setActive(true);
         kd.setSize(plCW, plCH);
         kd.setPosition(plLeftX, plBotY);
@@ -1784,16 +1784,16 @@ public class GameScreen extends ScreenAdapter {
       plDefSumLbl.setPosition(plRightX, plBotY - 22f);
       gameStage.addActor(plDefSumLbl);
 
-      gameStage.addActor(plunderResultLabel);
+      gameStage.addActor(lootResultLabel);
 
-      // Reservists plunder boost button — only when currently failing but can be won
-      for (Hero resH : plunderPlayer.getHeroes()) {
+      // Reservists loot boost button — only when currently failing but can be won
+      for (Hero resH : lootPlayer.getHeroes()) {
         if ("Reservists".equals(resH.getHeroName())) {
           final Reservists resHero = (Reservists) resH;
-          boolean canFlipPlunder = !pt.isPlunderSuccess() && resHero.isAvailable()
-              && (pt.getPendingPlunderAttackSum() + pt.getReservistAttackBonus() + resHero.countReady())
-                  > pt.getPendingPlunderDefStrength();
-          if (canFlipPlunder) {
+          boolean canFlipLoot = !pt.isLootSuccess() && resHero.isAvailable()
+              && (pt.getPendingLootAttackSum() + pt.getReservistAttackBonus() + resHero.countReady())
+                  > pt.getPendingLootDefStrength();
+          if (canFlipLoot) {
             TextButton resBtn = new TextButton("Reservists +1  (" + resHero.countReady() + " left)", MyGdxGame.skin);
             resBtn.pack();
             resBtn.setPosition(MyGdxGame.WIDTH / 2f - resBtn.getWidth() / 2f, MyGdxGame.WIDTH * 0.42f);
@@ -1803,10 +1803,10 @@ public class GameScreen extends ScreenAdapter {
                 resHero.spend();
                 emitReservistsKingBoost(resHero.countReady());
                 pt.incrementReservistAttackBonus();
-                boolean newPlunderSuccess =
-                    pt.getPendingPlunderAttackSum() + pt.getReservistAttackBonus() > pt.getPendingPlunderDefStrength();
-                pt.setPlunderSuccess(newPlunderSuccess);
-                // Re-emit plunderPreview so watchers see the updated sum and outcome
+                boolean newLootSuccess =
+                    pt.getPendingLootAttackSum() + pt.getReservistAttackBonus() > pt.getPendingLootDefStrength();
+                pt.setLootSuccess(newLootSuccess);
+                // Re-emit lootPreview so watchers see the updated sum and outcome
                 if (socket != null) {
                   try {
                     JSONObject plPreview = new JSONObject();
@@ -1814,11 +1814,11 @@ public class GameScreen extends ScreenAdapter {
                     plPreview.put("deckIndex", plDeckIdx);
                     ArrayList<Card> plDeckCurr = gameState.getPickingDecks().get(plDeckIdx).getCards();
                     plPreview.put("defCardId", plDeckCurr.isEmpty() ? -1 : plDeckCurr.get(plDeckCurr.size() - 1).getCardId());
-                    plPreview.put("attackSum", pt.getPendingPlunderAttackSum() + pt.getReservistAttackBonus());
-                    plPreview.put("defStrength", pt.getPendingPlunderDefStrength());
-                    plPreview.put("success", newPlunderSuccess);
+                    plPreview.put("attackSum", pt.getPendingLootAttackSum() + pt.getReservistAttackBonus());
+                    plPreview.put("defStrength", pt.getPendingLootDefStrength());
+                    plPreview.put("success", newLootSuccess);
                     plPreview.put("kingUsed", pt.isKingUsed());
-                    plPreview.put("kingCardId", pt.isKingUsed() && plunderPlayer.getKingCard() != null ? plunderPlayer.getKingCard().getCardId() : -1);
+                    plPreview.put("kingCardId", pt.isKingUsed() && lootPlayer.getKingCard() != null ? lootPlayer.getKingCard().getCardId() : -1);
                     plPreview.put("mercenaryBonus", pt.getPendingAttackMercenaryBonus());
                     plPreview.put("reservistBonus", pt.getReservistAttackBonus());
                     JSONArray plResAtkIds = new JSONArray();
@@ -1827,7 +1827,7 @@ public class GameScreen extends ScreenAdapter {
                     JSONArray plResOwnIds = new JSONArray();
                     for (Card c : pt.getPendingAttackOwnDefCards()) plResOwnIds.put(c.getCardId());
                     plPreview.put("ownDefCardIds", plResOwnIds);
-                    socket.emit("plunderPreview", plPreview);
+                    socket.emit("lootPreview", plPreview);
                   } catch (JSONException ex) { ex.printStackTrace(); }
                 }
                 gameState.setUpdateState(true);
@@ -1840,19 +1840,19 @@ public class GameScreen extends ScreenAdapter {
       }
     }
 
-    // Plunder watcher overlay — shown to non-plundering players when another player is plundering
-    if (pendingPlunderBroadcast != null && !currentPlayer.getPlayerTurn().isPlunderPending()) {
+    // Loot watcher overlay — shown to non-looting players when another player is looting
+    if (pendingLootBroadcast != null && !currentPlayer.getPlayerTurn().isLootPending()) {
       try {
-        final int plBcAtkIdx = pendingPlunderBroadcast.getInt("attackerIdx");
-        final boolean plBcSuccess = pendingPlunderBroadcast.getBoolean("success");
-        final boolean plBcKingUsed = pendingPlunderBroadcast.optBoolean("kingUsed", false);
-        final int plBcKingCardId = pendingPlunderBroadcast.optInt("kingCardId", -1);
-        final int plBcDefCardId = pendingPlunderBroadcast.optInt("defCardId", -1);
-        final int plBcAtkSum = pendingPlunderBroadcast.optInt("attackSum", 0)
-            + pendingPlunderBroadcast.optInt("reservistBonus", 0);
-        final int plBcDefStr = pendingPlunderBroadcast.optInt("defStrength", 0);
-        final JSONArray plBcAtkIds = pendingPlunderBroadcast.optJSONArray("attackCardIds");
-        final JSONArray plBcOwnDefIds = pendingPlunderBroadcast.optJSONArray("ownDefCardIds");
+        final int plBcAtkIdx = pendingLootBroadcast.getInt("attackerIdx");
+        final boolean plBcSuccess = pendingLootBroadcast.getBoolean("success");
+        final boolean plBcKingUsed = pendingLootBroadcast.optBoolean("kingUsed", false);
+        final int plBcKingCardId = pendingLootBroadcast.optInt("kingCardId", -1);
+        final int plBcDefCardId = pendingLootBroadcast.optInt("defCardId", -1);
+        final int plBcAtkSum = pendingLootBroadcast.optInt("attackSum", 0)
+            + pendingLootBroadcast.optInt("reservistBonus", 0);
+        final int plBcDefStr = pendingLootBroadcast.optInt("defStrength", 0);
+        final JSONArray plBcAtkIds = pendingLootBroadcast.optJSONArray("attackCardIds");
+        final JSONArray plBcOwnDefIds = pendingLootBroadcast.optJSONArray("ownDefCardIds");
 
         Image wPlOverlay = new Image(MyGdxGame.skin, "white");
         wPlOverlay.setFillParent(true);
@@ -1869,7 +1869,7 @@ public class GameScreen extends ScreenAdapter {
         float wPlRightX = MyGdxGame.WIDTH / 2f + 10f;
 
         // Column headers
-        Label wPlAtkHdr = new Label(plAtkName + " plunders:", MyGdxGame.skin);
+        Label wPlAtkHdr = new Label(plAtkName + " loots:", MyGdxGame.skin);
         wPlAtkHdr.setColor(Color.CYAN);
         wPlAtkHdr.setPosition(wPlLeftX, wPlBotY + wPlCH + 22f);
         gameStage.addActor(wPlAtkHdr);
@@ -1916,7 +1916,7 @@ public class GameScreen extends ScreenAdapter {
         wPlDefSumLbl.setPosition(wPlRightX, wPlBotY - 22f);
         gameStage.addActor(wPlDefSumLbl);
 
-        Label wPlResultLbl = new Label(plBcSuccess ? plAtkName + " plunders!" : plAtkName + " fails!", MyGdxGame.skin);
+        Label wPlResultLbl = new Label(plBcSuccess ? plAtkName + " loots!" : plAtkName + " fails!", MyGdxGame.skin);
         wPlResultLbl.setColor(plBcSuccess ? Color.GREEN : Color.RED);
         wPlResultLbl.setPosition(MyGdxGame.WIDTH / 2f - wPlResultLbl.getPrefWidth() / 2f, wPlBotY - 44f);
         gameStage.addActor(wPlResultLbl);
@@ -2041,7 +2041,7 @@ public class GameScreen extends ScreenAdapter {
           apt.setAttackTargetIsKing(false);
           // Mark king as spent only for normal king attacks. Warlord direct attacks
           // are an additional action granted by the hero and must NOT consume the
-          // regular once-per-turn king attack/plunder.
+          // regular once-per-turn king attack/loot.
           if (apt.isKingUsed() && !apt.isPendingAttackIsWarlord()) apt.setKingUsedThisTurn(true);
           // Count this attack locally (same pattern as Warlord) so the expose-card penalty
           // check in FinishTurnButtonListener never falsely fires before the server stateUpdate arrives.
@@ -3048,12 +3048,12 @@ public class GameScreen extends ScreenAdapter {
       } catch (JSONException e) { e.printStackTrace(); }
     }
 
-    // Sword overlay on both harvest decks when plunder is available — added late so it sits above all cards.
+    // Sword overlay on both harvest decks when loot is available — added late so it sits above all cards.
     // Crone overlay on own king card when king attack is possible.
     if (gameState.getCurrentPlayer() == currentPlayer) {
       PlayerTurn ptGame = currentPlayer.getPlayerTurn();
 
-      if (ptGame.getPickingDeckAttacks() > 0 && !ptGame.isPlunderPending()) {
+      if (ptGame.getPickingDeckAttacks() > 0 && !ptGame.isLootPending()) {
         ArrayList<PickingDeck> swordDecks = gameState.getPickingDecks();
         for (int si = 0; si < swordDecks.size(); si++) {
           ArrayList<Card> sCards = swordDecks.get(si).getCards();
@@ -4279,8 +4279,8 @@ public class GameScreen extends ScreenAdapter {
   //   1  – ACTION: take a defense card to hand    (auto-advances after takeDefCard)
   //   2  – ACTION: select a hand card             (auto-advances in render() poll)
   //   3  – Blocking info: attack symbols
-  //   4  – ACTION: plunder a harvest deck         (auto-advances after plunderResolved)
-  //   5  – Blocking info: plunder mechanics
+  //   4  – ACTION: loot a harvest deck         (auto-advances after lootResolved)
+  //   5  – Blocking info: loot mechanics
   //   6  – Blocking info: joker card
   //   7  – ACTION: place a defense card           (auto-advances in render() poll)
   //   8  – ACTION: end your turn                  (auto-advances after finishTurn)
@@ -4296,8 +4296,8 @@ public class GameScreen extends ScreenAdapter {
   private static final int TUTORIAL_STEP_TAKE_DEF_FIRST  = 1;
   private static final int TUTORIAL_STEP_SELECT          = 2;
   private static final int TUTORIAL_STEP_INFO_SYMBOLS    = 3;
-  private static final int TUTORIAL_STEP_PLUNDER         = 4;
-  private static final int TUTORIAL_STEP_INFO_PLUNDER    = 5;
+  private static final int TUTORIAL_STEP_LOOT           = 4;
+  private static final int TUTORIAL_STEP_INFO_LOOT      = 5;
   private static final int TUTORIAL_STEP_INFO_JOKER      = 6;
   private static final int TUTORIAL_STEP_DEFENSE         = 7;
   private static final int TUTORIAL_STEP_ENDTURN         = 8;
@@ -4412,18 +4412,18 @@ public class GameScreen extends ScreenAdapter {
       + "Cards with DIFFERENT symbols cannot be combined. "
       + "Select a card first: all other hand cards of the same symbol will be combinable.\n\n"
       + "Your active symbol is locked-in on your first attack of the turn "
-      + "and stays set until you click 'End Turn' — even after a plunder resolves. "
+      + "and stays set until you click 'End Turn' — even after a loot resolves. "
       + "This means you can attack again with the same symbol before ending your turn.",
       null
     ),
-    /* 4  PLUNDER */
+    /* 4  LOOT */
     new TutorialStepDef(
-      "Plunder a harvest deck",
-      "With a card selected, tap one of the tilted card stacks in the center to plunder it."
+      "Loot a harvest deck",
+      "With a card selected, tap one of the tilted card stacks in the center to loot it."
     ),
-    /* 5  INFO_PLUNDER */
+    /* 5  INFO_LOOT */
     new TutorialStepDef(
-      "How Plundering Works",
+      "How Looting Works",
       "When you attack a harvest deck, your total attack value is compared to the hidden top card of that deck.\n\n"
       + "\u2022 If your value is HIGHER (or equal): you win and take cards from the deck.\n"
       + "\u2022 If your value is LOWER: the attack fails — your card(s) go to the discard pile and you gain nothing.\n\n"
@@ -4467,7 +4467,7 @@ public class GameScreen extends ScreenAdapter {
       + "face-down defense cards before ending your turn.\n\n"
       + "Tap 'Finish turn' — the game will ask you to choose which defense slot to expose. "
       + "The card stays in the slot but becomes visible to all players.\n\n"
-      + "If you DO attack (plunder or player attack), no card needs to be exposed.",
+      + "If you DO attack (loot or player attack), no card needs to be exposed.",
       null
     ),
     /* 11 INFO_KING */
@@ -4503,7 +4503,7 @@ public class GameScreen extends ScreenAdapter {
     new TutorialStepDef(
       "Tutorial Complete!",
       "Well done! You've completed the interactive tutorial.\n\n"
-      + "You now know how to select and combine cards, plunder decks, "
+      + "You now know how to select and combine cards, loot decks, "
       + "place defenses, expose cards, use your king, "
       + "end your turn, and attack enemies.\n\n"
       + "Feel free to keep playing or return to the menu.",
@@ -4864,7 +4864,7 @@ public class GameScreen extends ScreenAdapter {
   /**
    * Issue #167: destroy {@code count} of the given player's placed mercenaries
    * (state==1 -> state==2). Used when a boosted defense card disappears from a
-   * player's def slots due to a successful enemy attack/plunder, so the
+   * player's def slots due to a successful enemy attack/loot, so the
    * mercenaries that fought on it don't remain stuck in the in-use state.
    */
   private void destroyMercenariesForPlayer(Player p, int count) {
@@ -5038,7 +5038,7 @@ public class GameScreen extends ScreenAdapter {
             bc.addBoosted(e.getValue()[1]);
           } else {
             // Issue #167: the previously boosted card is no longer in this
-            // slot (plundered or attacked away). Destroy the owner's
+            // slot (looted or attacked away). Destroy the owner's
             // mercenaries that were placed on it so they don't stay stuck
             // in the in-use state forever.
             destroyMercenariesForPlayer(p, e.getValue()[1]);
@@ -5174,36 +5174,36 @@ public class GameScreen extends ScreenAdapter {
         pendingAttackBroadcast = null;
       }
 
-      // Sync plunder preview — restore overlay for attacker on reconnect, watcher overlay for others
-      JSONObject serverPendingPlunder = state.optJSONObject("pendingPlunder");
-      if (serverPendingPlunder != null
-          && serverPendingPlunder.optInt("attackerIdx", -1) == playerIndex
-          && !currentPlayer.getPlayerTurn().isPlunderPending()) {
-        // Restore the plunder confirmation overlay so it reappears after a page refresh
+      // Sync loot preview — restore overlay for attacker on reconnect, watcher overlay for others
+      JSONObject serverPendingLoot = state.optJSONObject("pendingLoot");
+      if (serverPendingLoot != null
+          && serverPendingLoot.optInt("attackerIdx", -1) == playerIndex
+          && !currentPlayer.getPlayerTurn().isLootPending()) {
+        // Restore the loot confirmation overlay so it reappears after a page refresh
         PlayerTurn rpt = currentPlayer.getPlayerTurn();
-        rpt.setPlunderPending(true);
-        rpt.setPendingPickingDeckIndex(serverPendingPlunder.optInt("deckIndex", 0));
-        rpt.setPlunderSuccess(serverPendingPlunder.optBoolean("success", false));
-        rpt.setKingUsed(serverPendingPlunder.optBoolean("kingUsed", false));
-        rpt.setPendingPlunderAttackSum(serverPendingPlunder.optInt("attackSum", 0));
-        rpt.setPendingPlunderDefStrength(serverPendingPlunder.optInt("defStrength", 0));
+        rpt.setLootPending(true);
+        rpt.setPendingPickingDeckIndex(serverPendingLoot.optInt("deckIndex", 0));
+        rpt.setLootSuccess(serverPendingLoot.optBoolean("success", false));
+        rpt.setKingUsed(serverPendingLoot.optBoolean("kingUsed", false));
+        rpt.setPendingLootAttackSum(serverPendingLoot.optInt("attackSum", 0));
+        rpt.setPendingLootDefStrength(serverPendingLoot.optInt("defStrength", 0));
         ArrayList<Card> rptAtkCards = new ArrayList<Card>();
-        JSONArray rptAtkIds = serverPendingPlunder.optJSONArray("attackCardIds");
+        JSONArray rptAtkIds = serverPendingLoot.optJSONArray("attackCardIds");
         if (rptAtkIds != null) {
           for (int rai = 0; rai < rptAtkIds.length(); rai++) rptAtkCards.add(Card.fromCardId(rptAtkIds.getInt(rai)));
         }
         rpt.setPendingAttackCards(rptAtkCards);
         ArrayList<Card> rptOwnDefCards = new ArrayList<Card>();
-        JSONArray rptOwnDefIds = serverPendingPlunder.optJSONArray("ownDefCardIds");
+        JSONArray rptOwnDefIds = serverPendingLoot.optJSONArray("ownDefCardIds");
         if (rptOwnDefIds != null) {
           for (int rai = 0; rai < rptOwnDefIds.length(); rai++) rptOwnDefCards.add(Card.fromCardId(rptOwnDefIds.getInt(rai)));
         }
         rpt.setPendingAttackOwnDefCards(rptOwnDefCards);
-        pendingPlunderBroadcast = null;
-      } else if (serverPendingPlunder != null && serverPendingPlunder.optInt("attackerIdx", -1) != playerIndex) {
-        pendingPlunderBroadcast = serverPendingPlunder;
+        pendingLootBroadcast = null;
+      } else if (serverPendingLoot != null && serverPendingLoot.optInt("attackerIdx", -1) != playerIndex) {
+        pendingLootBroadcast = serverPendingLoot;
       } else {
-        pendingPlunderBroadcast = null;
+        pendingLootBroadcast = null;
       }
 
       // Sync pending hero selection after king defeat (only relevant to the attacker)

--- a/core/src/com/mygdx/game/HeroTutorialSteps.java
+++ b/core/src/com/mygdx/game/HeroTutorialSteps.java
@@ -11,7 +11,7 @@ package com.mygdx.game;
  *
  * Hooks fired by GameScreen:
  *   FINISH_TURN     - player clicked Finish Turn
- *   PLUNDER         - player resolved a plunder
+ *   LOOT            - player resolved a loot
  *   PUT_DEF         - player placed a defense card
  *   TAKE_DEF        - player took a defense card back
  *   MY_TURN_START   - player turn started (after bot turn ended)
@@ -67,12 +67,12 @@ final class HeroTutorialSteps {
       "To boost an attack:\n"
       + "  1. Select hand cards for an attack.\n"
       + "  2. Tap the Mercenaries hero icon - each tap adds +1 attack strength.\n\n"
-      + "Then plunder a deck or attack an enemy as usual.",
+      + "Then loot a deck or attack an enemy as usual.",
       null),
     GameScreen.TutorialStepDef.banner(
-      "Try a Plunder with Mercenaries",
+      "Try a Loot with Mercenaries",
       "Select a hand card, tap Mercenaries to boost, then tap a harvest deck.",
-      "PLUNDER"),
+      "LOOT"),
     new GameScreen.TutorialStepDef(
       "Recovery",
       "Mercenaries lost in a failed attack are gone forever.\n\n"
@@ -211,12 +211,12 @@ final class HeroTutorialSteps {
     new GameScreen.TutorialStepDef(
       "How to Use the Priest",
       "To steal an enemy hand card:\n  1. Tap the Priest hero icon to select it.\n  2. Tap the enemy's hand card deck.\n  3. Pick a card matching your attack symbol to take it.\n\n"
-      + "Note: you must make at least one attack or plunder first this turn to set your attack symbol.",
+      + "Note: you must make at least one attack or loot first this turn to set your attack symbol.",
       null),
     GameScreen.TutorialStepDef.banner(
       "Try the Priest",
-      "First plunder or attack to set your symbol, then tap Priest and tap the bot's hand deck. Click Next when done.",
-      "PLUNDER"),
+      "First loot or attack to set your symbol, then tap Priest and tap the bot's hand deck. Click Next when done.",
+      "LOOT"),
     GameScreen.TutorialStepDef.banner(
       "Finish Your Turn",
       "Click 'Finish turn' when done. Conversion attempts reset each new turn.",
@@ -244,9 +244,9 @@ final class HeroTutorialSteps {
       null),
     GameScreen.TutorialStepDef.banner(
       "Try an Attack",
-      "Plunder a harvest deck or attack an enemy defense card. If the attack is failing and you "
+      "Loot a harvest deck or attack an enemy defense card. If the attack is failing and you "
       + "have ready reservists, the boost button will appear.",
-      "PLUNDER"),
+      "LOOT"),
     GameScreen.TutorialStepDef.banner(
       "Finish Your Turn",
       "Click 'Finish turn'. 2 reservists will recover for next turn.",
@@ -268,10 +268,10 @@ final class HeroTutorialSteps {
       + "Both symbols can be combined in the same attack round.",
       null),
     GameScreen.TutorialStepDef.banner(
-      "Try a Plunder",
-      "Select hand cards and plunder a harvest deck. "
+      "Try a Loot",
+      "Select hand cards and loot a harvest deck. "
       + "Notice the dual symbol unlocking.",
-      "PLUNDER"),
+      "LOOT"),
     GameScreen.TutorialStepDef.banner(
       "Finish Your Turn",
       "Click 'Finish turn' when done.",

--- a/core/src/com/mygdx/game/PlayerTurn.java
+++ b/core/src/com/mygdx/game/PlayerTurn.java
@@ -80,26 +80,26 @@ public class PlayerTurn {
     return attackingSymbol;
   }
 
-  // --- Plunder preview state ---
-  private boolean plunderPending = false;
-  private boolean plunderSuccess = false;
+  // --- Loot preview state ---
+  private boolean lootPending = false;
+  private boolean lootSuccess = false;
   private ArrayList<Card> pendingAttackCards = new ArrayList<Card>();
   private int pendingPickingDeckIndex = -1;
 
-  public boolean isPlunderPending() {
-    return plunderPending;
+  public boolean isLootPending() {
+    return lootPending;
   }
 
-  public void setPlunderPending(boolean pending) {
-    this.plunderPending = pending;
+  public void setLootPending(boolean pending) {
+    this.lootPending = pending;
   }
 
-  public boolean isPlunderSuccess() {
-    return plunderSuccess;
+  public boolean isLootSuccess() {
+    return lootSuccess;
   }
 
-  public void setPlunderSuccess(boolean success) {
-    this.plunderSuccess = success;
+  public void setLootSuccess(boolean success) {
+    this.lootSuccess = success;
   }
 
   public ArrayList<Card> getPendingAttackCards() {
@@ -160,7 +160,7 @@ public class PlayerTurn {
   // True when the pending attack was initiated via the Warlord hero's extra attack.
   // Warlord grants an additional attack action, so resolving such an attack must NOT
   // mark the king as spent for the turn — otherwise the regular once-per-turn king
-  // attack/plunder is permanently blocked even after the player clears all defenses.
+  // attack/loot is permanently blocked even after the player clears all defenses.
   private boolean pendingAttackIsWarlord = false;
   public boolean isPendingAttackIsWarlord() { return pendingAttackIsWarlord; }
   public void setPendingAttackIsWarlord(boolean v) { this.pendingAttackIsWarlord = v; }
@@ -218,21 +218,21 @@ public class PlayerTurn {
   public void setPreyCardIds(ArrayList<Integer> ids) { this.preyCardIds = ids; }
 
   // --- Reservists attack bonus ---
-  // Incremented each time the player clicks the Reservists button in the attack or plunder overlay.
-  // Reset to 0 after the attack/plunder resolves.
+  // Incremented each time the player clicks the Reservists button in the attack or loot overlay.
+  // Reset to 0 after the attack/loot resolves.
   private int reservistAttackBonus = 0;
   public int getReservistAttackBonus() { return reservistAttackBonus; }
   public void incrementReservistAttackBonus() { reservistAttackBonus++; }
   public void resetReservistAttackBonus() { reservistAttackBonus = 0; }
 
-  // --- Plunder pending strength snapshot ---
-  // Stored when a plunder is initiated so the Reservists overlay button can recalculate the result.
-  private int pendingPlunderAttackSum = 0;
-  private int pendingPlunderDefStrength = 0;
-  public int getPendingPlunderAttackSum() { return pendingPlunderAttackSum; }
-  public void setPendingPlunderAttackSum(int v) { this.pendingPlunderAttackSum = v; }
-  public int getPendingPlunderDefStrength() { return pendingPlunderDefStrength; }
-  public void setPendingPlunderDefStrength(int v) { this.pendingPlunderDefStrength = v; }
+  // --- Loot pending strength snapshot ---
+  // Stored when a loot is initiated so the Reservists overlay button can recalculate the result.
+  private int pendingLootAttackSum = 0;
+  private int pendingLootDefStrength = 0;
+  public int getPendingLootAttackSum() { return pendingLootAttackSum; }
+  public void setPendingLootAttackSum(int v) { this.pendingLootAttackSum = v; }
+  public int getPendingLootDefStrength() { return pendingLootDefStrength; }
+  public void setPendingLootDefStrength(int v) { this.pendingLootDefStrength = v; }
 
   // --- King attack pending strength snapshot ---
   // Stored when a king attack is initiated so the Reservists overlay button can recalculate.

--- a/core/src/com/mygdx/game/StatsScreen.java
+++ b/core/src/com/mygdx/game/StatsScreen.java
@@ -213,7 +213,7 @@ public class StatsScreen extends AbstractScreen {
     addCell(table, "#",        colPlace,    hc, false);
     addCell(table, "Name",     colName,     hc, true);
     addCell(table, "Rounds",   colRounds,   hc, false);
-    addCell(table, "Plunders", colPlund,    hc, false);
+    addCell(table, "Loots", colPlund,    hc, false);
     addCell(table, "Attacks",  colAtk,      hc, false);
     addCell(table, "Defeated", colDefeated, hc, false);
     addCell(table, "King",     colKing,     hc, false);
@@ -250,8 +250,8 @@ public class StatsScreen extends AbstractScreen {
           int placement   = p.optInt("placement", i + 1);
           String name     = p.optString("name", "?");
           int roundsOut   = p.optInt("roundsUntilOut", 0);
-          int plundOk     = p.optInt("plundersSuccess", 0);
-          int plundFail   = p.optInt("plundersFailed", 0);
+          int plundOk     = p.optInt("lootsSuccess", 0);
+          int plundFail   = p.optInt("lootsFailed", 0);
           int atkOk       = p.optInt("attacksSuccess", 0);
           int atkFail     = p.optInt("attacksFailed", 0);
           int defeated    = p.optInt("defeated", 0);

--- a/core/src/com/mygdx/game/listeners/EnemyDefCardListener.java
+++ b/core/src/com/mygdx/game/listeners/EnemyDefCardListener.java
@@ -65,7 +65,7 @@ public class EnemyDefCardListener extends ClickListener {
   public void clicked(InputEvent event, float x, float y) {
     // Ignore taps while ANY preview overlay is active
     PlayerTurn pt = player.getPlayerTurn();
-    if (pt.isPlunderPending() || pt.isAttackPending()) return;
+    if (pt.isLootPending() || pt.isAttackPending()) return;
 
     // Spy peek: if spy is selected with no attack cards, flip enemy card face-up
     for (int si = 0; si < player.getHeroes().size(); si++) {
@@ -303,7 +303,7 @@ public class EnemyDefCardListener extends ClickListener {
     if (warlordAttack && warlord != null) {
       // Mark this pending attack as a Warlord extra-attack so the resolved
       // callback does NOT mark the king as spent for the turn (Warlord grants
-      // an additional attack action; the regular king attack/plunder must
+      // an additional attack action; the regular king attack/loot must
       // remain available).
       pt.setPendingAttackIsWarlord(true);
       warlord.useAttack();

--- a/core/src/com/mygdx/game/listeners/EnemyKingCardListener.java
+++ b/core/src/com/mygdx/game/listeners/EnemyKingCardListener.java
@@ -49,7 +49,7 @@ public class EnemyKingCardListener extends ClickListener {
   @Override
   public void clicked(InputEvent event, float x, float y) {
     PlayerTurn pt = player.getPlayerTurn();
-    if (pt.isPlunderPending() || pt.isAttackPending()) return;
+    if (pt.isLootPending() || pt.isAttackPending()) return;
 
     // Find which player owns this king card (the defender)
     int defenderIdx = -1;
@@ -229,7 +229,7 @@ public class EnemyKingCardListener extends ClickListener {
     if (warlordAttack && warlord != null) {
       // Mark this pending attack as a Warlord extra-attack so the resolved
       // callback does NOT mark the king as spent for the turn (Warlord grants
-      // an additional attack action; the regular king attack/plunder must
+      // an additional attack action; the regular king attack/loot must
       // remain available).
       pt.setPendingAttackIsWarlord(true);
       warlord.useAttack();

--- a/core/src/com/mygdx/game/listeners/PickingDeckListener.java
+++ b/core/src/com/mygdx/game/listeners/PickingDeckListener.java
@@ -33,7 +33,7 @@ public class PickingDeckListener extends ClickListener {
     Player currentPlayer = gameState.getCurrentPlayer();
     PlayerTurn pt = currentPlayer.getPlayerTurn();
 
-    if (pt.isPlunderPending()) {
+    if (pt.isLootPending()) {
       // Confirmation is handled by the fullscreen overlay in GameScreen; ignore deck clicks.
       return;
     }
@@ -117,14 +117,14 @@ public class PickingDeckListener extends ClickListener {
         System.out.println("Attack with " + attackSum + " defense is " + topCard.getStrength());
 
         pt.decreasePickingDeckAttacks();
-        pt.setPlunderPending(true);
+        pt.setLootPending(true);
         // Joker on top of harvest deck defends with infinite+1 (1000) — unbeatable
         int defStrength = "joker".equals(topCard.getSymbol()) ? 1000 : topCard.getStrength();
-        pt.setPendingPlunderAttackSum(attackSum);
-        pt.setPendingPlunderDefStrength(defStrength);
-        pt.setPlunderSuccess(attackSum > defStrength);
+        pt.setPendingLootAttackSum(attackSum);
+        pt.setPendingLootDefStrength(defStrength);
+        pt.setLootSuccess(attackSum > defStrength);
 
-        // Broadcast plunder preview to all players so watchers can see what's happening
+        // Broadcast loot preview to all players so watchers can see what's happening
         if (gameState.getSocket() != null) {
           try {
             int attackerIdx = gameState.getCurrentPlayerIndex();
@@ -147,7 +147,7 @@ public class PickingDeckListener extends ClickListener {
             preview.put("ownDefCardIds", ownDefIds);
             preview.put("attackingSymbol", pt.getAttackingSymbol()[0]);
             preview.put("attackingSymbol2", pt.getAttackingSymbol()[1]);
-            gameState.getSocket().emit("plunderPreview", preview);
+            gameState.getSocket().emit("lootPreview", preview);
           } catch (JSONException e) { e.printStackTrace(); }
         }
 

--- a/index.md
+++ b/index.md
@@ -13,7 +13,7 @@ Be the last player not eliminated. A player is eliminated when their king is def
 On your turn, you typically:
 
 1. Improve your board (take/put defense cards)
-2. Plunder center picking decks for resources
+2. Loot center picking decks for resources
 3. Attack enemy defenses or king when legal
 4. Use hero abilities for tactical advantage
 5. End with Finish Turn
@@ -21,7 +21,7 @@ On your turn, you typically:
 ## Core Concepts
 
 - Defense cards protect your king.
-- Picking decks are central reward piles for plunder actions.
+- Picking decks are central reward piles for loot actions.
 - Captured cards become prey cards and unlock after your turn ends.
 - Jokers can be sacrificed to acquire heroes.
 

--- a/server/bot.js
+++ b/server/bot.js
@@ -36,8 +36,8 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     defenseCardStrategy()     { return 'weakest'; }
     /** Replace exposed (face-up) defense cards with fresh face-down ones? */
     replaceExposedDefense()   { return true; }
-    /** Perform a follow-up defense attack after a successful plunder? */
-    attackAfterPlunder()      { return true; }
+    /** Perform a follow-up defense attack after a successful loot? */
+    attackAfterLoot()      { return true; }
     /** Maximum defense-card attacks per turn. -1 means unlimited. */
     maxAttacksPerTurn()       { return 1; }
     /** Probe covered defense cards to reveal them for future turns? */
@@ -60,12 +60,12 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
   /**
    * Passive — defensive wall builder.
    * Uses strongest cards for defense. One attack max (just to avoid the expose penalty).
-   * Never follows up after a plunder. Happy to trade joker for a hero.
+   * Never follows up after a loot. Happy to trade joker for a hero.
    */
   class PassivePersonality extends BotPersonality {
     constructor() { super('passive'); }
     defenseCardStrategy()   { return 'strongest'; }
-    attackAfterPlunder()    { return false; }
+    attackAfterLoot()    { return false; }
     maxAttacksPerTurn()     { return 1; }
   }
 
@@ -80,7 +80,7 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     constructor() { super('aggressive'); }
     fillDefenseFirst()      { return false; }
     replaceExposedDefense() { return false; }
-    attackAfterPlunder()    { return true; }
+    attackAfterLoot()    { return true; }
     maxAttacksPerTurn()     { return -1; }
     sacrificeJokerForHero() { return false; }
   }
@@ -93,7 +93,7 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
    */
   class TacticianPersonality extends BotPersonality {
     constructor() { super('tactician'); }
-    attackAfterPlunder()    { return true; }
+    attackAfterLoot()    { return true; }
     maxAttacksPerTurn()     { return 2; }
     allowScouting()         { return true; }
     sacrificeJokerForHero() { return true; }
@@ -185,9 +185,9 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     return best;
   }
 
-  // Choose the best plunder: smart multi-card combo, preferring bigger decks with larger margin.
+  // Choose the best loot: smart multi-card combo, preferring bigger decks with larger margin.
   // Returns { deckIndex, cardIds, symbol, success } or null.
-  function botChoosePlunder(gs, attackerIdx) {
+  function botChooseLoot(gs, attackerIdx) {
     var p = gs.players[attackerIdx];
     if (!p || !p.hand || p.hand.length === 0 || (p.pickingDeckAttacks || 0) <= 0) return null;
 
@@ -236,7 +236,7 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
         }
       }
     }
-    // Don't attempt plunder if facing certain failure
+    // Don't attempt loot if facing certain failure
     return (bestChoice && (bestChoice.success || bestScore > -200)) ? bestChoice : null;
   }
 
@@ -550,19 +550,19 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     callback(false);
   }
 
-  // After a plunder: optionally attack a face-up defense card, then finish the turn.
-  function botContinueAfterPlunder(sess, gs, idx) {
-    var atkAfterPlunder = botChooseDefAttack(gs, idx, false);
-    if (atkAfterPlunder) {
-      var apDefCardId = gs.players[atkAfterPlunder.defenderIdx].defCards[atkAfterPlunder.positionId];
-      var apPreview = { attackerIdx: idx, defenderIdx: atkAfterPlunder.defenderIdx,
-                        positionId: atkAfterPlunder.positionId, level: 0,
-                        attackingSymbol: atkAfterPlunder.symbol, attackingSymbol2: 'none',
-                        success: atkAfterPlunder.success, attackCardIds: atkAfterPlunder.cardIds,
+  // After a loot: optionally attack a face-up defense card, then finish the turn.
+  function botContinueAfterLoot(sess, gs, idx) {
+    var atkAfterLoot = botChooseDefAttack(gs, idx, false);
+    if (atkAfterLoot) {
+      var apDefCardId = gs.players[atkAfterLoot.defenderIdx].defCards[atkAfterLoot.positionId];
+      var apPreview = { attackerIdx: idx, defenderIdx: atkAfterLoot.defenderIdx,
+                        positionId: atkAfterLoot.positionId, level: 0,
+                        attackingSymbol: atkAfterLoot.symbol, attackingSymbol2: 'none',
+                        success: atkAfterLoot.success, attackCardIds: atkAfterLoot.cardIds,
                         defCardIds: apDefCardId != null ? [apDefCardId] : [] };
       gs.setAttackPreview(apPreview);
       io.to(sess.id).emit('stateUpdate', gs.serialize());
-      botDoDefAttackWithBatteryCheck(sess, gs, atkAfterPlunder, apPreview, function() {
+      botDoDefAttackWithBatteryCheck(sess, gs, atkAfterLoot, apPreview, function() {
         botFinishTurn(sess, gs, idx, true);
       });
     } else {
@@ -733,11 +733,11 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
       }
     }
 
-    // Exception 2: save joker if it is the only way to plunder a known deck
+    // Exception 2: save joker if it is the only way to loot a known deck
     if ((p.pickingDeckAttacks || 0) > 0) {
       var nonJokerHand = p.hand.filter(function(id) { return id <= 52; });
       var hasUncoveredDeck = false;
-      var canPlunderWithoutJoker = false;
+      var canLootWithoutJoker = false;
       for (var d = 0; d < gs.pickingDecks.length; d++) {
         var deck = gs.pickingDecks[d];
         if (deck.length === 0) continue;
@@ -746,9 +746,9 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
         hasUncoveredDeck = true;
         var threshold = gs.cardStrength(topCard.id);
         var best = botBestSuitCombo(gs, nonJokerHand);
-        if (best.sum >= threshold) { canPlunderWithoutJoker = true; break; }
+        if (best.sum >= threshold) { canLootWithoutJoker = true; break; }
       }
-      if (hasUncoveredDeck && !canPlunderWithoutJoker) return false; // save joker for plunder
+      if (hasUncoveredDeck && !canLootWithoutJoker) return false; // save joker for loot
     }
 
     // Perform sacrifice
@@ -916,7 +916,7 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
 
   // ── MCTS Bot Turn ────────────────────────────────────────────────────────────
   // Runs balanced setup steps, then uses Monte Carlo Tree Search to select
-  // the best first action (plunder, defense attack, or king attack).
+  // the best first action (loot, defense attack, or king attack).
   function executeMctsTurnAsync(sess, gs, idx) {
     var p = gs.players[idx];
     if (!p || p.isOut) return;
@@ -944,14 +944,14 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
       return;
     }
 
-    if (action.type === 'plunder') {
+    if (action.type === 'loot') {
       var plDeck = gs.pickingDecks[action.deckIndex];
       var plTopCard = plDeck && plDeck.length > 0 ? plDeck[plDeck.length - 1] : null;
       var plAtkSum = action.symbol === 'joker' ? 999
         : action.cardIds.reduce(function(s, id) { return s + gs.cardStrength(id); }, 0);
       var plDefStrength = plTopCard ? gs.cardStrength(plTopCard.id) : 0;
       var plSuccess = plAtkSum > plDefStrength;
-      gs.setPlunderPreview({
+      gs.setLootPreview({
         attackerIdx: idx, deckIndex: action.deckIndex,
         attackCardIds: action.cardIds,
         attackingSymbol: action.symbol, attackingSymbol2: 'none',
@@ -962,7 +962,7 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
       io.to(sess.id).emit('stateUpdate', gs.serialize());
       var plAction = action;
       setTimeout(function() {
-        gs.plunderResolved(idx, plAction.deckIndex, plSuccess, plAction.cardIds, false, []);
+        gs.lootResolved(idx, plAction.deckIndex, plSuccess, plAction.cardIds, false, []);
         io.to(sess.id).emit('stateUpdate', gs.serialize());
         checkAndHandleWinner(sess);
         botFinishTurn(sess, gs, idx, false);
@@ -1065,30 +1065,30 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
         return;
       }
 
-      // 5. Smart plunder — multi-card, economical combo
-      var plunderChoice = botChoosePlunder(gs, idx);
-      if (plunderChoice) {
+      // 5. Smart loot — multi-card, economical combo
+      var lootChoice = botChooseLoot(gs, idx);
+      if (lootChoice) {
         var plAtkSum = 0;
-        for (var pci = 0; pci < plunderChoice.cardIds.length; pci++) plAtkSum += gs.cardStrength(plunderChoice.cardIds[pci]);
-        var plDeck = gs.pickingDecks[plunderChoice.deckIndex];
+        for (var pci = 0; pci < lootChoice.cardIds.length; pci++) plAtkSum += gs.cardStrength(lootChoice.cardIds[pci]);
+        var plDeck = gs.pickingDecks[lootChoice.deckIndex];
         var plTopCard = plDeck && plDeck.length > 0 ? plDeck[plDeck.length - 1] : null;
         var plDefStrength = plTopCard ? gs.cardStrength(plTopCard.id) : 0;
-        gs.setPlunderPreview({ attackerIdx: idx, deckIndex: plunderChoice.deckIndex,
-                               attackCardIds: plunderChoice.cardIds,
-                               attackingSymbol: plunderChoice.symbol, attackingSymbol2: 'none',
-                               success: plunderChoice.success, attackSum: plAtkSum,
+        gs.setLootPreview({ attackerIdx: idx, deckIndex: lootChoice.deckIndex,
+                               attackCardIds: lootChoice.cardIds,
+                               attackingSymbol: lootChoice.symbol, attackingSymbol2: 'none',
+                               success: lootChoice.success, attackSum: plAtkSum,
                                defCardId: plTopCard ? plTopCard.id : -1,
                                defStrength: plDefStrength });
         io.to(sess.id).emit('stateUpdate', gs.serialize());
-        var captured = plunderChoice;
+        var captured = lootChoice;
         setTimeout(function() {
           try {
-            gs.plunderResolved(idx, captured.deckIndex, captured.success,
+            gs.lootResolved(idx, captured.deckIndex, captured.success,
                                captured.cardIds, false, []);
             io.to(sess.id).emit('stateUpdate', gs.serialize());
             checkAndHandleWinner(sess);
-            // 6. After plunder: optional follow-up attack chain (personality-controlled)
-            if (personality.attackAfterPlunder()) {
+            // 6. After loot: optional follow-up attack chain (personality-controlled)
+            if (personality.attackAfterLoot()) {
               botAttackChainAsync(sess, gs, idx, personality, function(attacked) {
                 botFinishTurn(sess, gs, idx, attacked);
               });
@@ -1096,7 +1096,7 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
               botFinishTurn(sess, gs, idx, false);
             }
           } catch (e) {
-            console.error('[plunderResolved setTimeout] uncaught error:', e && e.message, e && e.stack);
+            console.error('[lootResolved setTimeout] uncaught error:', e && e.message, e && e.stack);
           }
         }, BOT_ACTION_DELAY);
         return;

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -23,7 +23,7 @@ class GameState {
     this.log = []; // activity log: [{ text, success }, ...], max 100 entries
     this.lastMerchantReveal = null; // set during 2nd-try, cleared on finishTurn
     this.pendingAttack = null; // current attack preview broadcast, cleared on defAttackResolved
-    this.pendingPlunder = null; // current plunder preview broadcast, cleared on plunderResolved
+    this.pendingLoot = null; // current loot preview broadcast, cleared on lootResolved
     this.setupPhase = manualSetup;
     this.setupSubmitted = {}; // { playerIdx: true } — tracks who confirmed during manual setup
     this.roundNumber = 1;     // incremented each time the full turn order wraps around
@@ -59,8 +59,8 @@ class GameState {
       p.attackingSymbol = 'none';
       p.attackingSymbol2 = 'none';
       p.statHeroesReceived = 0;
-      p.statPlundersSuccess = 0;
-      p.statPlundersFailed = 0;
+      p.statLootsSuccess = 0;
+      p.statLootsFailed = 0;
       p.statAttacksSuccess = 0;
       p.statAttacksFailed = 0;
       p.statRoundEliminatedAt = 0;
@@ -158,7 +158,7 @@ class GameState {
     return (this.players[idx] && this.players[idx].name) || ('P' + idx);
   }
 
-  setPlunderPreview(data) {
+  setLootPreview(data) {
     // Immediately remove committed hand-based attack cards from attacker's hand.
     // This prevents them reappearing in hand if the player refreshes before confirming the overlay.
     const p = data.attackerIdx !== undefined ? this.players[data.attackerIdx] : null;
@@ -173,7 +173,7 @@ class GameState {
         if (i !== -1) { p.hand.splice(i, 1); lockedHandCards.push(cardId); }
       }
     }
-    this.pendingPlunder = Object.assign({}, data, { _lockedHandCards: lockedHandCards });
+    this.pendingLoot = Object.assign({}, data, { _lockedHandCards: lockedHandCards });
     // Persist the top card of the attacked deck as face-up so the stateUpdate
     // broadcast doesn't re-cover it for all players
     if (data.deckIndex !== undefined) {
@@ -496,18 +496,18 @@ class GameState {
     this.pushLog(`${this.pname(playerIdx)} discarded own shield(s)`, true, true);
   }
 
-  plunderResolved(attackerIdx, deckIdx, success, attackCardIds, kingUsed, attackerOwnDefCardIds) {
-    // Use cards pre-locked in setPlunderPreview if available (prevents reappearance on refresh)
-    const lockedHandCards = this.pendingPlunder ? (this.pendingPlunder._lockedHandCards || []) : [];
+  lootResolved(attackerIdx, deckIdx, success, attackCardIds, kingUsed, attackerOwnDefCardIds) {
+    // Use cards pre-locked in setLootPreview if available (prevents reappearance on refresh)
+    const lockedHandCards = this.pendingLoot ? (this.pendingLoot._lockedHandCards || []) : [];
     // Capture deck top card strength BEFORE any deck modification (for log display)
     const deck = this.pickingDecks[deckIdx];
     const topDeckCard = deck.length > 0 ? deck[deck.length - 1].id : null;
     const deckDefStrength = topDeckCard ? this.cardStrength(topDeckCard) : 0;
-    this.pendingPlunder = null;
+    this.pendingLoot = null;
     const attacker = this.players[attackerIdx];
-    // NOTE: plundering does NOT increment attackCount — only real attacks (defAttack/kingAttack/warlord) do.
+    // NOTE: looting does NOT increment attackCount — only real attacks (defAttack/kingAttack/warlord) do.
     const handCardsToProcess = lockedHandCards.length > 0 ? lockedHandCards : attackCardIds;
-    const plunderAtkSum = handCardsToProcess.reduce((sum, id) => sum + this.cardStrength(id), 0)
+    const lootAtkSum = handCardsToProcess.reduce((sum, id) => sum + this.cardStrength(id), 0)
       + (attackerOwnDefCardIds || []).reduce((sum, id) => sum + this.cardStrength(id), 0);
     for (const cardId of handCardsToProcess) {
       const i = attacker.hand.indexOf(cardId);
@@ -526,20 +526,20 @@ class GameState {
     }
     if (kingUsed) { attacker.kingCovered = false; attacker.statKingUsed = (attacker.statKingUsed || 0) + 1; }
     if (success) {
-      attacker.statPlundersSuccess = (attacker.statPlundersSuccess || 0) + 1;
-      this.pushLog(`${this.pname(attackerIdx)} plundered deck ${deckIdx + 1}! (${plunderAtkSum} vs ${deckDefStrength})`, true);
-      // Move all cards from plundered deck into attacker's hand
+      attacker.statLootsSuccess = (attacker.statLootsSuccess || 0) + 1;
+      this.pushLog(`${this.pname(attackerIdx)} looted deck ${deckIdx + 1}! (${lootAtkSum} vs ${deckDefStrength})`, true);
+      // Move all cards from looted deck into attacker's hand
       for (const c of this.pickingDecks[deckIdx]) attacker.hand.push(c.id);
       this.pickingDecks[deckIdx] = [];
       const otherIdx = 1 - deckIdx;
       // Add one face-DOWN card to the other deck (deck B grows by one hidden card)
       const c1 = this.pickCard(); if (c1 !== null) this.pickingDecks[otherIdx].push({ id: c1, covered: true });
-      // Rebuild plundered deck: one face-up card (visible) + one face-down card on top
+      // Rebuild looted deck: one face-up card (visible) + one face-down card on top
       const c2 = this.pickCard(); if (c2 !== null) this.pickingDecks[deckIdx].push({ id: c2, covered: false });
       const c3 = this.pickCard(); if (c3 !== null) this.pickingDecks[deckIdx].push({ id: c3, covered: true });
     } else {
-      attacker.statPlundersFailed = (attacker.statPlundersFailed || 0) + 1;
-      this.pushLog(`${this.pname(attackerIdx)} plunder on deck ${deckIdx + 1} failed (${plunderAtkSum} vs ${deckDefStrength})`, false);
+      attacker.statLootsFailed = (attacker.statLootsFailed || 0) + 1;
+      this.pushLog(`${this.pname(attackerIdx)} loot on deck ${deckIdx + 1} failed (${lootAtkSum} vs ${deckDefStrength})`, false);
       if (kingUsed) {
         attacker.isOut = true;
         attacker.statRoundEliminatedAt = this.roundNumber;
@@ -548,7 +548,7 @@ class GameState {
         for (const cardId of attacker.hand) this.cemetery.push(cardId);
         attacker.hand = [];
       }
-      // Keep the attacked (top) card face-up after a failed plunder,
+      // Keep the attacked (top) card face-up after a failed loot,
       // then add a new face-down card on top.
       const deck = this.pickingDecks[deckIdx];
       if (deck.length > 0) deck[deck.length - 1].covered = false;
@@ -707,8 +707,8 @@ class GameState {
         placement: 1,
         roundsUntilOut: this.roundNumber,
         heroesReceived: winner.statHeroesReceived || 0,
-        plundersSuccess: winner.statPlundersSuccess || 0,
-        plundersFailed: winner.statPlundersFailed || 0,
+        lootsSuccess: winner.statLootsSuccess || 0,
+        lootsFailed: winner.statLootsFailed || 0,
         attacksSuccess: winner.statAttacksSuccess || 0,
         attacksFailed: winner.statAttacksFailed || 0,
         defeated: winner.statDefeated || 0,
@@ -727,8 +727,8 @@ class GameState {
         placement: playerResults.length + 1,
         roundsUntilOut: p.statRoundEliminatedAt || this.roundNumber,
         heroesReceived: p.statHeroesReceived || 0,
-        plundersSuccess: p.statPlundersSuccess || 0,
-        plundersFailed: p.statPlundersFailed || 0,
+        lootsSuccess: p.statLootsSuccess || 0,
+        lootsFailed: p.statLootsFailed || 0,
         attacksSuccess: p.statAttacksSuccess || 0,
         attacksFailed: p.statAttacksFailed || 0,
         defeated: p.statDefeated || 0,
@@ -994,7 +994,7 @@ class GameState {
       log: [...this.log],
       merchantReveal: this.lastMerchantReveal || null,
       pendingAttack: this.pendingAttack || null,
-      pendingPlunder: this.pendingPlunder || null,
+      pendingLoot: this.pendingLoot || null,
       pendingHeroSelection: this.pendingHeroSelection || null,
       pendingHeroAuction: this.pendingHeroAuction || null,
       isTutorial: this.isTutorial || false,

--- a/server/index.js
+++ b/server/index.js
@@ -366,9 +366,9 @@ function botBestSuitCombo(gs, hand) {
   return best;
 }
 
-// Choose the best plunder: smart multi-card combo, preferring bigger decks with larger margin.
+// Choose the best loot: smart multi-card combo, preferring bigger decks with larger margin.
 // Returns { deckIndex, cardIds, symbol, success } or null.
-function botChoosePlunder(gs, attackerIdx) {
+function botChooseLoot(gs, attackerIdx) {
   var p = gs.players[attackerIdx];
   if (!p || !p.hand || p.hand.length === 0 || (p.pickingDeckAttacks || 0) <= 0) return null;
 
@@ -417,7 +417,7 @@ function botChoosePlunder(gs, attackerIdx) {
       }
     }
   }
-  // Don't attempt plunder if facing certain failure
+  // Don't attempt loot if facing certain failure
   return (bestChoice && (bestChoice.success || bestScore > -200)) ? bestChoice : null;
 }
 
@@ -555,15 +555,15 @@ function botTryKingAttackAsync(sess, gs, attackerIdx, callback) {
   callback(false);
 }
 
-// After a plunder: optionally attack a face-up defense card, then finish the turn.
-function botContinueAfterPlunder(sess, gs, idx) {
-  var atkAfterPlunder = botChooseDefAttack(gs, idx, false);
-  if (atkAfterPlunder) {
-    gs.setAttackPreview({ attackerIdx: idx, defenderIdx: atkAfterPlunder.defenderIdx,
-                           positionId: atkAfterPlunder.positionId, level: 0,
-                           attackingSymbol: atkAfterPlunder.symbol, attackingSymbol2: 'none' });
+// After a loot: optionally attack a face-up defense card, then finish the turn.
+function botContinueAfterLoot(sess, gs, idx) {
+  var atkAfterLoot = botChooseDefAttack(gs, idx, false);
+  if (atkAfterLoot) {
+    gs.setAttackPreview({ attackerIdx: idx, defenderIdx: atkAfterLoot.defenderIdx,
+                           positionId: atkAfterLoot.positionId, level: 0,
+                           attackingSymbol: atkAfterLoot.symbol, attackingSymbol2: 'none' });
     io.to(sess.id).emit('stateUpdate', gs.serialize());
-    var captured = atkAfterPlunder;
+    var captured = atkAfterLoot;
     setTimeout(function() {
       gs.defAttackResolved(idx, captured.defenderIdx, captured.positionId,
                             0, captured.success, captured.cardIds, false, []);
@@ -690,11 +690,11 @@ function botTryJokerSacrifice(sess, gs, playerIdx) {
     }
   }
 
-  // Exception 2: save joker if it is the only way to plunder a known deck
+  // Exception 2: save joker if it is the only way to loot a known deck
   if ((p.pickingDeckAttacks || 0) > 0) {
     var nonJokerHand = p.hand.filter(function(id) { return id <= 52; });
     var hasUncoveredDeck = false;
-    var canPlunderWithoutJoker = false;
+    var canLootWithoutJoker = false;
     for (var d = 0; d < gs.pickingDecks.length; d++) {
       var deck = gs.pickingDecks[d];
       if (deck.length === 0) continue;
@@ -703,9 +703,9 @@ function botTryJokerSacrifice(sess, gs, playerIdx) {
       hasUncoveredDeck = true;
       var threshold = gs.cardStrength(topCard.id);
       var best = botBestSuitCombo(gs, nonJokerHand);
-      if (best.sum >= threshold) { canPlunderWithoutJoker = true; break; }
+      if (best.sum >= threshold) { canLootWithoutJoker = true; break; }
     }
-    if (hasUncoveredDeck && !canPlunderWithoutJoker) return false; // save joker for plunder
+    if (hasUncoveredDeck && !canLootWithoutJoker) return false; // save joker for loot
   }
 
   // Perform sacrifice
@@ -763,26 +763,26 @@ function executeBotTurn(sess) {
       return;
     }
 
-    // 5. Smart plunder — multi-card, economical combo
-    var plunderChoice = botChoosePlunder(gs, idx);
-    if (plunderChoice) {
-      gs.setPlunderPreview({ attackerIdx: idx, deckIndex: plunderChoice.deckIndex,
-                             attackCardIds: plunderChoice.cardIds,
-                             attackingSymbol: plunderChoice.symbol, attackingSymbol2: 'none' });
+    // 5. Smart loot — multi-card, economical combo
+    var lootChoice = botChooseLoot(gs, idx);
+    if (lootChoice) {
+      gs.setLootPreview({ attackerIdx: idx, deckIndex: lootChoice.deckIndex,
+                             attackCardIds: lootChoice.cardIds,
+                             attackingSymbol: lootChoice.symbol, attackingSymbol2: 'none' });
       io.to(sess.id).emit('stateUpdate', gs.serialize());
-      var captured = plunderChoice;
+      var captured = lootChoice;
       setTimeout(function() {
-        gs.plunderResolved(idx, captured.deckIndex, captured.success,
+        gs.lootResolved(idx, captured.deckIndex, captured.success,
                            captured.cardIds, false, []);
         io.to(sess.id).emit('stateUpdate', gs.serialize());
         checkAndHandleWinner(sess);
-        // 6. After plunder: optional follow-up defense attack, then finish
-        botContinueAfterPlunder(sess, gs, idx);
+        // 6. After loot: optional follow-up defense attack, then finish
+        botContinueAfterLoot(sess, gs, idx);
       }, BOT_ACTION_DELAY);
       return;
     }
 
-    // 7. No plunder: attack a face-up defense card
+    // 7. No loot: attack a face-up defense card
     var atkChoice = botChooseDefAttack(gs, idx, false);
     if (atkChoice) {
       gs.setAttackPreview({ attackerIdx: idx, defenderIdx: atkChoice.defenderIdx,
@@ -1216,7 +1216,7 @@ io.on('connection', function(socket) {
     if (!sess || !sess.gameState) return;
     // Verify by socket identity rather than trusting the client-sent currentPlayerIndex.
     // This is more robust and prevents rejection when the client sends a stale or wrong index
-    // (recurring bug: "nothing happens" after selecting the card to expose on a plunder-only turn).
+    // (recurring bug: "nothing happens" after selecting the card to expose on a loot-only turn).
     var socketPlayerIdx = sess.users.findIndex(function(u) { return u.id === socket.id; });
     if (socketPlayerIdx !== sess.gameState.currentPlayerIndex) {
       console.log("finishTurn rejected: server currentPlayerIndex=" + sess.gameState.currentPlayerIndex + ", socket player=" + socketPlayerIdx + " (client sent " + data.currentPlayerIndex + ")");
@@ -1226,7 +1226,7 @@ io.on('connection', function(socket) {
     // Safety net: if no attack was made this turn and the expose-defence-card penalty
     // was not fulfilled (client did not emit exposeDefCard / exposeKingCard), auto-expose
     // the first covered card here.  Handles the edge case where the client emits finishTurn
-    // without a preceding exposeDefCard (recurring bug after the #187 plunder-only-turn fix).
+    // without a preceding exposeDefCard (recurring bug after the #187 loot-only-turn fix).
     var p = sess.gameState.players[socketPlayerIdx];
     if (p && (p.attackCount || 0) === 0 && !p.didExposeThisTurn) {
       var exposedDef = false;
@@ -1282,19 +1282,19 @@ io.on('connection', function(socket) {
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
-  socket.on('plunderPreview', function(data) {
+  socket.on('lootPreview', function(data) {
     var sess = getSession(socket.id);
     if (!sess || !sess.gameState) return;
-    sess.gameState.setPlunderPreview(data);
+    sess.gameState.setLootPreview(data);
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 
-  socket.on('plunderResolved', function(data) {
+  socket.on('lootResolved', function(data) {
     var sess = getSession(socket.id);
     if (!sess || !sess.gameState) return;
-    console.log("plunderResolved: attackerIdx=" + data.attackerIdx + " deckIndex=" + data.deckIndex + " success=" + data.success);
-    sess.gameState.plunderResolved(data.attackerIdx, data.deckIndex, data.success, data.attackCardIds || [], data.kingUsed || false, data.attackerOwnDefCardIds || []);
-    // Auto-finish turn if attacker was eliminated (failed king-used plunder)
+    console.log("lootResolved: attackerIdx=" + data.attackerIdx + " deckIndex=" + data.deckIndex + " success=" + data.success);
+    sess.gameState.lootResolved(data.attackerIdx, data.deckIndex, data.success, data.attackCardIds || [], data.kingUsed || false, data.attackerOwnDefCardIds || []);
+    // Auto-finish turn if attacker was eliminated (failed king-used loot)
     var plAttacker = sess.gameState.players[data.attackerIdx];
     if (plAttacker && plAttacker.isOut && sess.gameState.currentPlayerIndex === data.attackerIdx) {
       sess.gameState.finishTurn();

--- a/server/mcts-sim.js
+++ b/server/mcts-sim.js
@@ -96,7 +96,7 @@ function simLegalActions(sim, allowCovered) {
   var jokers = p.hand.filter(function(id) { return id > 52; });
   var suits = Object.keys(groups);
 
-  // ---- Plunder ----
+  // ---- Loot ----
   if ((p.pickingDeckAttacks || 0) > 0) {
     for (var di = 0; di < sim.pickingDecks.length; di++) {
       var deck = sim.pickingDecks[di];
@@ -105,10 +105,10 @@ function simLegalActions(sim, allowCovered) {
       var threshold = simCardStrength(topCard.id);
       for (var si = 0; si < suits.length; si++) {
         var combo = simMinimalWinning(groups[suits[si]], threshold);
-        if (combo) actions.push({ type: 'plunder', deckIndex: di, cardIds: combo, symbol: suits[si] });
+        if (combo) actions.push({ type: 'loot', deckIndex: di, cardIds: combo, symbol: suits[si] });
       }
       if (jokers.length > 0) {
-        actions.push({ type: 'plunder', deckIndex: di, cardIds: [jokers[0]], symbol: 'joker' });
+        actions.push({ type: 'loot', deckIndex: di, cardIds: [jokers[0]], symbol: 'joker' });
       }
     }
   }
@@ -191,7 +191,7 @@ function simApplyAction(sim, action) {
   var p = sim.players[idx];
   var i, cardId;
 
-  if (action.type === 'plunder') {
+  if (action.type === 'loot') {
     p.pickingDeckAttacks = 0;
     for (i = 0; i < action.cardIds.length; i++) {
       cardId = action.cardIds[i];

--- a/tests/tutorial.test.js
+++ b/tests/tutorial.test.js
@@ -181,26 +181,26 @@ test('tutorial full walkthrough', async ({ page }) => {
   await page.waitForTimeout(800);
   await shot(page, '08_after_symbols_info');
 
-  // ── Step 4: PLUNDER – tap a harvest deck (card already selected from step 2)
+  // ── Step 4: LOOT – tap a harvest deck (card already selected from step 2)
   // Deck 1 center in gameStage: (232, 267) → browser(232, 208)
   await cgame(page, 232, 267, 'harvest deck');
   await page.waitForTimeout(2500);
-  await shot(page, '09_after_plunder');
+  await shot(page, '09_after_loot');
 
-  // ── Step 5: INFO_PLUNDER ──────────────────────────────────────────────────
-  // The plunder result ("FAILED. Tap to continue.") is a gameStage overlay and
+  // ── Step 5: INFO_LOOT ────────────────────────────────────────────────────
+  // The loot result ("FAILED. Tap to continue.") is a gameStage overlay and
   // MUST be dismissed by clicking inside gameStage (browser Y 25-475), not the
-  // hand area. After it is tapped the tutorial advances to INFO_PLUNDER whose
+  // hand area. After it is tapped the tutorial advances to INFO_LOOT whose
   // "Got it" button sits lower (~Y 601) because the body text is very long.
-  await cgame(page, 225, 200, 'dismiss plunder result');
-  await page.waitForTimeout(800);  // wait for INFO_PLUNDER overlay to build
-  console.log('  [click] Got it (plunder) browser(225,601)');
+  await cgame(page, 225, 200, 'dismiss loot result');
+  await page.waitForTimeout(800);  // wait for INFO_LOOT overlay to build
+  console.log('  [click] Got it (loot) browser(225,601)');
   await page.mouse.click(225, 601);
   await page.waitForTimeout(800);
-  await shot(page, '10_after_plunder_info');
+  await shot(page, '10_after_loot_info');
 
   // ── Step 6: INFO_JOKER ────────────────────────────────────────────────────
-  // INFO_JOKER body text is slightly shorter than INFO_PLUNDER, button ≈ Y 555.
+  // INFO_JOKER body text is slightly shorter than INFO_LOOT, button ≈ Y 555.
   console.log('  [click] Got it (joker) browser(225,555)');
   await page.mouse.click(225, 555);
   await page.waitForTimeout(800);


### PR DESCRIPTION
Closes #213

## Summary

Renames all occurrences of "plunder/Plunder/PLUNDER" to "loot/Loot/LOOT" across the entire codebase — Java client, Node.js server, tests, and documentation.

### Files changed

**Java (core)**
- `PlayerTurn.java` — `isLootPending()`, `setLootPending()`, `isLootSuccess()`, `setLootSuccess()`, `getPendingLootAttackSum()`, `setPendingLootAttackSum()`, `getPendingLootDefStrength()`, `setPendingLootDefStrength()`
- `GameScreen.java` — overlay UI, watcher text, tutorial constants (`TUTORIAL_STEP_LOOT`, `TUTORIAL_STEP_INFO_LOOT`), tutorial text, stateUpdate sync (`pendingLoot` key), `pendingLootBroadcast` field
- `HeroTutorialSteps.java` — all `"PLUNDER"` hook strings → `"LOOT"`, all user-facing tutorial text
- `StatsScreen.java` — `"Loots"` label, `lootsSuccess`/`lootsFailed` JSON keys
- `listeners/PickingDeckListener.java`, `EnemyDefCardListener.java`, `EnemyKingCardListener.java` — method calls and socket emit

**Server (Node.js)**
- `gameState.js` — `setLootPreview()`, `lootResolved()`, `pendingLoot`, `statLootsSuccess/Failed`, stats output keys
- `index.js` — socket events `lootPreview`/`lootResolved`, `botChooseLoot()`, `botContinueAfterLoot()`
- `bot.js` — `attackAfterLoot()`, all local variables and method calls
- `mcts-sim.js` — action type `'loot'`

**Tests & docs**
- `tests/tutorial.test.js`
- `GLOSSARY.md`, `index.md`, `.github/instructions/game-rules.instructions.md`

Zero remaining `plunder`/`Plunder`/`PLUNDER` occurrences in source, server, tests, or docs.