### PR TITLE
Fix duplicate loot/expose-card actions and rename "plundering" to "looting" in history log

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -4055,6 +4055,12 @@ public class GameScreen extends ScreenAdapter {
     float stageW = MyGdxGame.WIDTH;
     float stageH = MyGdxGame.HEIGHT - MyGdxGame.WIDTH;
 
+    // Wrap all overlay actors in a Group so we can remove them instantly on the
+    // first tap — eliminating the "frozen" appearance while the render loop catches up.
+    final com.badlogic.gdx.scenes.scene2d.Group overlayGroup =
+        new com.badlogic.gdx.scenes.scene2d.Group();
+    overlayGroup.setSize(stageW, stageH);
+
     Image bg = new Image(MyGdxGame.skin, "white");
     bg.setSize(stageW, stageH);
     bg.setPosition(0, 0);
@@ -4063,12 +4069,12 @@ public class GameScreen extends ScreenAdapter {
     // slot button click in any race condition (recurring bug: "finish turn does
     // nothing" when the user taps the expose slot button).
     bg.setTouchable(com.badlogic.gdx.scenes.scene2d.Touchable.disabled);
-    handStage.addActor(bg);
+    overlayGroup.addActor(bg);
 
     Label prompt = new Label("No attack -- expose a defense card:", MyGdxGame.skin);
     prompt.setColor(Color.YELLOW);
     prompt.setPosition(stageW / 2f - prompt.getPrefWidth() / 2f, stageH - prompt.getPrefHeight() - 6);
-    handStage.addActor(prompt);
+    overlayGroup.addActor(prompt);
 
     float btnW = stageW / 4f;
     float btnX = 4;
@@ -4094,11 +4100,12 @@ public class GameScreen extends ScreenAdapter {
         // (recurring bug: "select card to expose, nothing happens").
         @Override
         public boolean touchDown(InputEvent event, float x, float y, int pointer, int button) {
+          overlayGroup.remove(); // immediate visual feedback — don't wait for render loop
           submitExposeAndFinishTurn(finalSlot);
           return true;
         }
       });
-      handStage.addActor(slotBtn);
+      overlayGroup.addActor(slotBtn);
       buttonsAdded++;
     }
     // Fallback: if no covered slots exist, automatically cancel expose and end turn.
@@ -4114,6 +4121,8 @@ public class GameScreen extends ScreenAdapter {
         ftData.put("currentPlayerIndex", gameState.getCurrentPlayerIndex());
         socket.emit("finishTurn", ftData);
       } catch (JSONException ex) { ex.printStackTrace(); }
