### PR TITLE
feat: close lobby and return all players to session list when host leaves before game starts

### DIFF
--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -1739,6 +1739,27 @@ public class MenuScreen extends AbstractScreen {
       }
     });
 
+    socket.on("sessionClosed", new SocketListener() {
+      @Override
+      public void call(Object... args) {
+        Gdx.app.postRunnable(new Runnable() {
+          @Override
+          public void run() {
+            MyGdxGame.playerStorage.clearSessionId();
+            reconnecting = false;
+            reconnectElapsed = 0f;
+            lobbyJoined = false;
+            timerStarted = false;
+            gameRunning = false;
+            showPlayersTab = false;
+            menuState.clearUsers();
+            reservedByOthers.clear();
+            show();
+          }
+        });
+      }
+    });
+
     socket.on("sessionNotFound", new SocketListener() {
       @Override
       public void call(Object... args) {

--- a/server/index.js
+++ b/server/index.js
@@ -290,6 +290,34 @@ function leaveCurrentSession(socket) {
   }
   delete sess.heroSelections[socket.id];
   var userIdx = sess.users.findIndex(function(u) { return u.id === socket.id; });
+
+  // If the creator (users[0]) leaves before the game has started, close the lobby
+  // for everyone — the remaining players cannot start without a host.
+  if (sess.gameState === null && userIdx === 0 && sess.users.length > 1) {
+    io.to(sess.id).emit('sessionClosed', { reason: 'host_left' });
+    // Evict all remaining users from the socket room
+    sess.users.forEach(function(u) {
+      if (u.id === socket.id) return;
+      var s = io.sockets.sockets[u.id];
+      if (s) { s.leave(sess.id); }
+      delete socketToSession[u.id];
+      delete sess.heroSelections[u.id];
+    });
+    sess.spectators.forEach(function(sid) {
+      var s = io.sockets.sockets[sid];
+      if (s) { s.leave(sess.id); }
+      delete socketToSession[sid];
+    });
+    if (sess.timer) clearInterval(sess.timer);
+    delete sessions[sess.id];
+    delete socketToSession[socket.id];
+    socket.leave(sess.id);
+    console.log('Session ' + sess.id + ' closed: host ' + socket.id + ' left pre-game lobby');
+    broadcastSessionList();
+    broadcastPlayerList();
+    return;
+  }
+
   if (userIdx !== -1) sess.users.splice(userIdx, 1);
   var specIdx = sess.spectators.indexOf(socket.id);
   if (specIdx !== -1) sess.spectators.splice(specIdx, 1);


### PR DESCRIPTION
## Summary

When the host (creator) of a lobby leaves before the game starts, remaining players are now kicked back to the session list instead of being stuck in an orphaned lobby.

If the game has already started, the host leaving is treated like any other disconnect — no change to existing behaviour.

## Changes

### `server/index.js` — `leaveCurrentSession`

Added an early-exit path at the top of `leaveCurrentSession`: if the leaving socket is `users[0]` (the host) and `gameState === null` (lobby phase):

1. Emits `sessionClosed` to the entire room before evicting anyone
2. Evicts all remaining users and spectators from the socket room, cleaning up `socketToSession` for each
3. Clears the start countdown timer if running
4. Deletes the session from the map
5. Broadcasts updated session list and player list

### `core/src/com/mygdx/game/MenuScreen.java`

Added a `sessionClosed` socket event handler that mirrors `leftSessionNotReady`: clears saved session ID, resets all lobby flags, and calls `show()` to return the player to the session list.

## Testing

Deployed to https://baisch-game.fly.dev/

Closes #242