### PR TITLE
feat: diagnostics instrumentation — roundtrip logging, transport detection, window.baischDiag

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -214,6 +214,9 @@ public class GameScreen extends ScreenAdapter {
   // Sequence number of the last received stateUpdate. -1 = not yet received.
   // Used to detect dropped messages and trigger immediate resync.
   private int lastStateSeq = -1;
+  // Timestamp (ms) set when finishTurn is emitted; cleared when the ack stateUpdate arrives.
+  // Used to measure end-to-end roundtrip latency.
+  public static long finishTurnSentAt = 0L;
   private final ArrayList<Integer> setupKeepIds = new ArrayList<Integer>();
 
   // Textures cached once to avoid leaking a new Texture on every show() call
@@ -304,6 +307,13 @@ public class GameScreen extends ScreenAdapter {
         // Apply stateUpdate immediately, not via postRunnable, so updates are not deferred when tab is backgrounded
         applyStateUpdate(data);
         gameState.setUpdateState(true);
+        // Diagnostic: log roundtrip for finishTurn and stateSeq on every update
+        long csa = data.optLong("clientSentAt", 0L);
+        int seq = data.optInt("stateSeq", -1);
+        if (csa > 0L) {
+          long rt = System.currentTimeMillis() - csa;
+          Gdx.app.log("DIAG", "finishTurn roundtrip: " + rt + "ms (seq=" + seq + ")");
+        }
       }
     });
 
@@ -5653,6 +5663,7 @@ public class GameScreen extends ScreenAdapter {
       try {
         int seq = state.getInt("stateSeq");
         if (lastStateSeq >= 0 && seq != lastStateSeq + 1) {
+          Gdx.app.log("DIAG", "stateSeq gap: expected " + (lastStateSeq + 1) + " got " + seq + " — requesting resync");
           socket.emit("requestStateSync", new JSONObject());
         }
         lastStateSeq = seq;

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -310,9 +310,9 @@ public class GameScreen extends ScreenAdapter {
         // Diagnostic: log roundtrip for finishTurn and stateSeq on every update
         long csa = data.optLong("clientSentAt", 0L);
         int seq = data.optInt("stateSeq", -1);
-        if (csa > 0L) {
-          long rt = System.currentTimeMillis() - csa;
-          Gdx.app.log("DIAG", "finishTurn roundtrip: " + rt + "ms (seq=" + seq + ")");
+        if (csa > 0L && MyGdxGame.onRoundtripRecorded != null) {
+          int rt = (int)(System.currentTimeMillis() - csa);
+          MyGdxGame.onRoundtripRecorded.onRoundtrip(seq, rt);
         }
       }
     });

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -310,9 +310,17 @@ public class GameScreen extends ScreenAdapter {
         // Diagnostic: log roundtrip for finishTurn and stateSeq on every update
         long csa = data.optLong("clientSentAt", 0L);
         int seq = data.optInt("stateSeq", -1);
-        if (csa > 0L && MyGdxGame.onRoundtripRecorded != null) {
+        if (csa > 0L) {
           int rt = (int)(System.currentTimeMillis() - csa);
-          MyGdxGame.onRoundtripRecorded.onRoundtrip(seq, rt);
+          if (MyGdxGame.onRoundtripRecorded != null) {
+            MyGdxGame.onRoundtripRecorded.onRoundtrip(seq, rt);
+          }
+          try {
+            JSONObject diag = new JSONObject();
+            diag.put("seq", seq);
+            diag.put("ms", rt);
+            GameScreen.this.socket.emit("diagRoundtrip", diag);
+          } catch (JSONException e) { /* never thrown */ }
         }
       }
     });

--- a/core/src/com/mygdx/game/MyGdxGame.java
+++ b/core/src/com/mygdx/game/MyGdxGame.java
@@ -11,6 +11,7 @@ import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 
 // IO removed (platform-specific)
