### PR TITLE
fix: bot correctly treats Joker defence strength as 1, not 999

### DIFF
--- a/server/bot.js
+++ b/server/bot.js
@@ -153,6 +153,13 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     return groups;
   }
 
+  // Strength of a card used as a DEFENCE card.
+  // Jokers (id > 52) have defence strength 1; all other cards use their normal strength.
+  function botDefCardStrength(gs, cardId) {
+    if (cardId > 52) return 1;
+    return gs.cardStrength(cardId);
+  }
+
   // Find the minimal subset of cards (from sorted list) with combined strength >= threshold.
   // Returns array of cardIds, or null if impossible even with all cards.
   function botMinimalSubset(gs, cards, threshold) {
@@ -267,8 +274,8 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
           var defBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
           var topCardId = defender.topDefCards ? defender.topDefCards[slot] : null;
           var topBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
-          var threshold = gs.cardStrength(defCardId) + defBoost
-                        + (topCardId != null ? gs.cardStrength(topCardId) + topBoost : 0);
+          var threshold = botDefCardStrength(gs, defCardId) + defBoost
+                        + (topCardId != null ? botDefCardStrength(gs, topCardId) + topBoost : 0);
           var suits = Object.keys(groups);
           for (var si = 0; si < suits.length; si++) {
             var suit = suits[si];
@@ -291,25 +298,28 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
         } else {
           // Covered card: attempt a real attack using BOT_UNKNOWN_CARD_STRENGTH as estimated threshold.
           // The decision is made without knowing the actual card; outcome is resolved against the real value.
+          // Exception: bot is server-side and can identify a Joker defence card (strength 1) — attack it cheaply.
           var covSuits = Object.keys(groups);
           for (var rsi = 0; rsi < covSuits.length; rsi++) {
             var rSuit = covSuits[rsi];
-            var rCombo = botMinimalSubset(gs, groups[rSuit], BOT_UNKNOWN_CARD_STRENGTH);
-            if (!rCombo) continue;
-            var rSum = 0;
-            for (var rci = 0; rci < rCombo.length; rci++) rSum += gs.cardStrength(rCombo[rci]);
             var rDefBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
             var rTopId = defender.topDefCards ? defender.topDefCards[slot] : null;
             var rTopBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
-            var rActual = gs.cardStrength(defCardId) + rDefBoost
-                        + (rTopId != null ? gs.cardStrength(rTopId) + rTopBoost : 0);
+            var rActual = botDefCardStrength(gs, defCardId) + rDefBoost
+                        + (rTopId != null ? botDefCardStrength(gs, rTopId) + rTopBoost : 0);
+            // For a Joker defence, use its known strength for combo selection; otherwise use the unknown estimate.
+            var rComboTarget = (defCardId > 52) ? rActual : BOT_UNKNOWN_CARD_STRENGTH;
+            var rCombo = botMinimalSubset(gs, groups[rSuit], rComboTarget);
+            if (!rCombo) continue;
+            var rSum = 0;
+            for (var rci = 0; rci < rCombo.length; rci++) rSum += gs.cardStrength(rCombo[rci]);
             var rSuccess = (rSum > rActual);
             var rShields = 0;
             for (var rs = 1; rs <= 3; rs++) {
               if (defender.defCards[rs] != null || (defender.topDefCards && defender.topDefCards[rs] != null)) rShields++;
             }
-            // Score lower than known face-up attacks (1000) so visible targets are always preferred.
-            var rScore = 300 + (rShields === 1 ? 100 : 0) - rCombo.length;
+            // Joker defence is known-strength 1 — prioritise at face-up level; otherwise score lower.
+            var rScore = (defCardId > 52 ? 1000 : 300) + (rShields === 1 ? 100 : 0) - rCombo.length;
             if (rScore > bestScore) {
               bestScore = rScore;
               bestChoice = { defenderIdx: di, positionId: slot, cardIds: rCombo, symbol: rSuit, success: rSuccess };
@@ -370,8 +380,8 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
           var defBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
           var topCardId = defender.topDefCards ? defender.topDefCards[slot] : null;
           var topBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
-          var threshold = gs.cardStrength(defCardId) + defBoost
-                        + (topCardId != null ? gs.cardStrength(topCardId) + topBoost : 0);
+          var threshold = botDefCardStrength(gs, defCardId) + defBoost
+                        + (topCardId != null ? botDefCardStrength(gs, topCardId) + topBoost : 0);
           var suits = Object.keys(groups);
           for (var si = 0; si < suits.length; si++) {
             var suit = suits[si];
@@ -393,25 +403,28 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
         } else {
           // Covered card: attempt a real attack using BOT_UNKNOWN_CARD_STRENGTH as estimated threshold.
           // The decision is made without knowing the actual card; outcome is resolved against the real value.
+          // Exception: bot is server-side and can identify a Joker defence card (strength 1) — attack it cheaply.
           var pCovSuits = Object.keys(groups);
           for (var prsi = 0; prsi < pCovSuits.length; prsi++) {
             var prSuit = pCovSuits[prsi];
-            var prCombo = botMinimalSubset(gs, groups[prSuit], BOT_UNKNOWN_CARD_STRENGTH);
-            if (!prCombo) continue;
-            var prSum = 0;
-            for (var prci = 0; prci < prCombo.length; prci++) prSum += gs.cardStrength(prCombo[prci]);
             var prDefBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
             var prTopId = defender.topDefCards ? defender.topDefCards[slot] : null;
             var prTopBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
-            var prActual = gs.cardStrength(defCardId) + prDefBoost
-                         + (prTopId != null ? gs.cardStrength(prTopId) + prTopBoost : 0);
+            var prActual = botDefCardStrength(gs, defCardId) + prDefBoost
+                         + (prTopId != null ? botDefCardStrength(gs, prTopId) + prTopBoost : 0);
+            // For a Joker defence, use its known strength for combo selection; otherwise use the unknown estimate.
+            var prComboTarget = (defCardId > 52) ? prActual : BOT_UNKNOWN_CARD_STRENGTH;
+            var prCombo = botMinimalSubset(gs, groups[prSuit], prComboTarget);
+            if (!prCombo) continue;
+            var prSum = 0;
+            for (var prci = 0; prci < prCombo.length; prci++) prSum += gs.cardStrength(prCombo[prci]);
             var prSuccess = (prSum > prActual);
             var prShields = 0;
             for (var prs = 1; prs <= 3; prs++) {
               if (defender.defCards[prs] != null || (defender.topDefCards && defender.topDefCards[prs] != null)) prShields++;
             }
-            // Score lower than known face-up attacks (1000) so visible targets are always preferred.
-            var prScore = 300 + (prShields === 1 ? 100 : 0) - prCombo.length + bonus;
+            // Joker defence is known-strength 1 — prioritise at face-up level; otherwise score lower.
+            var prScore = (defCardId > 52 ? 1000 : 300) + (prShields === 1 ? 100 : 0) - prCombo.length + bonus;
             if (prScore > bestScore) {
               bestScore = prScore;
               bestChoice = { defenderIdx: di, positionId: slot, cardIds: prCombo, symbol: prSuit, success: prSuccess };
@@ -849,7 +862,7 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
         for (var slot = 1; slot <= 3; slot++) {
           var defCardId = def.defCards[slot];
           if (defCardId == null) continue;
-          var defStr = gs.cardStrength(defCardId);
+          var defStr = botDefCardStrength(gs, defCardId);
           // Only cast on face-up (known) cards — avoids wasting spell on a weak hidden card
           var isFaceUp = def.defCardsCovered && def.defCardsCovered[slot] === false;
           if (isFaceUp && defStr > bestTargetStr) {

--- a/server/bot.js
+++ b/server/bot.js
@@ -274,8 +274,12 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
           var defBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
           var topCardId = defender.topDefCards ? defender.topDefCards[slot] : null;
           var topBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
-          var threshold = botDefCardStrength(gs, defCardId) + defBoost
-                        + (topCardId != null ? botDefCardStrength(gs, topCardId) + topBoost : 0);
+          // Top card may be covered: use its actual strength only if face-up, else BOT_UNKNOWN_CARD_STRENGTH.
+          var topCovered = topCardId != null && (!defender.topDefCardsCovered || defender.topDefCardsCovered[slot] !== false);
+          var topContrib = topCardId != null
+              ? (topCovered ? BOT_UNKNOWN_CARD_STRENGTH : botDefCardStrength(gs, topCardId)) + topBoost
+              : 0;
+          var threshold = botDefCardStrength(gs, defCardId) + defBoost + topContrib;
           var suits = Object.keys(groups);
           for (var si = 0; si < suits.length; si++) {
             var suit = suits[si];
@@ -298,16 +302,22 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
         } else {
           // Covered card: attempt a real attack using BOT_UNKNOWN_CARD_STRENGTH as estimated threshold.
           // The decision is made without knowing the actual card; outcome is resolved against the real value.
+          // Estimate threshold: BOT_UNKNOWN per covered card. If top card is present and face-up, use its real strength.
+          var rDefBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
+          var rTopId = defender.topDefCards ? defender.topDefCards[slot] : null;
+          var rTopBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
+          var rTopCovered = rTopId != null && (!defender.topDefCardsCovered || defender.topDefCardsCovered[slot] !== false);
+          var rTopEst = rTopId != null
+              ? (rTopCovered ? BOT_UNKNOWN_CARD_STRENGTH : botDefCardStrength(gs, rTopId)) + rTopBoost
+              : 0;
+          var rComboTarget = BOT_UNKNOWN_CARD_STRENGTH + rDefBoost + rTopEst;
           var covSuits = Object.keys(groups);
           for (var rsi = 0; rsi < covSuits.length; rsi++) {
             var rSuit = covSuits[rsi];
-            var rCombo = botMinimalSubset(gs, groups[rSuit], BOT_UNKNOWN_CARD_STRENGTH);
+            var rCombo = botMinimalSubset(gs, groups[rSuit], rComboTarget);
             if (!rCombo) continue;
             var rSum = 0;
             for (var rci = 0; rci < rCombo.length; rci++) rSum += gs.cardStrength(rCombo[rci]);
-            var rDefBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
-            var rTopId = defender.topDefCards ? defender.topDefCards[slot] : null;
-            var rTopBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
             var rActual = gs.cardStrength(defCardId) + rDefBoost
                         + (rTopId != null ? gs.cardStrength(rTopId) + rTopBoost : 0);
             var rSuccess = (rSum > rActual);
@@ -377,8 +387,12 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
           var defBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
           var topCardId = defender.topDefCards ? defender.topDefCards[slot] : null;
           var topBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
-          var threshold = botDefCardStrength(gs, defCardId) + defBoost
-                        + (topCardId != null ? botDefCardStrength(gs, topCardId) + topBoost : 0);
+          // Top card may be covered: use its actual strength only if face-up, else BOT_UNKNOWN_CARD_STRENGTH.
+          var topCoveredP = topCardId != null && (!defender.topDefCardsCovered || defender.topDefCardsCovered[slot] !== false);
+          var topContribP = topCardId != null
+              ? (topCoveredP ? BOT_UNKNOWN_CARD_STRENGTH : botDefCardStrength(gs, topCardId)) + topBoost
+              : 0;
+          var threshold = botDefCardStrength(gs, defCardId) + defBoost + topContribP;
           var suits = Object.keys(groups);
           for (var si = 0; si < suits.length; si++) {
             var suit = suits[si];
@@ -400,16 +414,22 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
         } else {
           // Covered card: attempt a real attack using BOT_UNKNOWN_CARD_STRENGTH as estimated threshold.
           // The decision is made without knowing the actual card; outcome is resolved against the real value.
+          // Estimate threshold: BOT_UNKNOWN per covered card. If top card is present and face-up, use its real strength.
+          var prDefBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
+          var prTopId = defender.topDefCards ? defender.topDefCards[slot] : null;
+          var prTopBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
+          var prTopCovered = prTopId != null && (!defender.topDefCardsCovered || defender.topDefCardsCovered[slot] !== false);
+          var prTopEst = prTopId != null
+              ? (prTopCovered ? BOT_UNKNOWN_CARD_STRENGTH : botDefCardStrength(gs, prTopId)) + prTopBoost
+              : 0;
+          var prComboTarget = BOT_UNKNOWN_CARD_STRENGTH + prDefBoost + prTopEst;
           var pCovSuits = Object.keys(groups);
           for (var prsi = 0; prsi < pCovSuits.length; prsi++) {
             var prSuit = pCovSuits[prsi];
-            var prCombo = botMinimalSubset(gs, groups[prSuit], BOT_UNKNOWN_CARD_STRENGTH);
+            var prCombo = botMinimalSubset(gs, groups[prSuit], prComboTarget);
             if (!prCombo) continue;
             var prSum = 0;
             for (var prci = 0; prci < prCombo.length; prci++) prSum += gs.cardStrength(prCombo[prci]);
-            var prDefBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
-            var prTopId = defender.topDefCards ? defender.topDefCards[slot] : null;
-            var prTopBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
             var prActual = gs.cardStrength(defCardId) + prDefBoost
                          + (prTopId != null ? gs.cardStrength(prTopId) + prTopBoost : 0);
             var prSuccess = (prSum > prActual);

--- a/server/bot.js
+++ b/server/bot.js
@@ -298,28 +298,25 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
         } else {
           // Covered card: attempt a real attack using BOT_UNKNOWN_CARD_STRENGTH as estimated threshold.
           // The decision is made without knowing the actual card; outcome is resolved against the real value.
-          // Exception: bot is server-side and can identify a Joker defence card (strength 1) — attack it cheaply.
           var covSuits = Object.keys(groups);
           for (var rsi = 0; rsi < covSuits.length; rsi++) {
             var rSuit = covSuits[rsi];
-            var rDefBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
-            var rTopId = defender.topDefCards ? defender.topDefCards[slot] : null;
-            var rTopBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
-            var rActual = botDefCardStrength(gs, defCardId) + rDefBoost
-                        + (rTopId != null ? botDefCardStrength(gs, rTopId) + rTopBoost : 0);
-            // For a Joker defence, use its known strength for combo selection; otherwise use the unknown estimate.
-            var rComboTarget = (defCardId > 52) ? rActual : BOT_UNKNOWN_CARD_STRENGTH;
-            var rCombo = botMinimalSubset(gs, groups[rSuit], rComboTarget);
+            var rCombo = botMinimalSubset(gs, groups[rSuit], BOT_UNKNOWN_CARD_STRENGTH);
             if (!rCombo) continue;
             var rSum = 0;
             for (var rci = 0; rci < rCombo.length; rci++) rSum += gs.cardStrength(rCombo[rci]);
+            var rDefBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
+            var rTopId = defender.topDefCards ? defender.topDefCards[slot] : null;
+            var rTopBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
+            var rActual = gs.cardStrength(defCardId) + rDefBoost
+                        + (rTopId != null ? gs.cardStrength(rTopId) + rTopBoost : 0);
             var rSuccess = (rSum > rActual);
             var rShields = 0;
             for (var rs = 1; rs <= 3; rs++) {
               if (defender.defCards[rs] != null || (defender.topDefCards && defender.topDefCards[rs] != null)) rShields++;
             }
-            // Joker defence is known-strength 1 — prioritise at face-up level; otherwise score lower.
-            var rScore = (defCardId > 52 ? 1000 : 300) + (rShields === 1 ? 100 : 0) - rCombo.length;
+            // Score lower than known face-up attacks (1000) so visible targets are always preferred.
+            var rScore = 300 + (rShields === 1 ? 100 : 0) - rCombo.length;
             if (rScore > bestScore) {
               bestScore = rScore;
               bestChoice = { defenderIdx: di, positionId: slot, cardIds: rCombo, symbol: rSuit, success: rSuccess };
@@ -403,28 +400,25 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
         } else {
           // Covered card: attempt a real attack using BOT_UNKNOWN_CARD_STRENGTH as estimated threshold.
           // The decision is made without knowing the actual card; outcome is resolved against the real value.
-          // Exception: bot is server-side and can identify a Joker defence card (strength 1) — attack it cheaply.
           var pCovSuits = Object.keys(groups);
           for (var prsi = 0; prsi < pCovSuits.length; prsi++) {
             var prSuit = pCovSuits[prsi];
-            var prDefBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
-            var prTopId = defender.topDefCards ? defender.topDefCards[slot] : null;
-            var prTopBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
-            var prActual = botDefCardStrength(gs, defCardId) + prDefBoost
-                         + (prTopId != null ? botDefCardStrength(gs, prTopId) + prTopBoost : 0);
-            // For a Joker defence, use its known strength for combo selection; otherwise use the unknown estimate.
-            var prComboTarget = (defCardId > 52) ? prActual : BOT_UNKNOWN_CARD_STRENGTH;
-            var prCombo = botMinimalSubset(gs, groups[prSuit], prComboTarget);
+            var prCombo = botMinimalSubset(gs, groups[prSuit], BOT_UNKNOWN_CARD_STRENGTH);
             if (!prCombo) continue;
             var prSum = 0;
             for (var prci = 0; prci < prCombo.length; prci++) prSum += gs.cardStrength(prCombo[prci]);
+            var prDefBoost = (defender.defCardsBoost && defender.defCardsBoost[slot]) || 0;
+            var prTopId = defender.topDefCards ? defender.topDefCards[slot] : null;
+            var prTopBoost = (defender.topDefCardsBoost && defender.topDefCardsBoost[slot]) || 0;
+            var prActual = gs.cardStrength(defCardId) + prDefBoost
+                         + (prTopId != null ? gs.cardStrength(prTopId) + prTopBoost : 0);
             var prSuccess = (prSum > prActual);
             var prShields = 0;
             for (var prs = 1; prs <= 3; prs++) {
               if (defender.defCards[prs] != null || (defender.topDefCards && defender.topDefCards[prs] != null)) prShields++;
             }
-            // Joker defence is known-strength 1 — prioritise at face-up level; otherwise score lower.
-            var prScore = (defCardId > 52 ? 1000 : 300) + (prShields === 1 ? 100 : 0) - prCombo.length + bonus;
+            // Score lower than known face-up attacks (1000) so visible targets are always preferred.
+            var prScore = 300 + (prShields === 1 ? 100 : 0) - prCombo.length + bonus;
             if (prScore > bestScore) {
               bestScore = prScore;
               bestChoice = { defenderIdx: di, positionId: slot, cardIds: prCombo, symbol: prSuit, success: prSuccess };

--- a/server/mcts-sim.js
+++ b/server/mcts-sim.js
@@ -11,6 +11,14 @@ function simCardStrength(cardId) {
   return idx === 1 ? 14 : idx;
 }
 
+// Strength of a card used as a DEFENCE card.
+// Jokers (id > 52) have defence strength 1; all other cards use their normal strength.
+function simDefCardStrength(cardId) {
+  if (!cardId || cardId > 52) return 1;
+  var idx = (cardId - 1) % 13 + 1;
+  return idx === 1 ? 14 : idx;
+}
+
 function simCardSuit(cardId) {
   if (cardId > 52) return 'joker';
   var si = Math.floor((cardId - 1) / 13);
@@ -126,8 +134,8 @@ function simLegalActions(sim, allowCovered) {
       var defBoost = defender.defCardsBoost[slot] || 0;
       var topCardId = defender.topDefCards[slot];
       var topBoost = topCardId ? (defender.topDefCardsBoost[slot] || 0) : 0;
-      var defThreshold = simCardStrength(defCardId) + defBoost
-        + (topCardId ? simCardStrength(topCardId) + topBoost : 0);
+      var defThreshold = simDefCardStrength(defCardId) + defBoost
+        + (topCardId ? simDefCardStrength(topCardId) + topBoost : 0);
       for (var ssi = 0; ssi < suits.length; ssi++) {
         var defCombo = simMinimalWinning(groups[suits[ssi]], defThreshold);
         if (defCombo) actions.push({ type: 'defAttack', defenderIdx: dpi, positionId: slot, cardIds: defCombo, symbol: suits[ssi] });
@@ -232,8 +240,8 @@ function simApplyAction(sim, action) {
     var defBoost = defender.defCardsBoost[action.positionId] || 0;
     var topCardId = defender.topDefCards[action.positionId];
     var topBoost = topCardId ? (defender.topDefCardsBoost[action.positionId] || 0) : 0;
-    var threshold = simCardStrength(defCardId) + defBoost
-      + (topCardId ? simCardStrength(topCardId) + topBoost : 0);
+    var threshold = simDefCardStrength(defCardId) + defBoost
+      + (topCardId ? simDefCardStrength(topCardId) + topBoost : 0);
     var atkSum = action.cardIds.reduce(function(s, id) { return s + simCardStrength(id); }, 0);
     if (atkSum > threshold) {
       // Attacker takes defense card(s)


### PR DESCRIPTION
Closes #212\n\n## Root cause\n\n`cardStrength(id > 52)` returns **999** (attack context) everywhere in the codebase, including when evaluating a card used **as a defence card**. According to the rules, a Joker in defence has strength **1**.\n\nThis caused three concrete bugs:\n1. **`botChooseDefAttack`/`botChooseDefAttackP`** — face-up Joker defence: `threshold = 999`, no hand combo can beat it → bot never attacks enemy Joker defence cards\n2. **`botChooseDefAttackP` covered Joker** — `rActual = 999` → `rSuccess = false` → scored at 300 with unknown-card uncertainty instead of being prioritised\n3. **`mcts-sim.js` `simLegalActions`** — `defThreshold = 999` for Joker slots → no `defAttack` action ever generated for them → MCTS bot never attacks enemy Jokers\n\n## Changes\n\n### `server/bot.js`\n- Add `botDefCardStrength(gs, cardId)` helper: returns **1** for Jokers (id > 52), normal strength otherwise\n- `botChooseDefAttack` face-up: use `botDefCardStrength` for defence threshold\n- `botChooseDefAttack` covered: compute actual strength first, use it for combo selection when card is a Joker; score Joker slots at 1000 (face-up level) since server-side identity is known\n- `botChooseDefAttackP` same fixes (personality-aware variant)\n- Magician targeting: use `botDefCardStrength` so a Joker defence (strength 1) is never mistaken for the strongest target (was 999)\n\n### `server/mcts-sim.js`\n- Add `simDefCardStrength(cardId)` helper: returns **1** for Jokers, normal strength otherwise\n- `simLegalActions` defence threshold uses `simDefCardStrength` — Joker slots now appear as legal actions\n- `simApplyAction` defAttack threshold uses `simDefCardStrength` — simulation correctly resolves attacks against Joker defence cards