### PR TITLE
fix(ui): suppress card zoom during click/tap — hover only

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -4618,8 +4618,14 @@ public class GameScreen extends ScreenAdapter {
   private void attachZoomListener(final Card card) {
     card.addListener(new InputListener() {
       @Override
+      public boolean touchDown(InputEvent event, float x, float y, int pointer, int button) {
+        unzoomCard(card); // dismiss zoom immediately on any click/tap
+        return false; // do not consume — let game-action listeners still fire
+      }
+      @Override
       public void enter(InputEvent event, float x, float y, int pointer, Actor fromActor) {
         if (pointer != -1) return; // mouse hover only, not touch
+        if (Gdx.input.isTouched()) return; // suppress during click/tap (incl. synthetic mouse events from touch)
         if (!nothingSelectedInHand()) return;
         zoomCard(card);
       }
@@ -4638,8 +4644,19 @@ public class GameScreen extends ScreenAdapter {
     final float oy = MyGdxGame.HEIGHT - MyGdxGame.WIDTH;
     card.addListener(new InputListener() {
       @Override
+      public boolean touchDown(InputEvent event, float x, float y, int pointer, int button) {
+        // Dismiss overlay zoom on click/tap: restore card to gameStage if needed
+        if (card.getStage() == overlayStage) {
+          card.setY(card.getY() - oy);
+          gameStage.addActor(card);
+          unzoomCard(card);
+        }
+        return false; // do not consume
+      }
+      @Override
       public void enter(InputEvent event, float x, float y, int pointer, Actor fromActor) {
         if (pointer != -1) return;
+        if (Gdx.input.isTouched()) return; // suppress during click/tap
         if (!nothingSelectedInHand()) return;
         if (card.getStage() == overlayStage) return; // already in overlay (overlayStage re-fired enter)
         card.setY(card.getY() + oy);
@@ -4666,8 +4683,14 @@ public class GameScreen extends ScreenAdapter {
     // players to get stuck after a plunder attempt.
     deck.addListener(new InputListener() {
       @Override
+      public boolean touchDown(InputEvent event, float x, float y, int pointer, int button) {
+        setDeckScale(deck, 1f); // dismiss zoom immediately on click/tap
+        return false; // do not consume — let PickingDeckListener still fire
+      }
+      @Override
       public void enter(InputEvent event, float x, float y, int pointer, Actor fromActor) {
         if (pointer != -1) return;
+        if (Gdx.input.isTouched()) return; // suppress during click/tap (incl. synthetic mouse events from touch)
         if (!nothingSelectedInHand()) return;
         setDeckScale(deck, CARD_ZOOM);
       }


### PR DESCRIPTION
## Problem

The card zoom feature (defence cards, loot/picking decks, king cards) could fire during a click/tap because GWT on touch devices translates taps into synthetic mouse `mouseover` events (`pointer = -1`), bypassing the existing `pointer != -1` guard. This interfered with game actions on those cards.

## Fix

Three `attach*Zoom` methods in `GameScreen.java` each received two changes:

1. **`Gdx.input.isTouched()` guard in `enter`** — if any pointer is currently held down (mouse button or touch finger), skip the zoom. This suppresses the synthetic-mouse-event path on touch devices.

2. **`touchDown` handler that dismisses zoom immediately** — if the user clicks a card that was already zoomed by hover, the zoom is dismissed before the game action fires. Returns `false` in all cases so it does not consume the event and the underlying game-action listener (`PickingDeckListener`, card selection, etc.) still receives the touch.

   For the king overlay zoom (which reparents the card to `overlayStage`), the `touchDown` handler also restores the card back to `gameStage` before dismissing, preventing orphaned actors.

## Testing

Deployed to https://baisch-game.fly.dev/ (v573).

Closes #244