+    } else {
+      handStage.addActor(overlayGroup);
     }
   }
 

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -1744,6 +1744,7 @@ public class GameScreen extends ScreenAdapter {
       overlay.addListener(new ClickListener() {
         @Override
         public void clicked(InputEvent event, float x, float y) {
+          if (!pt.isLootPending()) return; // guard against double-tap before re-render
           final int deckIdx = pt.getPendingPickingDeckIndex();
           PickingDeck thisD = gameState.getPickingDecks().get(deckIdx);
           PickingDeck otherD = gameState.getPickingDecks().get(1 - deckIdx);

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -528,7 +528,7 @@ class GameState {
     if (kingUsed) { attacker.kingCovered = false; attacker.statKingUsed = (attacker.statKingUsed || 0) + 1; }
     if (success) {
       attacker.statPlundersSuccess = (attacker.statPlundersSuccess || 0) + 1;
-      this.pushLog(`${this.pname(attackerIdx)} plundered deck ${deckIdx + 1}! (${plunderAtkSum} vs ${deckDefStrength})`, true);
+      this.pushLog(`${this.pname(attackerIdx)} looted deck ${deckIdx + 1}! (${plunderAtkSum} vs ${deckDefStrength})`, true);
       // Move all cards from plundered deck into attacker's hand
       for (const c of this.pickingDecks[deckIdx]) attacker.hand.push(c.id);
       this.pickingDecks[deckIdx] = [];
@@ -540,7 +540,7 @@ class GameState {
       const c3 = this.pickCard(); if (c3 !== null) this.pickingDecks[deckIdx].push({ id: c3, covered: true });
     } else {
       attacker.statPlundersFailed = (attacker.statPlundersFailed || 0) + 1;
-      this.pushLog(`${this.pname(attackerIdx)} plunder on deck ${deckIdx + 1} failed (${plunderAtkSum} vs ${deckDefStrength})`, false);
+      this.pushLog(`${this.pname(attackerIdx)} loot on deck ${deckIdx + 1} failed (${plunderAtkSum} vs ${deckDefStrength})`, false);
       if (kingUsed) {
         attacker.isOut = true;
         attacker.statRoundEliminatedAt = this.roundNumber;
@@ -708,8 +708,8 @@ class GameState {
         placement: 1,
         roundsUntilOut: this.roundNumber,
         heroesReceived: winner.statHeroesReceived || 0,
-        plundersSuccess: winner.statPlundersSuccess || 0,
-        plundersFailed: winner.statPlundersFailed || 0,
+        lootsSuccess: winner.statPlundersSuccess || 0,
+        lootsFailed: winner.statPlundersFailed || 0,
         attacksSuccess: winner.statAttacksSuccess || 0,
         attacksFailed: winner.statAttacksFailed || 0,
         defeated: winner.statDefeated || 0,
@@ -728,8 +728,8 @@ class GameState {
         placement: playerResults.length + 1,
         roundsUntilOut: p.statRoundEliminatedAt || this.roundNumber,
         heroesReceived: p.statHeroesReceived || 0,
-        plundersSuccess: p.statPlundersSuccess || 0,
-        plundersFailed: p.statPlundersFailed || 0,
+        lootsSuccess: p.statPlundersSuccess || 0,
+        lootsFailed: p.statPlundersFailed || 0,
         attacksSuccess: p.statAttacksSuccess || 0,
         attacksFailed: p.statAttacksFailed || 0,
         defeated: p.statDefeated || 0,

--- a/server/index.js
+++ b/server/index.js
@@ -1322,6 +1322,11 @@ io.on('connection', function(socket) {
   socket.on('lootResolved', function(data) {
     var sess = getSession(socket.id);
     if (!sess || !sess.gameState) return;
+    var socketPlayerIdx = sess.users.findIndex(function(u) { return u.id === socket.id; });
+    if (socketPlayerIdx !== sess.gameState.currentPlayerIndex || data.attackerIdx !== socketPlayerIdx) {
+      console.log("lootResolved rejected: not current player (socket=" + socketPlayerIdx + " attackerIdx=" + data.attackerIdx + " current=" + sess.gameState.currentPlayerIndex + ")");
+      return;
+    }
     console.log("lootResolved: attackerIdx=" + data.attackerIdx + " deckIndex=" + data.deckIndex + " success=" + data.success);
     sess.gameState.lootResolved(data.attackerIdx, data.deckIndex, data.success, data.attackCardIds || [], data.kingUsed || false, data.attackerOwnDefCardIds || []);
     // Auto-finish turn if attacker was eliminated (failed king-used plunder)
@@ -1386,6 +1391,11 @@ io.on('connection', function(socket) {
   socket.on('exposeDefCard', function(data) {
     var sess = getSession(socket.id);
     if (!sess || !sess.gameState) return;
+    var socketPlayerIdx = sess.users.findIndex(function(u) { return u.id === socket.id; });
+    if (socketPlayerIdx !== sess.gameState.currentPlayerIndex || data.playerIdx !== socketPlayerIdx) {
+      console.log("exposeDefCard rejected: not current player (socket=" + socketPlayerIdx + " current=" + sess.gameState.currentPlayerIndex + ")");
+      return;
+    }
     console.log("exposeDefCard: playerIdx=" + data.playerIdx + " slot=" + data.slot);
     sess.gameState.exposeDefCard(data.playerIdx, data.slot);
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());


### PR DESCRIPTION
Closes #229

## Changes

### Bug fixes

**Triple-loot fix (client)** — `GameScreen.java`  
Added `if (!pt.isLootPending()) return;` as the first line of the loot overlay `ClickListener.clicked()`. If the player taps the overlay multiple times before the render loop rebuilds the stage, only the first tap is processed. Subsequent taps fall through the guard while `lootPending` is still `true`, but `setLootPending(false)` is called inside the handler so any re-entry after that returns immediately.

**Triple-loot fix (server)** — `server/index.js`  
The `lootResolved` handler now validates that the emitting socket's player index matches both `currentPlayerIndex` and `data.attackerIdx`. Duplicate events arriving before the state update are rejected with a console warning.

**Triple-expose-card fix (server)** — `server/index.js`  
The `exposeDefCard` handler now validates that the emitting socket's player index matches `currentPlayerIndex` and `data.playerIdx`. Same pattern as the existing guard already in the `finishTurn` handler.

### Terminology rename

**`server/gameState.js`** — Log strings:
- `"plundered deck N!"` → `"looted deck N!"`
- `"plunder on deck N failed"` → `"loot on deck N failed"`

**`server/gameState.js`** — `getGameStats()` output keys:
- `plundersSuccess` / `plundersFailed` → `lootsSuccess` / `lootsFailed`

This also fixes the stats screen always displaying 0 for loot counts — the client (`StatsScreen.java`) was already reading `lootsSuccess`/`lootsFailed` but the server was emitting the old `plundersSuccess`/`plundersFailed` keys.