+import com.mygdx.game.net.DiagListener;
 import com.mygdx.game.net.SocketClient;
 
 public class MyGdxGame extends Game implements InputProcessor {
@@ -66,6 +67,8 @@ public class MyGdxGame extends Game implements InputProcessor {
   public static Runnable onNameEntryScreenActive = null;
   /** Called when leaving the name-entry screen; hides the DOM logo overlay. */
   public static Runnable onNameEntryScreenDone = null;
+  /** Called after each finishTurn roundtrip is measured; pushes to window.baischDiag. Null on non-browser platforms. */
+  public static DiagListener onRoundtripRecorded = null;
 
   /** Singleton reference — set in {@link #create()} for JSNI callbacks. */
   public static MyGdxGame INSTANCE;

--- a/core/src/com/mygdx/game/listeners/FinishTurnButtonListener.java
+++ b/core/src/com/mygdx/game/listeners/FinishTurnButtonListener.java
@@ -26,6 +26,7 @@ public class FinishTurnButtonListener extends ClickListener {
     try {
       JSONObject data = new JSONObject();
       data.put("currentPlayerIndex", gameState.getCurrentPlayerIndex());
+      data.put("clientSentAt", System.currentTimeMillis());
       socket.emit("finishTurn", data);
     } catch (JSONException e) {
       e.printStackTrace();

--- a/core/src/com/mygdx/game/net/DiagListener.java
+++ b/core/src/com/mygdx/game/net/DiagListener.java
@@ -1,0 +1,10 @@
+package com.mygdx.game.net;
+
+/**
+ * Callback for diagnostic roundtrip measurements.
+ * Implemented by the HTML platform layer to push data into {@code window.baischDiag}.
+ * No-op on non-browser platforms.
+ */
+public interface DiagListener {
+    void onRoundtrip(int seq, int ms);
+}

--- a/html/src/com/mygdx/game/client/HtmlLauncher.java
+++ b/html/src/com/mygdx/game/client/HtmlLauncher.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.backends.gwt.GwtApplication;
 import com.badlogic.gdx.backends.gwt.GwtApplicationConfiguration;
 import com.google.gwt.user.client.Window;
 import com.mygdx.game.MyGdxGame;
+import com.mygdx.game.net.DiagListener;
 
 public class HtmlLauncher extends GwtApplication {
 
@@ -59,6 +60,12 @@ public class HtmlLauncher extends GwtApplication {
             @Override
             public void run() {
                 setNameEntryLogoVisible(false);
+            }
+        };
+        MyGdxGame.onRoundtripRecorded = new DiagListener() {
+            @Override
+            public void onRoundtrip(int seq, int ms) {
+                WebSocketClient.nativeRecordRoundtrip(seq, ms);
             }
         };
         installAudioUnlocker(app);

--- a/html/src/com/mygdx/game/client/WebSocketClient.java
+++ b/html/src/com/mygdx/game/client/WebSocketClient.java
@@ -19,7 +19,45 @@ public class WebSocketClient implements SocketClient {
     // autoConnect:false so the socket only connects after all listeners are
     // registered (connect() is called at end of configSocketEvents).
     jsSocket = nativeCreate(url);
+    nativeSetupDiag(jsSocket);
   }
+
+  /**
+   * Initialises window.baischDiag and wires up connect/disconnect events for
+   * transport-type logging and DevTools inspection.
+   */
+  private native void nativeSetupDiag(JavaScriptObject sock) /*-{
+    if (!$wnd.baischDiag) {
+      $wnd.baischDiag = {
+        transport: null,
+        connectedAt: null,
+        roundtrips: [],   // last 50 finishTurn roundtrips [{seq,ms,at}]
+        disconnects: [],  // last 10 disconnects [{reason,at}]
+        seqGaps: [],      // [{expected,got,at}]
+        addRoundtrip: function(seq, ms) {
+          this.roundtrips.push({ seq: seq, ms: ms, at: Date.now() });
+          if (this.roundtrips.length > 50) this.roundtrips.shift();
+        },
+        addGap: function(expected, got) {
+          this.seqGaps.push({ expected: expected, got: got, at: Date.now() });
+          console.warn('[Baisch] stateSeq gap: expected ' + expected + ' got ' + got);
+        }
+      };
+    }
+    var diag = $wnd.baischDiag;
+    sock.on('connect', function() {
+      var t = (sock.io && sock.io.engine && sock.io.engine.transport)
+              ? sock.io.engine.transport.name : 'unknown';
+      diag.transport = t;
+      diag.connectedAt = Date.now();
+      console.log('[Baisch] connected via ' + t);
+    });
+    sock.on('disconnect', function(reason) {
+      console.warn('[Baisch] disconnected: ' + reason);
+      diag.disconnects.push({ reason: reason, at: Date.now() });
+      if (diag.disconnects.length > 10) diag.disconnects.shift();
+    });
+  }-*/;
 
   private native JavaScriptObject nativeCreate(String url) /*-{
     // Force WebSocket transport, no fallback to polling

--- a/html/src/com/mygdx/game/client/WebSocketClient.java
+++ b/html/src/com/mygdx/game/client/WebSocketClient.java
@@ -64,6 +64,14 @@ public class WebSocketClient implements SocketClient {
     return $wnd.io(url, { autoConnect: false, transports: ['websocket'], upgrade: false });
   }-*/;
 
+  /** Pushes a finishTurn roundtrip measurement to window.baischDiag and logs to DevTools console. */
+  public static native void nativeRecordRoundtrip(int seq, int ms) /*-{
+    console.log('[Baisch] finishTurn roundtrip: ' + ms + 'ms (seq=' + seq + ')');
+    if ($wnd.baischDiag && $wnd.baischDiag.addRoundtrip) {
+      $wnd.baischDiag.addRoundtrip(seq, ms);
+    }
+  }-*/;
+
   @Override
   public void on(String event, final SocketListener listener) {
     nativeOn(jsSocket, event, listener);

--- a/server/index.js
+++ b/server/index.js
@@ -1318,9 +1318,17 @@ io.on('connection', function(socket) {
     if (clientSentAt) serialized.clientSentAt = clientSentAt;
     var payloadBytes = JSON.stringify(serialized).length;
     var processingMs = Date.now() - serverReceivedAt;
-    console.log('[perf] finishTurn: processing=' + processingMs + 'ms payload=' + payloadBytes + 'B seq=' + serialized.stateSeq);
+    var c2s = clientSentAt ? (serverReceivedAt - clientSentAt) : -1;
+    var c2sStr = c2s >= 0 ? ' c2s=' + c2s + 'ms' : '';
+    console.log('[perf] finishTurn: processing=' + processingMs + 'ms' + c2sStr + ' payload=' + payloadBytes + 'B seq=' + serialized.stateSeq);
     io.to(sess.id).emit('stateUpdate', serialized);
     bot.playBotTurnIfNeeded(sess);
+  });
+
+  socket.on('diagRoundtrip', function(data) {
+    if (!data || typeof data.ms !== 'number') return;
+    var seq = typeof data.seq === 'number' ? data.seq : -1;
+    console.log('[perf] roundtrip: ' + data.ms + 'ms (seq=' + seq + ')');
   });
 
   socket.on('putDefCard', function(data) {

--- a/server/index.js
+++ b/server/index.js
@@ -1278,6 +1278,8 @@ io.on('connection', function(socket) {
   });
 
   socket.on('finishTurn', function(data) {
+    var serverReceivedAt = Date.now();
+    var clientSentAt = (data && typeof data.clientSentAt === 'number') ? data.clientSentAt : 0;
     var sess = getSession(socket.id);
     if (!sess || !sess.gameState) return;
     // Verify by socket identity rather than trusting the client-sent currentPlayerIndex.
@@ -1312,7 +1314,12 @@ io.on('connection', function(socket) {
       }
     }
     sess.gameState.finishTurn();
-    io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
+    var serialized = sess.gameState.serialize();
+    if (clientSentAt) serialized.clientSentAt = clientSentAt;
+    var payloadBytes = JSON.stringify(serialized).length;
+    var processingMs = Date.now() - serverReceivedAt;
+    console.log('[perf] finishTurn: processing=' + processingMs + 'ms payload=' + payloadBytes + 'B seq=' + serialized.stateSeq);
+    io.to(sess.id).emit('stateUpdate', serialized);
     bot.playBotTurnIfNeeded(sess);
   });
 


### PR DESCRIPTION
Adds lightweight instrumentation to measure and diagnose the stability issues tracked in #254.

## What's instrumented

### Client → Server → Client roundtrip for `finishTurn`
- `FinishTurnButtonListener` now stamps `clientSentAt: System.currentTimeMillis()` in the emitted payload.
- The server echoes `clientSentAt` back inside the `stateUpdate` response for the `finishTurn` handler.
- The `stateUpdate` listener in `GameScreen` reads the echo and logs: `DIAG: finishTurn roundtrip: 142ms (seq=15)` — visible in DevTools console.

### Server-side performance logging
- `finishTurn` handler now logs: `[perf] finishTurn: processing=3ms payload=4521B seq=15`
- Gives per-turn visibility into server processing time and payload size growth (tracking root cause #4 — unbounded log payload).

### Transport detection on connect
- `WebSocketClient.nativeSetupDiag()` registers `connect`/`disconnect` listeners that log:
  - `[Baisch] connected via websocket` (or `polling` if the forced-WebSocket fix ever fails)
  - `[Baisch] disconnected: <reason>` with the socket.io disconnect reason

### `window.baischDiag` DevTools object
Type `window.baischDiag` in DevTools console at any time to inspect:
- `transport` — current transport name
- `connectedAt` — timestamp of last connect
- `roundtrips` — ring buffer of last 50 finishTurn roundtrips `[{seq, ms, at}]`
- `disconnects` — last 10 disconnects with reason and timestamp

### Improved stateSeq gap logging
Gap detection now logs the exact expected vs received sequence numbers:
`DIAG: stateSeq gap: expected 14 got 16 — requesting resync`