### PR TITLE
feat: add Random hero option in lobby with guaranteed unique assignment

### DIFF
--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -197,6 +197,7 @@ public class MenuScreen extends AbstractScreen {
 
     // Starting hero selector (for testing)
     Array<String> heroNames = new Array<String>();
+    heroNames.add("Random");
     heroNames.add("None");
     heroNames.add("Mercenaries");
     heroNames.add("Marshal");
@@ -213,7 +214,8 @@ public class MenuScreen extends AbstractScreen {
 
     heroSelectBox = new SelectBox<String>(MyGdxGame.skin);
     heroSelectBox.setItems(heroNames);
-    heroSelectBox.setSelected("None");
+    heroSelectBox.setSelected("Random");
+    menuState.setStartingHero("Random");
     heroSelectBox.setSize(140f, 44f);
     heroSelectBox.setPosition((MyGdxGame.WIDTH - heroSelectBox.getWidth()) / 2f, 0.21f * MyGdxGame.HEIGHT);
     heroSelectBox.addListener(new ChangeListener() {
@@ -252,11 +254,12 @@ public class MenuScreen extends AbstractScreen {
   }
 
   /**
-   * Build a dropdown item list containing "None" plus all heroes not reserved by others,
-   * always including {@code currentSelection} so the current value stays visible.
+   * Build a dropdown item list containing "Random", "None", plus all heroes not reserved by
+   * others, always including {@code currentSelection} so the current value stays visible.
    */
   private Array<String> buildHeroDropdownItems(String currentSelection) {
     Array<String> items = new Array<String>();
+    items.add("Random");
     items.add("None");
     for (int i = 0; i < ALL_HERO_NAMES.length; i++) {
       String h = ALL_HERO_NAMES[i];
@@ -274,9 +277,10 @@ public class MenuScreen extends AbstractScreen {
    */
   private void refreshHeroDropdown() {
     String currentSelected = heroSelectBox.getSelected();
-    // Treat null (empty SelectBox) the same as "None" so we don't wipe startingHero.
-    if (currentSelected == null) currentSelected = "None";
+    // Treat null (empty SelectBox) the same as "Random" so we don't wipe startingHero.
+    if (currentSelected == null) currentSelected = "Random";
     Array<String> items = new Array<String>();
+    items.add("Random");
     items.add("None");
     for (int i = 0; i < ALL_HERO_NAMES.length; i++) {
       if (!reservedByOthers.contains(ALL_HERO_NAMES[i])) {
@@ -285,15 +289,15 @@ public class MenuScreen extends AbstractScreen {
     }
     updatingDropdown = true;
     heroSelectBox.setItems(items);
-    // Keep the previous selection if it is still available; otherwise fall back to "None".
-    if (!currentSelected.equals("None") && !reservedByOthers.contains(currentSelected)) {
+    // Keep the previous selection if it is still available; otherwise fall back to "Random".
+    if (currentSelected.equals("Random") || currentSelected.equals("None")) {
       heroSelectBox.setSelected(currentSelected);
-    } else if (!currentSelected.equals("None")) {
-      // Hero was reserved by another player — reset.
-      heroSelectBox.setSelected("None");
-      menuState.setStartingHero("None");
+    } else if (!reservedByOthers.contains(currentSelected)) {
+      heroSelectBox.setSelected(currentSelected);
     } else {
-      heroSelectBox.setSelected("None");
+      // Hero was reserved by another player — reset to Random.
+      heroSelectBox.setSelected("Random");
+      menuState.setStartingHero("Random");
     }
     updatingDropdown = false;
   }
@@ -1448,7 +1452,7 @@ public class MenuScreen extends AbstractScreen {
             User u = menuState.getUsers().get(j);
             if (!u.getUserID().equals(menuState.getMyUserID())) {
               String h = u.getSelectedHero();
-              if (!h.equals("None")) reservedByOthers.add(h);
+              if (!h.equals("None") && !h.equals("Random")) reservedByOthers.add(h);
             }
           }
           updateScreen = true;
@@ -1720,6 +1724,8 @@ public class MenuScreen extends AbstractScreen {
               if (!sessId.isEmpty()) MyGdxGame.playerStorage.saveSessionId(sessId);
             } catch (Exception e) { /* keep default */ }
             lobbyJoined = true;
+            // Notify server of our initial hero selection (default: Random).
+            socket.emit("heroSelected", menuState.getStartingHero());
             updateScreen = true;
           }
         });

--- a/server/index.js
+++ b/server/index.js
@@ -188,10 +188,32 @@ function startGameForSession(sess, requesterSocketId) {
   sess.gameState = new GameState(sess.users, { startingCards: sess.startingCards, manualSetup: sess.manualSetup });
 
   // Apply lobby starting hero selections before initial gameState broadcast.
+  // Players who selected a specific hero get it directly; players who selected
+  // "Random" are assigned a unique hero from the remaining pool (shuffled).
+  var ALL_HERO_POOL = [
+    'Mercenaries', 'Marshal', 'Spy', 'Battery Tower', 'Merchant', 'Priest',
+    'Reservists', 'Banneret', 'Saboteurs', 'Fortified Tower', 'Magician', 'Warlord'
+  ];
+  var takenHeroes = {};
+  sess.users.forEach(function(u) {
+    var hero = sess.heroSelections[u.id];
+    if (hero && hero !== 'None' && hero !== 'Random') takenHeroes[hero] = true;
+  });
+  var randomPool = ALL_HERO_POOL.filter(function(h) { return !takenHeroes[h]; });
+  // Fisher-Yates shuffle
+  for (var ri = randomPool.length - 1; ri > 0; ri--) {
+    var rj = Math.floor(Math.random() * (ri + 1));
+    var tmp = randomPool[ri]; randomPool[ri] = randomPool[rj]; randomPool[rj] = tmp;
+  }
+  var randomIdx = 0;
   sess.users.forEach(function(u, idx) {
     var hero = sess.heroSelections[u.id];
-    if (hero && hero !== 'None') {
+    if (hero && hero !== 'None' && hero !== 'Random') {
       sess.gameState.heroAcquired(idx, hero);
+    } else if (hero === 'Random') {
+      if (randomIdx < randomPool.length) {
+        sess.gameState.heroAcquired(idx, randomPool[randomIdx++]);
+      }
     }
   });
 
@@ -1439,10 +1461,11 @@ io.on('connection', function(socket) {
     if (!sess) return;
     var oldHero = sess.heroSelections[socket.id] || 'None';
     sess.heroSelections[socket.id] = heroName;
-    if (oldHero !== 'None') {
+    // "Random" does not reserve a specific hero, so don't broadcast heroReserved/heroReleased for it.
+    if (oldHero !== 'None' && oldHero !== 'Random') {
       socket.to(sess.id).emit('heroReleased', { heroName: oldHero });
     }
-    if (heroName !== 'None') {
+    if (heroName !== 'None' && heroName !== 'Random') {
       socket.to(sess.id).emit('heroReserved', { heroName: heroName });
     }
   });
@@ -1458,11 +1481,11 @@ io.on('connection', function(socket) {
     var botUser = sess.users.find(function(u) { return u.id === botUserId && bot.isBot(u); });
     if (!botUser) return;
     var oldHero = sess.heroSelections[botUserId] || 'None';
-    if (oldHero !== 'None') {
+    if (oldHero !== 'None' && oldHero !== 'Random') {
       socket.to(sess.id).emit('heroReleased', { heroName: oldHero });
     }
     sess.heroSelections[botUserId] = heroName;
-    if (heroName !== 'None') {
+    if (heroName !== 'None' && heroName !== 'Random') {
       socket.to(sess.id).emit('heroReserved', { heroName: heroName });
     }
     io.to(sess.id).emit('getUsers', getUsersWithHeroes(sess));


### PR DESCRIPTION
Closes #227

## Changes

### Client (`MenuScreen.java`)
- "Random" added as the **first and default** hero option in the dropdown (above "None")
- `buildHeroDropdownItems` and `refreshHeroDropdown` updated to include "Random" at the top
- When a player's specific hero gets taken by another player, they fall back to "Random" (not "None")
- "Random" is excluded from `reservedByOthers` — it never blocks other players' dropdowns
- On lobby join the initial hero selection ("Random") is sent to the server immediately

### Server (`index.js`)
- `heroSelected` / `setBotHeroSelection`: "Random" no longer emits `heroReserved`/`heroReleased` to other clients (it doesn't claim a specific hero)
- `startGameForSession`: players with "Random" are assigned a unique hero from the remaining pool using a Fisher-Yates shuffle, after all specific selections are reserved first