### PR TITLE
fix: state desync quick wins (closes #254)

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -211,6 +211,9 @@ public class GameScreen extends ScreenAdapter {
   // Heartbeat resync: during active gameplay, request a full state resync if no stateUpdate
   // has been received for 30 seconds. Recovers clients that silently get out of sync.
   private float syncHeartbeatTimer = 0f;
+  // Sequence number of the last received stateUpdate. -1 = not yet received.
+  // Used to detect dropped messages and trigger immediate resync.
+  private int lastStateSeq = -1;
   private final ArrayList<Integer> setupKeepIds = new ArrayList<Integer>();
 
   // Textures cached once to avoid leaking a new Texture on every show() call
@@ -298,13 +301,9 @@ public class GameScreen extends ScreenAdapter {
           }
         } catch (JSONException e) { /* ignore malformed packet */ }
         syncHeartbeatTimer = 0f;
-        Gdx.app.postRunnable(new Runnable() {
-          @Override
-          public void run() {
-            applyStateUpdate(data);
-            gameState.setUpdateState(true);
-          }
-        });
+        // Apply stateUpdate immediately, not via postRunnable, so updates are not deferred when tab is backgrounded
+        applyStateUpdate(data);
+        gameState.setUpdateState(true);
       }
     });
 
@@ -5643,7 +5642,21 @@ public class GameScreen extends ScreenAdapter {
         pendingExposeCard = false;
         // Note: turn notification is fired in the socket listener callback (not here)
         // so it works even when the tab is hidden and the render loop is paused.
+        // Reset finishTurnEmitted when the turn transitions back to this client's player.
+        if (serverCurrentIdx == playerIndex) {
+          currentPlayer.getPlayerTurn().setFinishTurnEmitted(false);
+        }
       }
+
+      // Sequence-number gap check: if we skipped a stateUpdate, request an immediate resync.
+      // With WebSocket transport this should not happen, but guards against any transient drop.
+      try {
+        int seq = state.getInt("stateSeq");
+        if (lastStateSeq >= 0 && seq != lastStateSeq + 1) {
+          socket.emit("requestStateSync", new JSONObject());
+        }
+        lastStateSeq = seq;
+      } catch (JSONException ignored) { /* server may not yet send stateSeq */ }
       // Issue #171: track the previous player index here (not only in show()) so that
       // MY_TURN_START fires correctly even when multiple stateUpdates arrive in the same
       // render frame (e.g. the bot plays and finishes its turn synchronously, sending both

--- a/core/src/com/mygdx/game/PlayerTurn.java
+++ b/core/src/com/mygdx/game/PlayerTurn.java
@@ -251,4 +251,10 @@ public class PlayerTurn {
   public int getCoupSwapPendingCardId() { return coupSwapPendingCardId; }
   public void setCoupSwapPendingCardId(int id) { this.coupSwapPendingCardId = id; }
 
+  // Tracks whether finishTurn has been emitted for this turn. Survives show() rebuilds;
+  // reset by applyStateUpdate when the server confirms the turn has transitioned to this player.
+  private boolean finishTurnEmitted = false;
+  public boolean isFinishTurnEmitted() { return finishTurnEmitted; }
+  public void setFinishTurnEmitted(boolean b) { this.finishTurnEmitted = b; }
+
 }

--- a/core/src/com/mygdx/game/listeners/FinishTurnButtonListener.java
+++ b/core/src/com/mygdx/game/listeners/FinishTurnButtonListener.java
@@ -18,12 +18,11 @@ public class FinishTurnButtonListener extends ClickListener {
     this.socket = socket;
   }
 
-  private boolean fired = false;
-
   @Override
   public void clicked(InputEvent event, float x, float y) {
-    if (fired) return;
-    fired = true;
+    // Guard against double-emit: flag lives on PlayerTurn so it survives show() rebuilds.
+    if (gameState.getCurrentPlayer().getPlayerTurn().isFinishTurnEmitted()) return;
+    gameState.getCurrentPlayer().getPlayerTurn().setFinishTurnEmitted(true);
     try {
       JSONObject data = new JSONObject();
       data.put("currentPlayerIndex", gameState.getCurrentPlayerIndex());
@@ -32,7 +31,6 @@ public class FinishTurnButtonListener extends ClickListener {
       e.printStackTrace();
     }
     // Do NOT call setUpdateState(true) here. The server will respond with a stateUpdate
-    // that triggers the re-render. Calling it prematurely rebuilds the button with a
-    // fresh fired=false listener before the server responds, creating a second-tap window.
+    // that triggers the re-render.
   };
 }

--- a/html/src/com/mygdx/game/client/WebSocketClient.java
+++ b/html/src/com/mygdx/game/client/WebSocketClient.java
@@ -22,7 +22,8 @@ public class WebSocketClient implements SocketClient {
   }
 
   private native JavaScriptObject nativeCreate(String url) /*-{
-    return $wnd.io(url, { autoConnect: false });
+    // Force WebSocket transport, no fallback to polling
+    return $wnd.io(url, { autoConnect: false, transports: ['websocket'], upgrade: false });
   }-*/;
 
   @Override

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -30,6 +30,7 @@ class GameState {
     this.firstSetupSubmitter = null; // player index of first manual-setup finisher → becomes starting player
     this.roundNumber = 1;     // incremented each time the full turn order wraps around
     this.eliminationOrder = []; // player indices in elimination order (first out = index 0)
+    this.stateSeq = 0;          // incremented on every serialize(); clients detect gaps
     this.dealCards(startingCards);
     if (manualSetup) {
       this.initPlayerStats(); // init combat counters without placing king/def/cemetery
@@ -1005,6 +1006,7 @@ class GameState {
       pendingHeroAuction: this.pendingHeroAuction || null,
       isTutorial: this.isTutorial || false,
       heroTutorialName: this.heroTutorialName || null,
+      stateSeq: ++this.stateSeq,
     };
   }
 


### PR DESCRIPTION
Addresses the four quick-win root causes identified in #254.

## Changes

### 1. Force WebSocket transport (`WebSocketClient.java`)
`socket.io` was negotiating over HTTP long-polling first (the default), adding 1–2 s of latency on every connect and reconnect. Transport is now locked to `['websocket']` with `upgrade: false`, so the connection is always a true WebSocket from the first request.

### 2. Apply `stateUpdate` synchronously (`GameScreen.java`)
The `stateUpdate` listener was wrapped in `Gdx.app.postRunnable`, deferring state application to the next GDX render frame. Browsers throttle (or completely pause) `requestAnimationFrame` in background tabs, causing other players to wait until the tab was foregrounded again. State is now applied directly in the socket callback.

### 3. Move `fired` flag to `PlayerTurn` (`PlayerTurn.java`, `FinishTurnButtonListener.java`, `GameScreen.java`)
The double-emit guard was a local boolean on the `FinishTurnButtonListener` instance. Every `show()` call rebuilt the UI from scratch, allocating a new listener with `fired = false` — making the guard useless if the server was slow to respond. The flag now lives on `PlayerTurn` so it survives UI rebuilds. It is reset when the server confirms turn ownership returns to this player.

### 4. Add `stateSeq` sequence numbers (`gameState.js`, `GameScreen.java`)
Server auto-increments a `stateSeq` counter on every `serialize()` call. Clients detect gaps and emit `requestStateSync` immediately instead of waiting up to 30 s for the heartbeat timeout.

## Deployed
Live at https://baisch-game.fly.dev/