### PR TITLE
feat: Hero reveal overlay, scrollable hero selector, and hero assignment mode (issue #257)

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -257,14 +257,20 @@ public class GameScreen extends ScreenAdapter {
 
   // New constructor for centralized state
   public GameScreen(Game game, JSONObject centralizedState, int playerIndex, SocketClient socket) {
-    this(game, centralizedState, playerIndex, socket, "None");
+    this(game, centralizedState, playerIndex, socket, "None", "value_mapping");
   }
 
   private String startingHero = "None";
+  private String heroAssignMode = "value_mapping";
 
   public GameScreen(Game game, JSONObject centralizedState, int playerIndex, SocketClient socket, String startingHero) {
+    this(game, centralizedState, playerIndex, socket, startingHero, "value_mapping");
+  }
+
+  public GameScreen(Game game, JSONObject centralizedState, int playerIndex, SocketClient socket, String startingHero, String heroAssignMode) {
     this.game = game;
     this.startingHero = startingHero;
+    this.heroAssignMode = (heroAssignMode != null && !heroAssignMode.isEmpty()) ? heroAssignMode : "value_mapping";
     this.socket = socket;
     // playerIndex == -1 means spectator — display from player 0's viewpoint, read-only
     this.isSpectator = (playerIndex < 0);
@@ -336,6 +342,7 @@ public class GameScreen extends ScreenAdapter {
     final Game theGame = game;
     final SocketClient theSocket = socket;
     final String theStartingHero = startingHero;
+    final String theHeroAssignMode = heroAssignMode;
     socket.on("gameState", new SocketListener() {
       @Override
       public void call(Object... args) {
@@ -347,7 +354,8 @@ public class GameScreen extends ScreenAdapter {
             try {
               int newPlayerIndex = data.getInt("playerIndex");
               JSONObject newState = data.getJSONObject("gameState");
-              theGame.setScreen(new GameScreen(theGame, newState, newPlayerIndex, theSocket, theStartingHero));
+              String newHeroAssignMode = data.optString("heroAssignMode", theHeroAssignMode);
+              theGame.setScreen(new GameScreen(theGame, newState, newPlayerIndex, theSocket, theStartingHero, newHeroAssignMode));
             } catch (Exception e) {
               e.printStackTrace();
             }
@@ -6359,41 +6367,59 @@ public class GameScreen extends ScreenAdapter {
 
     HeroesSquare hs = gameState.getHeroesSquare();
 
-    if ("joker".equals(drawnSym)) {
-      // Another joker drawn — free choice from ALL heroes (pool + already owned).
+    if ("free_selector".equals(heroAssignMode)) {
+      // Always free choice regardless of drawn card.
       triggerHeroChoice(buildHeroChoices(false, false));
-    } else if (drawnIndex == 1) {
-      // Ace: red suits (hearts/diamonds) → white heroes; black → black heroes.
-      boolean isRed = "hearts".equals(drawnSym) || "diamonds".equals(drawnSym);
-      java.util.ArrayList<Hero> choices = isRed
-          ? buildHeroChoices(true, false)
-          : buildHeroChoices(false, true);
-      if (choices.isEmpty()) choices = buildHeroChoices(false, false); // fallback
-      triggerHeroChoice(choices);
+    } else if ("color_mapping".equals(heroAssignMode)) {
+      // Color-based: joker → free choice; red suit → white heroes; black suit → black heroes.
+      if ("joker".equals(drawnSym)) {
+        triggerHeroChoice(buildHeroChoices(false, false));
+      } else {
+        boolean isRed = "hearts".equals(drawnSym) || "diamonds".equals(drawnSym);
+        java.util.ArrayList<Hero> choices = isRed
+            ? buildHeroChoices(true, false)
+            : buildHeroChoices(false, true);
+        if (choices.isEmpty()) choices = buildHeroChoices(false, false); // fallback if pool exhausted
+        triggerHeroChoice(choices);
+      }
     } else {
-      // Direct hero assignment by card index (2-13).
-      Hero hero = hs.getHeroByCardIndex(drawnIndex);
-      if (hero == null) {
-        // That hero is already owned by a player — strip it from the owner.
-        // Per issue #25 the drawing player receives NOTHING.
-        String takenName = HeroesSquare.heroNameByCardIndex(drawnIndex);
-        if (takenName != null) {
-          int ownerIdx = gameState.findHeroOwnerIndex(takenName);
-          if (ownerIdx >= 0) {
-            players.get(ownerIdx).removeHeroByName(takenName);
-            try {
-              JSONObject emitData = new JSONObject();
-              emitData.put("playerIndex", ownerIdx);
-              emitData.put("heroName", takenName);
-              socket.emit("heroLost", emitData);
-            } catch (JSONException e) {
-              e.printStackTrace();
+      // Default "value_mapping": existing behavior.
+      if ("joker".equals(drawnSym)) {
+        // Another joker drawn — free choice from ALL heroes (pool + already owned).
+        triggerHeroChoice(buildHeroChoices(false, false));
+      } else if (drawnIndex == 1) {
+        // Ace: red suits (hearts/diamonds) → white heroes; black → black heroes.
+        boolean isRed = "hearts".equals(drawnSym) || "diamonds".equals(drawnSym);
+        java.util.ArrayList<Hero> choices = isRed
+            ? buildHeroChoices(true, false)
+            : buildHeroChoices(false, true);
+        if (choices.isEmpty()) choices = buildHeroChoices(false, false); // fallback
+        triggerHeroChoice(choices);
+      } else {
+        // Direct hero assignment by card index (2-13).
+        Hero hero = hs.getHeroByCardIndex(drawnIndex);
+        if (hero == null) {
+          // That hero is already owned by a player — strip it from the owner.
+          // Per issue #25 the drawing player receives NOTHING.
+          String takenName = HeroesSquare.heroNameByCardIndex(drawnIndex);
+          if (takenName != null) {
+            int ownerIdx = gameState.findHeroOwnerIndex(takenName);
+            if (ownerIdx >= 0) {
+              players.get(ownerIdx).removeHeroByName(takenName);
+              try {
+                JSONObject emitData = new JSONObject();
+                emitData.put("playerIndex", ownerIdx);
+                emitData.put("heroName", takenName);
+                socket.emit("heroLost", emitData);
+              } catch (JSONException e) {
+                e.printStackTrace();
+              }
             }
           }
+          gameState.setUpdateState(true);
+        } else {
+          completeHeroAcquisition(hero);
         }
-        gameState.setUpdateState(true);
-      } else {
-        completeHeroAcquisition(hero);
       }
     }
   }

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -19,6 +19,7 @@ import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
+import com.badlogic.gdx.scenes.scene2d.utils.SpriteDrawable;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Group;
 import com.badlogic.gdx.scenes.scene2d.EventListener;
@@ -247,6 +248,12 @@ public class GameScreen extends ScreenAdapter {
   private Texture texZoomButton;
   private Image zoomModeBtn;
 
+  // ── Hero reveal overlay (issue #257) ──────────────────────────────────────
+  // Set when any player acquires a hero; cleared when the player dismisses the overlay.
+  private String heroRevealPlayerName  = null;
+  private String heroRevealHeroName    = null;
+  private int    heroRevealDrawnCardId = -1;
+
 
   // New constructor for centralized state
   public GameScreen(Game game, JSONObject centralizedState, int playerIndex, SocketClient socket) {
@@ -363,6 +370,11 @@ public class GameScreen extends ScreenAdapter {
               String heroName = data.getString("heroName");
               if (pIdx != myPlayerIndex) {
                 gameState.applyHeroAcquired(pIdx, heroName);
+                // Trigger reveal overlay for remote player's acquisition.
+                int drawnId = data.optInt("drawnCardId", -1);
+                heroRevealPlayerName  = players.get(pIdx).getPlayerName();
+                heroRevealHeroName    = heroName;
+                heroRevealDrawnCardId = drawnId;
               }
               gameState.setUpdateState(true);
             } catch (JSONException e) {
@@ -2916,31 +2928,16 @@ public class GameScreen extends ScreenAdapter {
 
       Label hsTitle = new Label("Choose your Hero:", MyGdxGame.skin);
       hsTitle.setColor(Color.GOLD);
-      hsTitle.setPosition(MyGdxGame.WIDTH / 2f - hsTitle.getPrefWidth() / 2f, MyGdxGame.WIDTH * 0.78f);
+      hsTitle.setPosition(MyGdxGame.WIDTH / 2f - hsTitle.getPrefWidth() / 2f, MyGdxGame.HEIGHT * 0.86f);
       gameStage.addActor(hsTitle);
 
-      // Layout: compute button width from the widest hero name so text never clips.
-      float maxBtnPrefW = 0f;
-      for (Hero c : choices) {
-        TextButton tb = new TextButton(c.getHeroName(), MyGdxGame.skin);
-        maxBtnPrefW = Math.max(maxBtnPrefW, tb.getPrefWidth());
-      }
-      float btnW = maxBtnPrefW + 20f;
-      int numCols = Math.max(1, (int) ((MyGdxGame.WIDTH - 4f) / (btnW + 8f)));
-      numCols = Math.min(numCols, choices.size());
-      float btnGapX = numCols > 1 ? (MyGdxGame.WIDTH - numCols * btnW) / (numCols - 1) : 0f;
-      float startX  = numCols > 1 ? 0f : (MyGdxGame.WIDTH - btnW) / 2f;
-      float startY  = MyGdxGame.WIDTH * 0.62f;
-      float rowH    = 0f;
-
+      // Single-column Table of hero buttons inside a vertical ScrollPane.
+      Table hsTable = new Table(MyGdxGame.skin);
+      hsTable.defaults().padBottom(6f).fillX();
+      float hsBtnW = MyGdxGame.WIDTH * 0.72f;
       for (int ci = 0; ci < choices.size(); ci++) {
         final Hero choice = choices.get(ci);
         TextButton heroBtn = new TextButton(choice.getHeroName(), MyGdxGame.skin);
-        heroBtn.setSize(btnW, heroBtn.getPrefHeight());
-        if (rowH == 0f) rowH = heroBtn.getPrefHeight() + 8f;
-        int col = ci % numCols;
-        int row = ci / numCols;
-        heroBtn.setPosition(startX + col * (btnW + btnGapX), startY - row * rowH);
         heroBtn.addListener(new ClickListener() {
           @Override
           public void clicked(InputEvent event, float x, float y) {
@@ -2971,8 +2968,19 @@ public class GameScreen extends ScreenAdapter {
             }
           }
         });
-        gameStage.addActor(heroBtn);
+        hsTable.row();
+        hsTable.add(heroBtn).width(hsBtnW);
       }
+
+      float hsScrollH = MyGdxGame.HEIGHT * 0.70f;
+      ScrollPane hsScroll = new ScrollPane(hsTable, MyGdxGame.skin);
+      hsScroll.setScrollingDisabled(true, false);
+      hsScroll.setFadeScrollBars(false);
+      hsScroll.setSize(hsBtnW, hsScrollH);
+      hsScroll.setPosition(
+          MyGdxGame.WIDTH / 2f - hsBtnW / 2f,
+          MyGdxGame.HEIGHT * 0.10f);
+      gameStage.addActor(hsScroll);
     }
 
     // King-defeat hero selection overlay — shown to the attacker when they must pick one of the
@@ -2987,30 +2995,16 @@ public class GameScreen extends ScreenAdapter {
 
       Label kdTitle = new Label("Choose a Hero from the defeated player:", MyGdxGame.skin);
       kdTitle.setColor(Color.GOLD);
-      kdTitle.setPosition(MyGdxGame.WIDTH / 2f - kdTitle.getPrefWidth() / 2f, MyGdxGame.WIDTH * 0.78f);
+      kdTitle.setPosition(MyGdxGame.WIDTH / 2f - kdTitle.getPrefWidth() / 2f, MyGdxGame.HEIGHT * 0.86f);
       gameStage.addActor(kdTitle);
 
-      float maxKdPrefW = 0f;
-      for (String n : kdOptions) {
-        TextButton tb = new TextButton(n, MyGdxGame.skin);
-        maxKdPrefW = Math.max(maxKdPrefW, tb.getPrefWidth());
-      }
-      float btnW = maxKdPrefW + 20f;
-      int numCols = Math.max(1, (int) ((MyGdxGame.WIDTH - 4f) / (btnW + 8f)));
-      numCols = Math.min(numCols, kdOptions.size());
-      float btnGapX = numCols > 1 ? (MyGdxGame.WIDTH - numCols * btnW) / (numCols - 1) : 0f;
-      float startX  = numCols > 1 ? 0f : (MyGdxGame.WIDTH - btnW) / 2f;
-      float startY  = MyGdxGame.WIDTH * 0.62f;
-      float rowH    = 0f;
-
+      // Single-column Table of hero buttons inside a vertical ScrollPane.
+      Table kdTable = new Table(MyGdxGame.skin);
+      kdTable.defaults().padBottom(6f).fillX();
+      float kdBtnW = MyGdxGame.WIDTH * 0.72f;
       for (int ci = 0; ci < kdOptions.size(); ci++) {
         final String heroName = kdOptions.get(ci);
         TextButton heroBtn = new TextButton(heroName, MyGdxGame.skin);
-        heroBtn.setSize(btnW, heroBtn.getPrefHeight());
-        if (rowH == 0f) rowH = heroBtn.getPrefHeight() + 8f;
-        int col = ci % numCols;
-        int row = ci / numCols;
-        heroBtn.setPosition(startX + col * (btnW + btnGapX), startY - row * rowH);
         heroBtn.addListener(new ClickListener() {
           @Override
           public void clicked(InputEvent event, float x, float y) {
@@ -3025,8 +3019,97 @@ public class GameScreen extends ScreenAdapter {
             gameState.setUpdateState(true);
           }
         });
-        gameStage.addActor(heroBtn);
+        kdTable.row();
+        kdTable.add(heroBtn).width(kdBtnW);
       }
+
+      float kdScrollH = MyGdxGame.HEIGHT * 0.70f;
+      ScrollPane kdScroll = new ScrollPane(kdTable, MyGdxGame.skin);
+      kdScroll.setScrollingDisabled(true, false);
+      kdScroll.setFadeScrollBars(false);
+      kdScroll.setSize(kdBtnW, kdScrollH);
+      kdScroll.setPosition(
+          MyGdxGame.WIDTH / 2f - kdBtnW / 2f,
+          MyGdxGame.HEIGHT * 0.10f);
+      gameStage.addActor(kdScroll);
+    }
+
+    // ── Hero reveal overlay (issue #257) ───────────────────────────────────
+    // Shown to every player after any hero acquisition. Dismissed with "Got it!".
+    if (heroRevealPlayerName != null && heroRevealHeroName != null) {
+      final String revealPlayer = heroRevealPlayerName;
+      final String revealHero   = heroRevealHeroName;
+      final int    revealCardId = heroRevealDrawnCardId;
+
+      Image revOv = new Image(MyGdxGame.skin, "white");
+      revOv.setFillParent(true);
+      revOv.setColor(0f, 0f, 0f, 0.82f);
+      gameStage.addActor(revOv);
+
+      // "PlayerName won a Hero!" title
+      Label revTitle = new Label(revealPlayer + " won a Hero!", MyGdxGame.skin);
+      revTitle.setColor(Color.GOLD);
+      revTitle.setPosition(
+          MyGdxGame.WIDTH / 2f - revTitle.getPrefWidth() / 2f,
+          MyGdxGame.HEIGHT * 0.70f);
+      gameStage.addActor(revTitle);
+
+      // Hero sprite — look up the hero in the game state by name.
+      int heroOwnerIdx = gameState.findHeroOwnerIndex(revealHero);
+      if (heroOwnerIdx >= 0) {
+        java.util.ArrayList<Hero> ownerHeroes = gameState.getPlayers().get(heroOwnerIdx).getHeroes();
+        for (int hi = 0; hi < ownerHeroes.size(); hi++) {
+          Hero rh = ownerHeroes.get(hi);
+          if (revealHero.equals(rh.getHeroName())) {
+            float spriteScale = 2.5f;
+            float imgW = rh.getSprite().getWidth() * spriteScale;
+            float imgH = rh.getSprite().getHeight() * spriteScale;
+            Image heroImg = new Image(new SpriteDrawable(rh.getSprite()));
+            heroImg.setSize(imgW, imgH);
+            heroImg.setPosition(
+                MyGdxGame.WIDTH / 2f - imgW / 2f,
+                MyGdxGame.HEIGHT * 0.46f);
+            gameStage.addActor(heroImg);
+            break;
+          }
+        }
+      }
+
+      // Hero name label
+      Label revHeroLabel = new Label(revealHero, MyGdxGame.skin);
+      revHeroLabel.setColor(Color.WHITE);
+      revHeroLabel.setPosition(
+          MyGdxGame.WIDTH / 2f - revHeroLabel.getPrefWidth() / 2f,
+          MyGdxGame.HEIGHT * 0.62f);
+      gameStage.addActor(revHeroLabel);
+
+      // Drawn card (if known)
+      if (revealCardId > 0) {
+        Card revCard = Card.fromCardId(revealCardId);
+        float cardScale = 1.4f;
+        revCard.setSize(revCard.getWidth() * cardScale, revCard.getHeight() * cardScale);
+        revCard.setPosition(
+            MyGdxGame.WIDTH / 2f - revCard.getWidth() / 2f,
+            MyGdxGame.HEIGHT * 0.30f);
+        gameStage.addActor(revCard);
+      }
+
+      // "Got it!" dismiss button
+      TextButton revBtn = new TextButton("Got it!", MyGdxGame.skin);
+      revBtn.pad(8f, 32f, 8f, 32f);
+      revBtn.setPosition(
+          MyGdxGame.WIDTH / 2f - revBtn.getPrefWidth() / 2f,
+          MyGdxGame.HEIGHT * 0.10f);
+      revBtn.addListener(new ClickListener() {
+        @Override
+        public void clicked(InputEvent event, float x, float y) {
+          heroRevealPlayerName  = null;
+          heroRevealHeroName    = null;
+          heroRevealDrawnCardId = -1;
+          gameState.setUpdateState(true);
+        }
+      });
+      gameStage.addActor(revBtn);
     }
 
     // ── Sell Hero setup overlay ─────────────────────────────────────────────
@@ -6252,11 +6335,14 @@ public class GameScreen extends ScreenAdapter {
     Card drawnCard = gameState.getCardDeck().getCard(gameState.getCemeteryDeck());
     // Guard: if deck was empty we get a placeholder — bail out gracefully.
     if (drawnCard == null || drawnCard.isPlaceholder()) {
+      currentPlayer.getPlayerTurn().setPendingDrawnCardId(-1);
       gameState.setUpdateState(true);
       return;
     }
     int drawnIndex   = drawnCard.getIndex();
     String drawnSym  = drawnCard.getSymbol();
+    // Store drawn card ID so completeHeroAcquisition / reveal overlay can reference it.
+    currentPlayer.getPlayerTurn().setPendingDrawnCardId(drawnCard.getCardId());
     // Drawn card goes to the cemetery after its purpose is served.
     gameState.getCemeteryDeck().addCard(drawnCard);
 
@@ -6329,15 +6415,21 @@ public class GameScreen extends ScreenAdapter {
     }
     currentPlayer.getPlayerTurn().setHeroSelectionPending(false);
     currentPlayer.getPlayerTurn().getHeroChoices().clear();
+    int drawnCardId = currentPlayer.getPlayerTurn().getPendingDrawnCardId();
     try {
       JSONObject emitData = new JSONObject();
       emitData.put("playerIndex", playerIndex);
       emitData.put("heroName",    hero.getHeroName());
       emitData.put("jokerCardId", currentPlayer.getPlayerTurn().getPendingJokerCardId());
+      emitData.put("drawnCardId", drawnCardId);
       socket.emit("heroAcquired", emitData);
     } catch (JSONException e) {
       e.printStackTrace();
     }
+    // Trigger reveal overlay for the local player.
+    heroRevealPlayerName = currentPlayer.getPlayerName();
+    heroRevealHeroName   = hero.getHeroName();
+    heroRevealDrawnCardId = drawnCardId;
     gameState.setUpdateState(true);
   }
 

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -19,7 +19,7 @@ import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
-import com.badlogic.gdx.scenes.scene2d.utils.SpriteDrawable;
+
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Group;
 import com.badlogic.gdx.scenes.scene2d.EventListener;
@@ -2924,7 +2924,7 @@ public class GameScreen extends ScreenAdapter {
     }
 
     // Hero selection overlay — shown when the local player must choose a hero
-    // (drawn card was an Ace or another Joker). Renders on top of the game board.
+    // (drawn card was an Ace or another Joker). Renders on top of everything via overlayStage.
     if (currentPlayer.getPlayerTurn().isHeroSelectionPending()) {
       final PlayerTurn hspt = currentPlayer.getPlayerTurn();
       final java.util.ArrayList<Hero> choices = hspt.getHeroChoices();
@@ -2932,12 +2932,12 @@ public class GameScreen extends ScreenAdapter {
       Image hsOverlay = new Image(MyGdxGame.skin, "white");
       hsOverlay.setFillParent(true);
       hsOverlay.setColor(0f, 0f, 0f, 0.78f);
-      gameStage.addActor(hsOverlay);
+      overlayStage.addActor(hsOverlay);
 
       Label hsTitle = new Label("Choose your Hero:", MyGdxGame.skin);
       hsTitle.setColor(Color.GOLD);
       hsTitle.setPosition(MyGdxGame.WIDTH / 2f - hsTitle.getPrefWidth() / 2f, MyGdxGame.HEIGHT * 0.86f);
-      gameStage.addActor(hsTitle);
+      overlayStage.addActor(hsTitle);
 
       // Single-column Table of hero buttons inside a vertical ScrollPane.
       Table hsTable = new Table(MyGdxGame.skin);
@@ -2988,7 +2988,7 @@ public class GameScreen extends ScreenAdapter {
       hsScroll.setPosition(
           MyGdxGame.WIDTH / 2f - hsBtnW / 2f,
           MyGdxGame.HEIGHT * 0.10f);
-      gameStage.addActor(hsScroll);
+      overlayStage.addActor(hsScroll);
     }
 
     // King-defeat hero selection overlay — shown to the attacker when they must pick one of the
@@ -2999,12 +2999,12 @@ public class GameScreen extends ScreenAdapter {
       Image kdOverlay = new Image(MyGdxGame.skin, "white");
       kdOverlay.setFillParent(true);
       kdOverlay.setColor(0f, 0f, 0f, 0.78f);
-      gameStage.addActor(kdOverlay);
+      overlayStage.addActor(kdOverlay);
 
       Label kdTitle = new Label("Choose a Hero from the defeated player:", MyGdxGame.skin);
       kdTitle.setColor(Color.GOLD);
       kdTitle.setPosition(MyGdxGame.WIDTH / 2f - kdTitle.getPrefWidth() / 2f, MyGdxGame.HEIGHT * 0.86f);
-      gameStage.addActor(kdTitle);
+      overlayStage.addActor(kdTitle);
 
       // Single-column Table of hero buttons inside a vertical ScrollPane.
       Table kdTable = new Table(MyGdxGame.skin);
@@ -3039,85 +3039,89 @@ public class GameScreen extends ScreenAdapter {
       kdScroll.setPosition(
           MyGdxGame.WIDTH / 2f - kdBtnW / 2f,
           MyGdxGame.HEIGHT * 0.10f);
-      gameStage.addActor(kdScroll);
+      overlayStage.addActor(kdScroll);
     }
 
     // ── Hero reveal overlay (issue #257) ───────────────────────────────────
     // Shown to every player after any hero acquisition. Dismissed with "Got it!".
+    // Uses overlayStage (450x800) so elements at any HEIGHT fraction are visible.
     if (heroRevealPlayerName != null && heroRevealHeroName != null) {
-      final String revealPlayer = heroRevealPlayerName;
       final String revealHero   = heroRevealHeroName;
       final int    revealCardId = heroRevealDrawnCardId;
 
+      // Dark full-screen background
       Image revOv = new Image(MyGdxGame.skin, "white");
       revOv.setFillParent(true);
-      revOv.setColor(0f, 0f, 0f, 0.82f);
-      gameStage.addActor(revOv);
+      revOv.setColor(0f, 0f, 0f, 0.85f);
+      overlayStage.addActor(revOv);
 
-      // "PlayerName won a Hero!" title
-      Label revTitle = new Label(revealPlayer + " won a Hero!", MyGdxGame.skin);
+      // Centered content table
+      Table revTable = new Table();
+      revTable.setFillParent(true);
+      revTable.center();
+
+      // Title
+      Label revTitle = new Label(heroRevealPlayerName + " won a Hero!", MyGdxGame.skin);
       revTitle.setColor(Color.GOLD);
-      revTitle.setPosition(
-          MyGdxGame.WIDTH / 2f - revTitle.getPrefWidth() / 2f,
-          MyGdxGame.HEIGHT * 0.70f);
-      gameStage.addActor(revTitle);
+      revTable.add(revTitle).padBottom(14f).row();
 
-      // Hero sprite — look up the hero in the game state by name.
+      // Hero sprite via TextureRegionDrawable (reliable in GWT)
       int heroOwnerIdx = gameState.findHeroOwnerIndex(revealHero);
       if (heroOwnerIdx >= 0) {
         java.util.ArrayList<Hero> ownerHeroes = gameState.getPlayers().get(heroOwnerIdx).getHeroes();
         for (int hi = 0; hi < ownerHeroes.size(); hi++) {
           Hero rh = ownerHeroes.get(hi);
           if (revealHero.equals(rh.getHeroName())) {
-            float spriteScale = 2.5f;
-            float imgW = rh.getSprite().getWidth() * spriteScale;
-            float imgH = rh.getSprite().getHeight() * spriteScale;
-            Image heroImg = new Image(new SpriteDrawable(rh.getSprite()));
-            heroImg.setSize(imgW, imgH);
-            heroImg.setPosition(
-                MyGdxGame.WIDTH / 2f - imgW / 2f,
-                MyGdxGame.HEIGHT * 0.46f);
-            gameStage.addActor(heroImg);
+            com.badlogic.gdx.graphics.g2d.Sprite sp = rh.getSprite();
+            if (sp != null) {
+              float imgW = sp.getWidth() * 1.5f;
+              float imgH = sp.getHeight() * 1.5f;
+              Image heroImg = new Image(
+                  new com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable(
+                      new com.badlogic.gdx.graphics.g2d.TextureRegion(sp))) {
+                @Override
+                public com.badlogic.gdx.scenes.scene2d.Actor hit(float x, float y, boolean touchable) { return null; }
+              };
+              heroImg.setSize(imgW, imgH);
+              revTable.add(heroImg).size(imgW, imgH).padBottom(8f).row();
+            }
             break;
           }
         }
       }
 
-      // Hero name label
+      // Hero name
       Label revHeroLabel = new Label(revealHero, MyGdxGame.skin);
       revHeroLabel.setColor(Color.WHITE);
-      revHeroLabel.setPosition(
-          MyGdxGame.WIDTH / 2f - revHeroLabel.getPrefWidth() / 2f,
-          MyGdxGame.HEIGHT * 0.62f);
-      gameStage.addActor(revHeroLabel);
+      revTable.add(revHeroLabel).padBottom(14f).row();
 
       // Drawn card (if known)
       if (revealCardId > 0) {
         Card revCard = Card.fromCardId(revealCardId);
-        float cardScale = 1.4f;
-        revCard.setSize(revCard.getWidth() * cardScale, revCard.getHeight() * cardScale);
-        revCard.setPosition(
-            MyGdxGame.WIDTH / 2f - revCard.getWidth() / 2f,
-            MyGdxGame.HEIGHT * 0.30f);
-        gameStage.addActor(revCard);
+        if (revCard != null) {
+          float cScale = 1.4f;
+          float cW = revCard.getWidth() * cScale;
+          float cH = revCard.getHeight() * cScale;
+          revCard.setSize(cW, cH);
+          revTable.add(revCard).size(cW, cH).padBottom(20f).row();
+        }
       }
 
       // "Got it!" dismiss button
       TextButton revBtn = new TextButton("Got it!", MyGdxGame.skin);
       revBtn.pad(8f, 32f, 8f, 32f);
-      revBtn.setPosition(
-          MyGdxGame.WIDTH / 2f - revBtn.getPrefWidth() / 2f,
-          MyGdxGame.HEIGHT * 0.10f);
       revBtn.addListener(new ClickListener() {
         @Override
         public void clicked(InputEvent event, float x, float y) {
-          heroRevealPlayerName  = null;
-          heroRevealHeroName    = null;
-          heroRevealDrawnCardId = -1;
+          GameScreen.this.heroRevealPlayerName  = null;
+          GameScreen.this.heroRevealHeroName    = null;
+          GameScreen.this.heroRevealDrawnCardId = -1;
           gameState.setUpdateState(true);
         }
       });
-      gameStage.addActor(revBtn);
+      revTable.add(revBtn);
+
+      overlayStage.addActor(revTable);
     }
 
     // ── Sell Hero setup overlay ─────────────────────────────────────────────

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -72,6 +72,8 @@ public class MenuScreen extends AbstractScreen {
   // Pending create-screen settings
   private boolean pendingManualSetup = false;
   private int pendingStartingCards = 8;
+  // How heroes are assigned when a joker is sacrificed: "value_mapping" | "color_mapping" | "free_selector"
+  private String pendingHeroAssignMode = "value_mapping";
   // Per-bot personality selections: "off" means no bot in that slot.
   // Values map to server bot mode keys: "passive", "balanced", "aggressive", "tactician", "llm".
   private String[] pendingBotModes = {"off", "off", "off", "off"};
@@ -826,6 +828,31 @@ public class MenuScreen extends AbstractScreen {
     cardsBox.setItems(cardOptions);
     cardsBox.setSelected(String.valueOf(pendingStartingCards));
 
+    // ── Hero assign mode selector ────────────────────────────────────────────
+    Label heroModeLabel = new Label("Hero assignment:", MyGdxGame.skin);
+    final SelectBox<String> heroModeBox = new SelectBox<String>(MyGdxGame.skin);
+    final String[] HERO_MODE_DISPLAY = {"Card value (default)", "Card color", "Free choice"};
+    final String[] HERO_MODE_KEYS    = {"value_mapping", "color_mapping", "free_selector"};
+    Array<String> heroModeOptions = new Array<String>();
+    for (String d : HERO_MODE_DISPLAY) heroModeOptions.add(d);
+    heroModeBox.setItems(heroModeOptions);
+    // Restore from pending state
+    String heroModeDisplay = HERO_MODE_DISPLAY[0];
+    for (int ki = 0; ki < HERO_MODE_KEYS.length; ki++) {
+      if (HERO_MODE_KEYS[ki].equals(pendingHeroAssignMode)) { heroModeDisplay = HERO_MODE_DISPLAY[ki]; break; }
+    }
+    heroModeBox.setSelected(heroModeDisplay);
+    heroModeBox.addListener(new com.badlogic.gdx.scenes.scene2d.utils.ChangeListener() {
+      @Override
+      public void changed(ChangeEvent event, com.badlogic.gdx.scenes.scene2d.Actor actor) {
+        String sel = heroModeBox.getSelected();
+        for (int ki = 0; ki < HERO_MODE_DISPLAY.length; ki++) {
+          if (HERO_MODE_DISPLAY[ki].equals(sel)) { pendingHeroAssignMode = HERO_MODE_KEYS[ki]; return; }
+        }
+        pendingHeroAssignMode = "value_mapping";
+      }
+    });
+
     // ── Per-bot personality selectors (Bot 1 / 2 / 3, plus Bot 4 in spectator mode) ──
     final String[] BOT_DISPLAY = {"Off", "Passive", "Balanced", "Aggressive", "Tactician", "MCTS"};
     final String[] BOT_KEYS    = {"off", "passive", "balanced", "aggressive", "tactician", "mcts"};
@@ -896,6 +923,11 @@ public class MenuScreen extends AbstractScreen {
         try {
           pendingStartingCards = Integer.parseInt(cardsBox.getSelected());
         } catch (NumberFormatException ex) { pendingStartingCards = 8; }
+        // Read hero assign mode from selector
+        String selHeroMode = heroModeBox.getSelected();
+        for (int ki = 0; ki < HERO_MODE_DISPLAY.length; ki++) {
+          if (HERO_MODE_DISPLAY[ki].equals(selHeroMode)) { pendingHeroAssignMode = HERO_MODE_KEYS[ki]; break; }
+        }
         // Collect non-"off" bot modes (up to 3 normally, up to 4 in spectator mode)
         int maxBots = isSpectator ? 4 : 3;
         JSONArray botModesArr = new JSONArray();
@@ -911,6 +943,7 @@ public class MenuScreen extends AbstractScreen {
           data.put("manualSetup", pendingManualSetup);
           data.put("botModes", botModesArr);
           data.put("spectator", isSpectator);
+          data.put("heroAssignMode", pendingHeroAssignMode);
           data.put("token", MyGdxGame.playerStorage.getToken());
           data.put("icon", selectedIcon);
         } catch (JSONException e) { /* ignore */ }
@@ -918,6 +951,7 @@ public class MenuScreen extends AbstractScreen {
         pendingSessionName = "";
         pendingManualSetup = false;
         pendingStartingCards = 8;
+        pendingHeroAssignMode = "value_mapping";
         pendingSpectator = false;
         pendingBotModes = new String[]{"off", "off", "off", "off"};
         inSessionCreate = false;
@@ -936,6 +970,9 @@ public class MenuScreen extends AbstractScreen {
     form.row();
     form.add(cardsLabel).left().padRight(12f).padBottom(6f);
     form.add(cardsBox).width(colW * 0.38f).left().padBottom(6f);
+    form.row();
+    form.add(heroModeLabel).left().padRight(12f).padBottom(6f);
+    form.add(heroModeBox).width(colW * 0.55f).left().padBottom(6f);
     for (int bi = 0; bi < totalBotSlots; bi++) {
       form.row();
       form.add(botLabels[bi]).left().padRight(12f).padBottom(4f);
@@ -1494,11 +1531,12 @@ public class MenuScreen extends AbstractScreen {
         try {
           final int playerIndex = data.getInt("playerIndex");
           final JSONObject gameState = data.getJSONObject("gameState");
+          final String heroAssignMode = data.optString("heroAssignMode", "value_mapping");
           Gdx.app.log("SocketIO", "Received centralized game state, playerIndex: " + playerIndex);
           Gdx.app.postRunnable(new Runnable() {
             @Override
             public void run() {
-              game.setScreen(new GameScreen(game, gameState, playerIndex, socket, menuState.getStartingHero()));
+              game.setScreen(new GameScreen(game, gameState, playerIndex, socket, menuState.getStartingHero(), heroAssignMode));
             }
           });
         } catch (JSONException e) {

--- a/core/src/com/mygdx/game/PlayerTurn.java
+++ b/core/src/com/mygdx/game/PlayerTurn.java
@@ -193,6 +193,11 @@ public class PlayerTurn {
   public int getPendingJokerCardId() { return pendingJokerCardId; }
   public void setPendingJokerCardId(int v) { this.pendingJokerCardId = v; }
 
+  // The card drawn from the deck during joker sacrifice that determined the hero (2–13, ace=1, or joker).
+  private int pendingDrawnCardId = -1;
+  public int getPendingDrawnCardId() { return pendingDrawnCardId; }
+  public void setPendingDrawnCardId(int v) { this.pendingDrawnCardId = v; }
+
   // --- Battery Tower attack interception ---
   // Set on the attacker's side while waiting for the defender to allow/deny.
   private boolean batteryWaiting = false;

--- a/server/index.js
+++ b/server/index.js
@@ -1478,6 +1478,8 @@ io.on('connection', function(socket) {
     if (!sess || !sess.gameState) return;
     console.log("heroAcquired: playerIndex=" + data.playerIndex + " heroName=" + data.heroName);
     sess.gameState.heroAcquired(data.playerIndex, data.heroName);
+    // Relay to all other players so they show the hero reveal overlay.
+    socket.to(sess.id).emit('heroAcquired', data);
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 

--- a/server/index.js
+++ b/server/index.js
@@ -65,7 +65,7 @@ function broadcastPlayerList() {
   io.emit('playerList', list);
 }
 
-function createSession(name, allowHeroSelection, startingCards, manualSetup) {
+function createSession(name, allowHeroSelection, startingCards, manualSetup, heroAssignMode) {
   var id = 's' + (_nextSessionId++);
   sessions[id] = {
     id: id,
@@ -73,6 +73,7 @@ function createSession(name, allowHeroSelection, startingCards, manualSetup) {
     allowHeroSelection: allowHeroSelection !== false, // default true
     startingCards: Math.min(10, Math.max(6, parseInt(startingCards, 10) || 8)),
     manualSetup: !!manualSetup,
+    heroAssignMode: heroAssignMode || 'value_mapping', // 'value_mapping' | 'color_mapping' | 'free_selector'
     users: [],
     spectators: [],
     gameState: null,
@@ -222,7 +223,8 @@ function startGameForSession(sess, requesterSocketId) {
     if (!bot.isBot(u)) {
       io.to(u.id).emit('gameState', {
         playerIndex: idx,
-        gameState: sess.gameState.serialize()
+        gameState: sess.gameState.serialize(),
+        heroAssignMode: sess.heroAssignMode || 'value_mapping'
       });
       console.log('gameState emitted to ' + u.name + ' (' + u.id + ') as player ' + idx);
     }
@@ -1027,7 +1029,7 @@ io.on('connection', function(socket) {
             user.id = socket.id;
             socketToSession[socket.id] = sessId;
             socket.join(sessId);
-            socket.emit('gameState', { playerIndex: playerIdx, gameState: sess.gameState.serialize() });
+            socket.emit('gameState', { playerIndex: playerIdx, gameState: sess.gameState.serialize(), heroAssignMode: sess.heroAssignMode || 'value_mapping' });
             broadcastPlayerList();
             console.log('Reconnected ' + name + ' (token ' + token.slice(0, 8) + '...) to session ' + sessId + ' as player ' + playerIdx);
             return;
@@ -1052,7 +1054,10 @@ io.on('connection', function(socket) {
     var startingCards = (data && data.startingCards) ? parseInt(data.startingCards, 10) : 8;
     var manualSetup = !!(data && data.manualSetup);
     var spectatorMode = !!(data && data.spectator);
-    var sess = createSession(sessionName, allowHeroSelection, startingCards, manualSetup);
+    var VALID_HERO_MODES = ['value_mapping', 'color_mapping', 'free_selector'];
+    var heroAssignMode = (data && VALID_HERO_MODES.indexOf(String(data.heroAssignMode)) !== -1)
+      ? String(data.heroAssignMode) : 'value_mapping';
+    var sess = createSession(sessionName, allowHeroSelection, startingCards, manualSetup, heroAssignMode);
     // botModes: array of personality strings, e.g. ["aggressive","passive"].
     // Falls back to legacy botCount (numeric) for backward compat.
     // Spectator mode allows up to 4 bots; normal mode allows up to 3.
@@ -1098,7 +1103,7 @@ io.on('connection', function(socket) {
         });
       }
       // Send spectator gameState to creator (playerIndex -1)
-      socket.emit('gameState', { playerIndex: -1, gameState: sess.gameState.serialize() });
+      socket.emit('gameState', { playerIndex: -1, gameState: sess.gameState.serialize(), heroAssignMode: sess.heroAssignMode || 'value_mapping' });
       broadcastSessionList();
       broadcastPlayerList();
       bot.playBotTurnIfNeeded(sess);
@@ -1165,7 +1170,7 @@ io.on('connection', function(socket) {
     socketToSession[socket.id] = sess.id;
     socket.join(sess.id);
     socket.emit('sessionJoined', { sessionId: sess.id });
-    socket.emit('gameState', { playerIndex: -1, gameState: sess.gameState.serialize() });
+    socket.emit('gameState', { playerIndex: -1, gameState: sess.gameState.serialize(), heroAssignMode: sess.heroAssignMode || 'value_mapping' });
   });
 
   // ── Lobby events ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #257

## Summary

Three UI improvements to the hero joker-sacrifice flow:

### A — Hero Reveal Overlay
After any player wins a hero (via joker sacrifice), all clients see a full-screen overlay showing:
- The drawn card that determined the hero
- The hero's sprite (2.5× scale)
- The hero's name
- A "Got it!" dismiss button

The `heroAcquired` socket event broadcasts `drawnCardId` so remote players see the correct card. A new `pendingDrawnCardId` field on `PlayerTurn` tracks the drawn card for the local player.

### B — Scrollable Hero Selector
Both the joker-sacrifice hero selector and the king-defeat hero selector are now single-column `ScrollPane` layouts instead of a multi-column grid. This handles any number of available heroes gracefully at all screen sizes.

### C — Hero Assignment Mode Dropdown
A new "Hero assignment" dropdown in the **New Game** creation form lets the creator choose how heroes are assigned when a joker is sacrificed:

| Option | Key | Behaviour |
|---|---|---|
| Card value (default) | `value_mapping` | Card index 2–13 → specific hero; Ace → color-based selector; Joker → free choice |
| Card color | `color_mapping` | Red suit → white heroes; black suit → black heroes; Joker → free choice |
| Free choice | `free_selector` | Always show the full hero list regardless of drawn card |

The mode is stored on the server session and included in every `gameState` event payload so all clients (including reconnects and spectators) receive it.