### PR TITLE
feat: configure lobby slots (Open / Closed / Bot) directly in the game lobby

### DIFF
--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -1336,7 +1336,7 @@ public class MenuScreen extends AbstractScreen {
             }
           }
         });
-        loggedInUserTable.add(slotBox).colspan(tableColumns).width(120f).padBottom(6f);
+        loggedInUserTable.add(slotBox).colspan(tableColumns).fillX().padBottom(6f);
 
       } else {
         // Non-host view of an empty/closed slot, or slot 0 placeholder not yet claimed

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -81,6 +81,8 @@ public class MenuScreen extends AbstractScreen {
   private String[] lobbySlotUserIds = {"", "", "", ""};
   private String[] lobbySlotBotUserIds = {"", "", "", ""};
   private String[] lobbySlotBotModes  = {"", "", "", ""};
+  // Whether the local player created this session (persists even if they move to spectator slot)
+  private boolean isSessionHost = false;
 
   // The session list received from the server
   private java.util.List<SessionInfo> sessionList = new java.util.ArrayList<SessionInfo>();
@@ -89,9 +91,10 @@ public class MenuScreen extends AbstractScreen {
     String id;
     String name;
     int playerCount;
+    int maxSlots;
     boolean running;
-    SessionInfo(String id, String name, int playerCount, boolean running) {
-      this.id = id; this.name = name; this.playerCount = playerCount; this.running = running;
+    SessionInfo(String id, String name, int playerCount, int maxSlots, boolean running) {
+      this.id = id; this.name = name; this.playerCount = playerCount; this.maxSlots = maxSlots; this.running = running;
     }
   }
 
@@ -633,7 +636,7 @@ public class MenuScreen extends AbstractScreen {
       for (int si = 0; si < list.size(); si++) {
         final SessionInfo s = list.get(si);
         Label nameL = new Label(s.name, MyGdxGame.skin);
-        Label countL = new Label(s.playerCount + "/4", MyGdxGame.skin);
+        Label countL = new Label(s.playerCount + "/" + s.maxSlots, MyGdxGame.skin);
         if (s.running) {
           TextButton watchBtn = new TextButton("Watch", MyGdxGame.skin);
           watchBtn.addListener(new ClickListener() {
@@ -1065,8 +1068,8 @@ public class MenuScreen extends AbstractScreen {
     loggedInUserTable.pad(14f, 18f, 14f, 18f);
     ArrayList<User> loggedInUsers = menuState.getUsers();
 
-    boolean isHost = !loggedInUsers.isEmpty()
-        && loggedInUsers.get(0).getUserID().equals(menuState.getMyUserID());
+    boolean isHost = isSessionHost;
+    boolean hostIsSpectator = isHost && "bot".equals(lobbySlotTypes != null && lobbySlotTypes.length > 0 ? lobbySlotTypes[0] : "player");
     int tableColumns = sessionAllowHeroSelection ? 3 : 2;
 
     Label headLine1 = new Label("Name", MyGdxGame.skin);
@@ -1086,12 +1089,17 @@ public class MenuScreen extends AbstractScreen {
     final String[] SLOT_DISPLAY = {"Open", "Closed", "Passive Bot", "Balanced Bot", "Aggressive Bot", "Tactician Bot", "MCTS Bot"};
     final String[] SLOT_TYPES   = {"open",  "closed",  "bot",         "bot",          "bot",            "bot",           "bot"};
     final String[] SLOT_MODES   = {"",      "",         "passive",     "balanced",     "aggressive",     "tactician",     "mcts"};
+    // Slot-0 options: player-self + bots (cannot be open/closed)
+    final String[] SLOT0_DISPLAY = {"Player (you)", "Passive Bot", "Balanced Bot", "Aggressive Bot", "Tactician Bot", "MCTS Bot"};
+    final String[] SLOT0_TYPES   = {"player",       "bot",         "bot",          "bot",            "bot",           "bot"};
+    final String[] SLOT0_MODES   = {"",             "passive",     "balanced",     "aggressive",     "tactician",     "mcts"};
 
     for (int slotIdx = 0; slotIdx < 4; slotIdx++) {
       final int si = slotIdx;
       String slotType = (lobbySlotTypes != null && lobbySlotTypes.length > slotIdx) ? lobbySlotTypes[slotIdx] : "open";
       String slotUserId = (lobbySlotUserIds != null && lobbySlotUserIds.length > slotIdx) ? lobbySlotUserIds[slotIdx] : "";
       String slotBotUserId = (lobbySlotBotUserIds != null && lobbySlotBotUserIds.length > slotIdx) ? lobbySlotBotUserIds[slotIdx] : "";
+      String slotBotMode = (lobbySlotBotModes != null && lobbySlotBotModes.length > slotIdx) ? lobbySlotBotModes[slotIdx] : "";
 
       // Find the matching user in menuState
       User rowUser = null;
@@ -1105,91 +1113,237 @@ public class MenuScreen extends AbstractScreen {
         }
       }
 
-      if ("player".equals(slotType) && rowUser != null) {
-        // Human player row
+      // --- Determine whether to show a config dropdown for this slot ---
+      // Host can reconfigure: slot 0 (always) and slots 1-3 when not occupied by another human.
+      boolean slotOccupiedByOtherHuman = "player".equals(slotType)
+          && !slotUserId.isEmpty()
+          && !slotUserId.equals(menuState.getMyUserID());
+      boolean showHostDropdown = isHost && !slotOccupiedByOtherHuman;
+
+      if (si == 0 && showHostDropdown) {
+        // Slot 0: always a row (host playing or bot), with dropdown for host
+        // Name / hero columns
+        if ("player".equals(slotType) && rowUser != null) {
+          Label nameLabel = new Label(rowUser.getName(), MyGdxGame.skin);
+          nameLabel.setColor(Color.GOLD);
+          loggedInUserTable.add(buildNameCell(nameLabel, rowUser.getIcon())).padRight(10).padBottom(6f).left();
+          if (sessionAllowHeroSelection) {
+            refreshHeroDropdown();
+            loggedInUserTable.add(heroSelectBox).padRight(10).padBottom(6f)
+                .width(heroSelectBox.getWidth()).height(heroSelectBox.getHeight());
+          }
+        } else if ("bot".equals(slotType) && rowUser != null) {
+          Label nameLabel = new Label(rowUser.getName(), MyGdxGame.skin);
+          nameLabel.setColor(0.6f, 0.9f, 1f, 1f);
+          loggedInUserTable.add(buildNameCell(nameLabel, rowUser.getIcon())).padRight(10).padBottom(6f).left();
+          if (sessionAllowHeroSelection) {
+            final String botUserId0 = rowUser.getUserID();
+            final String botCurrentHero0 = rowUser.getSelectedHero();
+            final SelectBox<String> botHeroBox0 = new SelectBox<String>(MyGdxGame.skin);
+            botHeroBox0.setItems(buildHeroDropdownItems(botCurrentHero0));
+            botHeroBox0.setSelected(botCurrentHero0);
+            botHeroBox0.setSize(100f, heroSelectBox.getHeight());
+            botHeroBox0.addListener(new ChangeListener() {
+              @Override
+              public void changed(ChangeEvent event, com.badlogic.gdx.scenes.scene2d.Actor actor) {
+                String selected = botHeroBox0.getSelected();
+                try {
+                  JSONObject data = new JSONObject();
+                  data.put("botUserId", botUserId0);
+                  data.put("heroName", selected);
+                  socket.emit("setBotHeroSelection", data);
+                } catch (JSONException e) { /* ignore */ }
+              }
+            });
+            loggedInUserTable.add(botHeroBox0).padRight(10).padBottom(6f)
+                .width(100f).height(heroSelectBox.getHeight());
+          }
+        } else {
+          // No user found yet — show placeholder in name (and hero) columns
+          Label placeholder = new Label("(you)", MyGdxGame.skin);
+          placeholder.setColor(Color.GOLD);
+          loggedInUserTable.add(placeholder).padRight(10).padBottom(6f).left();
+          if (sessionAllowHeroSelection) {
+            Label heroPlaceholder = new Label("-", MyGdxGame.skin);
+            loggedInUserTable.add(heroPlaceholder).padRight(10).padBottom(6f);
+          }
+        }
+        // Status column — dropdown to configure slot 0
+        final SelectBox<String> slot0Box = new SelectBox<String>(MyGdxGame.skin);
+        Array<String> slot0Opts = new Array<String>();
+        for (String d : SLOT0_DISPLAY) slot0Opts.add(d);
+        slot0Box.setItems(slot0Opts);
+        // Pre-select current state
+        if ("bot".equals(slotType)) {
+          String modeDisplay = "Balanced Bot";
+          for (int ki = 1; ki < SLOT0_MODES.length; ki++) {
+            if (SLOT0_MODES[ki].equals(slotBotMode)) { modeDisplay = SLOT0_DISPLAY[ki]; break; }
+          }
+          slot0Box.setSelected(modeDisplay);
+        } else {
+          slot0Box.setSelected("Player (you)");
+        }
+        slot0Box.addListener(new ChangeListener() {
+          @Override
+          public void changed(ChangeEvent event, com.badlogic.gdx.scenes.scene2d.Actor actor) {
+            String sel = slot0Box.getSelected();
+            for (int ki = 0; ki < SLOT0_DISPLAY.length; ki++) {
+              if (SLOT0_DISPLAY[ki].equals(sel)) {
+                try {
+                  JSONObject slotData = new JSONObject();
+                  slotData.put("slotIndex", 0);
+                  slotData.put("slotType", SLOT0_TYPES[ki]);
+                  if (!SLOT0_MODES[ki].isEmpty()) slotData.put("botMode", SLOT0_MODES[ki]);
+                  socket.emit("setLobbySlot", slotData);
+                } catch (JSONException e) { /* ignore */ }
+                return;
+              }
+            }
+          }
+        });
+        loggedInUserTable.add(slot0Box).padBottom(6f).width(120f).left();
+
+      } else if ("player".equals(slotType) && rowUser != null) {
+        // Human player row (non-host-configurable)
         Label nameLabel = new Label(rowUser.getName(), MyGdxGame.skin);
         if (rowUser.getUserID().equals(menuState.getMyUserID())) nameLabel.setColor(Color.GOLD);
-        loggedInUserTable.add(buildNameCell(nameLabel, rowUser.getIcon())).padRight(20).padBottom(6f).left();
+        loggedInUserTable.add(buildNameCell(nameLabel, rowUser.getIcon())).padRight(10).padBottom(6f).left();
         if (sessionAllowHeroSelection) {
           boolean isOwnRow = rowUser.getUserID().equals(menuState.getMyUserID());
           if (isOwnRow) {
             refreshHeroDropdown();
-            loggedInUserTable.add(heroSelectBox).padRight(20).padBottom(6f)
+            loggedInUserTable.add(heroSelectBox).padRight(10).padBottom(6f)
                 .width(heroSelectBox.getWidth()).height(heroSelectBox.getHeight());
           } else {
             String heroName = rowUser.getSelectedHero();
             Label heroLbl = new Label("None".equals(heroName) ? "-" : heroName, MyGdxGame.skin);
-            loggedInUserTable.add(heroLbl).padRight(20).padBottom(6f);
+            loggedInUserTable.add(heroLbl).padRight(10).padBottom(6f);
           }
         }
         Table statusBadge = rowUser.isReady()
             ? createStatusBadge("READY", new Color(0.14f, 0.56f, 0.24f, 1f), Color.WHITE)
             : createStatusBadge("WAIT", new Color(0.64f, 0.14f, 0.14f, 1f), new Color(1f, 0.94f, 0.94f, 1f));
         loggedInUserTable.add(statusBadge).left().padBottom(6f);
-      } else if ("bot".equals(slotType) && rowUser != null) {
-        // Bot row
+
+      } else if ("bot".equals(slotType) && rowUser != null && !showHostDropdown) {
+        // Bot row, non-host view
         Label nameLabel = new Label(rowUser.getName(), MyGdxGame.skin);
         nameLabel.setColor(0.6f, 0.9f, 1f, 1f);
-        loggedInUserTable.add(buildNameCell(nameLabel, rowUser.getIcon())).padRight(20).padBottom(6f).left();
-        if (sessionAllowHeroSelection && isHost) {
-          final String botUserId = rowUser.getUserID();
-          final String botCurrentHero = rowUser.getSelectedHero();
-          final SelectBox<String> botHeroBox = new SelectBox<String>(MyGdxGame.skin);
-          botHeroBox.setItems(buildHeroDropdownItems(botCurrentHero));
-          botHeroBox.setSelected(botCurrentHero);
-          botHeroBox.setSize(heroSelectBox.getWidth(), heroSelectBox.getHeight());
-          botHeroBox.addListener(new ChangeListener() {
-            @Override
-            public void changed(ChangeEvent event, com.badlogic.gdx.scenes.scene2d.Actor actor) {
-              String selected = botHeroBox.getSelected();
-              try {
-                JSONObject data = new JSONObject();
-                data.put("botUserId", botUserId);
-                data.put("heroName", selected);
-                socket.emit("setBotHeroSelection", data);
-              } catch (JSONException e) { /* ignore */ }
-            }
-          });
-          loggedInUserTable.add(botHeroBox).padRight(20).padBottom(6f)
-              .width(heroSelectBox.getWidth()).height(heroSelectBox.getHeight());
-        } else if (sessionAllowHeroSelection) {
+        loggedInUserTable.add(buildNameCell(nameLabel, rowUser.getIcon())).padRight(10).padBottom(6f).left();
+        if (sessionAllowHeroSelection) {
           String heroName = rowUser.getSelectedHero();
           Label heroLbl = new Label("None".equals(heroName) ? "-" : heroName, MyGdxGame.skin);
-          loggedInUserTable.add(heroLbl).padRight(20).padBottom(6f);
+          loggedInUserTable.add(heroLbl).padRight(10).padBottom(6f);
         }
         loggedInUserTable.add(createStatusBadge("READY", new Color(0.14f, 0.56f, 0.24f, 1f), Color.WHITE)).left().padBottom(6f);
+
+      } else if (showHostDropdown && si > 0) {
+        // Slots 1-3 that the host can configure (open, closed, or bot)
+        // Build pre-select string
+        String currentDisplay = "Open";
+        if ("closed".equals(slotType)) {
+          currentDisplay = "Closed";
+        } else if ("bot".equals(slotType)) {
+          // Find bot name row for display if available, but pre-select bot mode in dropdown
+          currentDisplay = "Balanced Bot";
+          for (int ki = 2; ki < SLOT_MODES.length; ki++) {
+            if (SLOT_MODES[ki].equals(slotBotMode)) { currentDisplay = SLOT_DISPLAY[ki]; break; }
+          }
+          // Show bot name / hero in name+hero columns before the dropdown col
+          if (rowUser != null) {
+            Label nameLabel = new Label(rowUser.getName(), MyGdxGame.skin);
+            nameLabel.setColor(0.6f, 0.9f, 1f, 1f);
+            loggedInUserTable.add(buildNameCell(nameLabel, rowUser.getIcon())).padRight(10).padBottom(6f).left();
+            if (sessionAllowHeroSelection) {
+              final String botUserIdN = rowUser.getUserID();
+              final String botCurrentHeroN = rowUser.getSelectedHero();
+              final SelectBox<String> botHeroBoxN = new SelectBox<String>(MyGdxGame.skin);
+              botHeroBoxN.setItems(buildHeroDropdownItems(botCurrentHeroN));
+              botHeroBoxN.setSelected(botCurrentHeroN);
+              botHeroBoxN.setSize(100f, heroSelectBox.getHeight());
+              botHeroBoxN.addListener(new ChangeListener() {
+                @Override
+                public void changed(ChangeEvent event, com.badlogic.gdx.scenes.scene2d.Actor actor) {
+                  String selected = botHeroBoxN.getSelected();
+                  try {
+                    JSONObject data = new JSONObject();
+                    data.put("botUserId", botUserIdN);
+                    data.put("heroName", selected);
+                    socket.emit("setBotHeroSelection", data);
+                  } catch (JSONException e) { /* ignore */ }
+                }
+              });
+              loggedInUserTable.add(botHeroBoxN).padRight(10).padBottom(6f)
+                  .width(100f).height(heroSelectBox.getHeight());
+            }
+            // Show config dropdown in status column only
+            final String fCurrentDisplay = currentDisplay;
+            final SelectBox<String> slotBox = new SelectBox<String>(MyGdxGame.skin);
+            Array<String> slotOpts = new Array<String>();
+            for (String d : SLOT_DISPLAY) slotOpts.add(d);
+            slotBox.setItems(slotOpts);
+            slotBox.setSelected(fCurrentDisplay);
+            slotBox.addListener(new ChangeListener() {
+              @Override
+              public void changed(ChangeEvent event, com.badlogic.gdx.scenes.scene2d.Actor actor) {
+                String sel = slotBox.getSelected();
+                for (int ki = 0; ki < SLOT_DISPLAY.length; ki++) {
+                  if (SLOT_DISPLAY[ki].equals(sel)) {
+                    try {
+                      JSONObject slotData = new JSONObject();
+                      slotData.put("slotIndex", si);
+                      slotData.put("slotType", SLOT_TYPES[ki]);
+                      if (!SLOT_MODES[ki].isEmpty()) slotData.put("botMode", SLOT_MODES[ki]);
+                      socket.emit("setLobbySlot", slotData);
+                    } catch (JSONException e) { /* ignore */ }
+                    return;
+                  }
+                }
+              }
+            });
+            loggedInUserTable.add(slotBox).padBottom(6f).width(120f).left();
+            loggedInUserTable.row();
+            if (si < 3) {
+              Image sep = new Image(MyGdxGame.skin.newDrawable("white", new Color(1f, 1f, 1f, 0.14f)));
+              loggedInUserTable.add(sep).colspan(tableColumns).growX().height(1f).padTop(2f).padBottom(5f);
+              loggedInUserTable.row();
+            }
+            continue; // row already closed above
+          }
+        }
+        // open or closed slot (or bot with no rowUser): span all columns with the dropdown
+        final String fCurrentDisplay = currentDisplay;
+        final SelectBox<String> slotBox = new SelectBox<String>(MyGdxGame.skin);
+        Array<String> slotOpts = new Array<String>();
+        for (String d : SLOT_DISPLAY) slotOpts.add(d);
+        slotBox.setItems(slotOpts);
+        slotBox.setSelected(fCurrentDisplay);
+        slotBox.addListener(new ChangeListener() {
+          @Override
+          public void changed(ChangeEvent event, com.badlogic.gdx.scenes.scene2d.Actor actor) {
+            String sel = slotBox.getSelected();
+            for (int ki = 0; ki < SLOT_DISPLAY.length; ki++) {
+              if (SLOT_DISPLAY[ki].equals(sel)) {
+                try {
+                  JSONObject slotData = new JSONObject();
+                  slotData.put("slotIndex", si);
+                  slotData.put("slotType", SLOT_TYPES[ki]);
+                  if (!SLOT_MODES[ki].isEmpty()) slotData.put("botMode", SLOT_MODES[ki]);
+                  socket.emit("setLobbySlot", slotData);
+                } catch (JSONException e) { /* ignore */ }
+                return;
+              }
+            }
+          }
+        });
+        loggedInUserTable.add(slotBox).colspan(tableColumns).width(120f).padBottom(6f);
+
       } else {
-        // Empty slot (open or closed) — host gets a config dropdown, others see a label
-        if (slotIdx == 0) {
+        // Non-host view of an empty/closed slot, or slot 0 placeholder not yet claimed
+        if (si == 0) {
           Label placeholder = new Label("(waiting)", MyGdxGame.skin);
           placeholder.setColor(1f, 1f, 1f, 0.4f);
           loggedInUserTable.add(placeholder).colspan(tableColumns).left().padBottom(6f);
-        } else if (isHost) {
-          String currentDisplay = "closed".equals(slotType) ? "Closed" : "Open";
-          final SelectBox<String> slotBox = new SelectBox<String>(MyGdxGame.skin);
-          Array<String> slotOpts = new Array<String>();
-          for (String d : SLOT_DISPLAY) slotOpts.add(d);
-          slotBox.setItems(slotOpts);
-          slotBox.setSelected(currentDisplay);
-          slotBox.addListener(new ChangeListener() {
-            @Override
-            public void changed(ChangeEvent event, com.badlogic.gdx.scenes.scene2d.Actor actor) {
-              String sel = slotBox.getSelected();
-              for (int ki = 0; ki < SLOT_DISPLAY.length; ki++) {
-                if (SLOT_DISPLAY[ki].equals(sel)) {
-                  try {
-                    JSONObject slotData = new JSONObject();
-                    slotData.put("slotIndex", si);
-                    slotData.put("slotType", SLOT_TYPES[ki]);
-                    if (!SLOT_MODES[ki].isEmpty()) slotData.put("botMode", SLOT_MODES[ki]);
-                    socket.emit("setLobbySlot", slotData);
-                  } catch (JSONException e) { /* ignore */ }
-                  return;
-                }
-              }
-            }
-          });
-          loggedInUserTable.add(slotBox).colspan(tableColumns).fillX().padBottom(6f);
         } else {
           Label slotLabel = new Label("closed".equals(slotType) ? "[ Closed ]" : "[ Open ]", MyGdxGame.skin);
           slotLabel.setColor(1f, 1f, 1f, 0.45f);
@@ -1264,14 +1418,23 @@ public class MenuScreen extends AbstractScreen {
           break;
         }
       }
-      boolean canHostStart = isHost && amReady && readyCount >= 2 && !timerStarted;
+      boolean canHostStart = isHost && readyCount >= 2 && !timerStarted
+          && (hostIsSpectator || amReady);
 
       if (isHost) {
         TextButton startGameButton = new TextButton("Start game", MyGdxGame.skin);
         startGameButton.setSize(startGameButton.getPrefWidth() + 20, startGameButton.getPrefHeight());
         float buttonGap = 20f;
-        float readyButtonX = (MyGdxGame.WIDTH / 2f) - button.getWidth() - (buttonGap / 2f);
-        float startButtonX = (MyGdxGame.WIDTH / 2f) + (buttonGap / 2f);
+        float startButtonX;
+        if (hostIsSpectator) {
+          // No Ready button — center the Start button
+          startButtonX = (MyGdxGame.WIDTH - startGameButton.getWidth()) / 2f;
+        } else {
+          float readyButtonX = (MyGdxGame.WIDTH / 2f) - button.getWidth() - (buttonGap / 2f);
+          startButtonX = (MyGdxGame.WIDTH / 2f) + (buttonGap / 2f);
+          button.setPosition(readyButtonX, buttonY);
+          menuStage.addActor(button);
+        }
         startGameButton.setPosition(startButtonX, buttonY);
         startGameButton.setDisabled(!canHostStart);
         startGameButton.setTouchable(!canHostStart
@@ -1289,8 +1452,6 @@ public class MenuScreen extends AbstractScreen {
           }
         });
         menuStage.addActor(startGameButton);
-
-        button.setPosition(readyButtonX, buttonY);
       } else {
         button.setPosition((MyGdxGame.WIDTH - button.getWidth()) / 2f, buttonY);
       }
@@ -1306,7 +1467,10 @@ public class MenuScreen extends AbstractScreen {
         // No hero selection in this session — clear any stale hero from a previous session.
         menuState.setStartingHero("None");
       }
-      menuStage.addActor(button);
+      // Only show the Ready button when not a spectating host
+      if (!hostIsSpectator) {
+        menuStage.addActor(button);
+      }
     }
 
     menuStage.addActor(actionBar);
@@ -1321,6 +1485,7 @@ public class MenuScreen extends AbstractScreen {
       public void clicked(InputEvent event, float x, float y) {
         socket.emit("leaveSession", "");
         MyGdxGame.playerStorage.clearSessionId();
+        isSessionHost = false;
         lobbyJoined = false;
         timerStarted = false;
         gameRunning = false;
@@ -1668,6 +1833,7 @@ public class MenuScreen extends AbstractScreen {
             MyGdxGame.playerStorage.clearSessionId();
             reconnecting = false;
             reconnectElapsed = 0f;
+            isSessionHost = false;
             lobbyJoined = false;
             timerStarted = false;
             gameRunning = false;
@@ -1691,6 +1857,7 @@ public class MenuScreen extends AbstractScreen {
             reconnectElapsed = 0f;
             timerStarted = false;
             gameRunning = false;
+            isSessionHost = false;
             lobbyJoined = false;
             showPlayersTab = false;
             menuState.clearUsers();
@@ -1716,6 +1883,7 @@ public class MenuScreen extends AbstractScreen {
                   o.getString("id"),
                   o.getString("name"),
                   o.getInt("playerCount"),
+                  o.optInt("maxSlots", 4),
                   o.getBoolean("running")
                 ));
               }
@@ -1766,6 +1934,7 @@ public class MenuScreen extends AbstractScreen {
               sessionAllowHeroSelection = data.optBoolean("allowHeroSelection", true);
               String sessId = data.optString("sessionId", "");
               if (!sessId.isEmpty()) MyGdxGame.playerStorage.saveSessionId(sessId);
+              if (data.optBoolean("isHost", false)) isSessionHost = true;
             } catch (Exception e) { /* keep default */ }
             lobbyJoined = true;
             // Notify server of our initial hero selection only when hero selection is enabled.
@@ -1787,6 +1956,7 @@ public class MenuScreen extends AbstractScreen {
             MyGdxGame.playerStorage.clearSessionId();
             reconnecting = false;
             reconnectElapsed = 0f;
+            isSessionHost = false;
             lobbyJoined = false;
             timerStarted = false;
             gameRunning = false;

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -74,11 +74,13 @@ public class MenuScreen extends AbstractScreen {
   private int pendingStartingCards = 8;
   // How heroes are assigned when a joker is sacrificed: "value_mapping" | "color_mapping" | "free_selector"
   private String pendingHeroAssignMode = "value_mapping";
-  // Per-bot personality selections: "off" means no bot in that slot.
-  // Values map to server bot mode keys: "passive", "balanced", "aggressive", "tactician", "llm".
-  private String[] pendingBotModes = {"off", "off", "off", "off"};
-  // Whether the creator joins as a spectator (4th bot slot enabled in this mode)
-  private boolean pendingSpectator = false;
+
+  // Lobby slot configuration received from the server (4 slots: slot 0 = host).
+  // Each entry is: "player", "open", "closed", or "bot:<mode>" (e.g. "bot:balanced").
+  private String[] lobbySlotTypes  = {"player", "open", "open", "open"};
+  private String[] lobbySlotUserIds = {"", "", "", ""};
+  private String[] lobbySlotBotUserIds = {"", "", "", ""};
+  private String[] lobbySlotBotModes  = {"", "", "", ""};
 
   // The session list received from the server
   private java.util.List<SessionInfo> sessionList = new java.util.ArrayList<SessionInfo>();
@@ -853,57 +855,7 @@ public class MenuScreen extends AbstractScreen {
       }
     });
 
-    // ── Per-bot personality selectors (Bot 1 / 2 / 3, plus Bot 4 in spectator mode) ──
-    final String[] BOT_DISPLAY = {"Off", "Passive", "Balanced", "Aggressive", "Tactician", "MCTS"};
-    final String[] BOT_KEYS    = {"off", "passive", "balanced", "aggressive", "tactician", "mcts"};
-    final int totalBotSlots = 4;
-    final Label[] botLabels = new Label[totalBotSlots];
-    @SuppressWarnings("unchecked")
-    final SelectBox<String>[] botBoxes = new SelectBox[totalBotSlots];
-    for (int bi = 0; bi < totalBotSlots; bi++) {
-      botLabels[bi] = new Label("Bot " + (bi + 1) + ":", MyGdxGame.skin);
-      botBoxes[bi] = new SelectBox<String>(MyGdxGame.skin);
-      Array<String> botOpts = new Array<String>();
-      for (String d : BOT_DISPLAY) botOpts.add(d);
-      botBoxes[bi].setItems(botOpts);
-      // Restore from pending state
-      String currentMode = pendingBotModes[bi];
-      String displayVal = "Off";
-      for (int ki = 0; ki < BOT_KEYS.length; ki++) {
-        if (BOT_KEYS[ki].equals(currentMode)) { displayVal = BOT_DISPLAY[ki]; break; }
-      }
-      botBoxes[bi].setSelected(displayVal);
-      // Bot 4 is read-only unless spectator mode is enabled
-      if (bi == 3 && !pendingSpectator) {
-        botBoxes[bi].setDisabled(true);
-        botLabels[bi].setColor(1f, 1f, 1f, 0.35f);
-      }
-      final int botSlot = bi;
-      botBoxes[bi].addListener(new com.badlogic.gdx.scenes.scene2d.utils.ChangeListener() {
-        @Override
-        public void changed(ChangeEvent event, com.badlogic.gdx.scenes.scene2d.Actor actor) {
-          String sel = botBoxes[botSlot].getSelected();
-          for (int ki = 0; ki < BOT_DISPLAY.length; ki++) {
-            if (BOT_DISPLAY[ki].equals(sel)) { pendingBotModes[botSlot] = BOT_KEYS[ki]; return; }
-          }
-          pendingBotModes[botSlot] = "off";
-        }
-      });
-    }
-
     // ── Checkboxes ───────────────────────────────────────────────────────────
-    final CheckBox spectatorCheckbox = new CheckBox(" Spectator mode (watch bots only)", MyGdxGame.skin);
-    spectatorCheckbox.setChecked(pendingSpectator);
-    spectatorCheckbox.addListener(new com.badlogic.gdx.scenes.scene2d.utils.ChangeListener() {
-      @Override
-      public void changed(ChangeEvent event, com.badlogic.gdx.scenes.scene2d.Actor actor) {
-        pendingSpectator = spectatorCheckbox.isChecked();
-        // Reset Bot 4 selection when spectator is unchecked
-        if (!pendingSpectator) pendingBotModes[3] = "off";
-        Gdx.app.postRunnable(new Runnable() { @Override public void run() { show(); } });
-      }
-    });
-
     final CheckBox manualSetupCheckbox = new CheckBox(" Manual setup", MyGdxGame.skin);
     manualSetupCheckbox.setChecked(pendingManualSetup);
 
@@ -919,7 +871,6 @@ public class MenuScreen extends AbstractScreen {
             ? menuState.getMyName() + "'s game" : pendingSessionName;
         sessionAllowHeroSelection = heroCheckbox.isChecked();
         pendingManualSetup = manualSetupCheckbox.isChecked();
-        boolean isSpectator = spectatorCheckbox.isChecked();
         try {
           pendingStartingCards = Integer.parseInt(cardsBox.getSelected());
         } catch (NumberFormatException ex) { pendingStartingCards = 8; }
@@ -928,12 +879,6 @@ public class MenuScreen extends AbstractScreen {
         for (int ki = 0; ki < HERO_MODE_DISPLAY.length; ki++) {
           if (HERO_MODE_DISPLAY[ki].equals(selHeroMode)) { pendingHeroAssignMode = HERO_MODE_KEYS[ki]; break; }
         }
-        // Collect non-"off" bot modes (up to 3 normally, up to 4 in spectator mode)
-        int maxBots = isSpectator ? 4 : 3;
-        JSONArray botModesArr = new JSONArray();
-        for (int bi = 0; bi < maxBots; bi++) {
-          if (!"off".equals(pendingBotModes[bi])) botModesArr.put(pendingBotModes[bi]);
-        }
         JSONObject data = new JSONObject();
         try {
           data.put("name", menuState.getMyName());
@@ -941,8 +886,6 @@ public class MenuScreen extends AbstractScreen {
           data.put("allowHeroSelection", sessionAllowHeroSelection);
           data.put("startingCards", pendingStartingCards);
           data.put("manualSetup", pendingManualSetup);
-          data.put("botModes", botModesArr);
-          data.put("spectator", isSpectator);
           data.put("heroAssignMode", pendingHeroAssignMode);
           data.put("token", MyGdxGame.playerStorage.getToken());
           data.put("icon", selectedIcon);
@@ -952,8 +895,6 @@ public class MenuScreen extends AbstractScreen {
         pendingManualSetup = false;
         pendingStartingCards = 8;
         pendingHeroAssignMode = "value_mapping";
-        pendingSpectator = false;
-        pendingBotModes = new String[]{"off", "off", "off", "off"};
         inSessionCreate = false;
       }
     });
@@ -973,13 +914,6 @@ public class MenuScreen extends AbstractScreen {
     form.row();
     form.add(heroModeLabel).left().padRight(12f).padBottom(6f);
     form.add(heroModeBox).width(colW * 0.55f).left().padBottom(6f);
-    for (int bi = 0; bi < totalBotSlots; bi++) {
-      form.row();
-      form.add(botLabels[bi]).left().padRight(12f).padBottom(4f);
-      form.add(botBoxes[bi]).width(colW * 0.5f).left().padBottom(4f);
-    }
-    form.row();
-    form.add(spectatorCheckbox).colspan(2).left().padBottom(4f);
     form.row();
     form.add(manualSetupCheckbox).colspan(2).left().padBottom(4f);
     form.row();
@@ -1125,7 +1059,7 @@ public class MenuScreen extends AbstractScreen {
     lobbyTitle.setColor(1f, 1f, 1f, 0.98f);
     lobbyTitle.setPosition(Math.round(cx - lobbyTitle.getPrefWidth() / 2f), Math.round(0.835f * MyGdxGame.HEIGHT));
 
-    // table with all logged in users
+    // table showing all 4 lobby slots
     Table loggedInUserTable = new Table(MyGdxGame.skin);
     loggedInUserTable.setBackground(MyGdxGame.skin.newDrawable("white", new Color(0f, 0f, 0f, 0.35f)));
     loggedInUserTable.pad(14f, 18f, 14f, 18f);
@@ -1136,7 +1070,7 @@ public class MenuScreen extends AbstractScreen {
     int tableColumns = sessionAllowHeroSelection ? 3 : 2;
 
     Label headLine1 = new Label("Name", MyGdxGame.skin);
-    Label headLine2 = new Label("Status", MyGdxGame.skin);
+    Label headLine2 = new Label("Slot", MyGdxGame.skin);
     headLine1.setColor(1f, 1f, 1f, 0.9f);
     headLine2.setColor(1f, 1f, 1f, 0.9f);
 
@@ -1149,33 +1083,57 @@ public class MenuScreen extends AbstractScreen {
     loggedInUserTable.add(headLine2).padBottom(8f);
     loggedInUserTable.row();
 
-    for (int i = 0; i < loggedInUsers.size(); i++) {
-      User user = loggedInUsers.get(i);
-      Label nameLabel = new Label(user.getName(), MyGdxGame.skin);
+    final String[] SLOT_DISPLAY = {"Open", "Closed", "Passive Bot", "Balanced Bot", "Aggressive Bot", "Tactician Bot", "MCTS Bot"};
+    final String[] SLOT_TYPES   = {"open",  "closed",  "bot",         "bot",          "bot",            "bot",           "bot"};
+    final String[] SLOT_MODES   = {"",      "",         "passive",     "balanced",     "aggressive",     "tactician",     "mcts"};
 
-      if (user.getUserID().equals(menuState.getMyUserID())) {
-        nameLabel.setColor(Color.GOLD);
+    for (int slotIdx = 0; slotIdx < 4; slotIdx++) {
+      final int si = slotIdx;
+      String slotType = (lobbySlotTypes != null && lobbySlotTypes.length > slotIdx) ? lobbySlotTypes[slotIdx] : "open";
+      String slotUserId = (lobbySlotUserIds != null && lobbySlotUserIds.length > slotIdx) ? lobbySlotUserIds[slotIdx] : "";
+      String slotBotUserId = (lobbySlotBotUserIds != null && lobbySlotBotUserIds.length > slotIdx) ? lobbySlotBotUserIds[slotIdx] : "";
+
+      // Find the matching user in menuState
+      User rowUser = null;
+      if ("player".equals(slotType) && !slotUserId.isEmpty()) {
+        for (int ui = 0; ui < loggedInUsers.size(); ui++) {
+          if (loggedInUsers.get(ui).getUserID().equals(slotUserId)) { rowUser = loggedInUsers.get(ui); break; }
+        }
+      } else if ("bot".equals(slotType) && !slotBotUserId.isEmpty()) {
+        for (int ui = 0; ui < loggedInUsers.size(); ui++) {
+          if (loggedInUsers.get(ui).getUserID().equals(slotBotUserId)) { rowUser = loggedInUsers.get(ui); break; }
+        }
       }
 
-      Table statusBadge;
-      if (user.isReady()) {
-        statusBadge = createStatusBadge("READY", new Color(0.14f, 0.56f, 0.24f, 1f), Color.WHITE);
-      } else {
-        statusBadge = createStatusBadge("WAIT", new Color(0.64f, 0.14f, 0.14f, 1f), new Color(1f, 0.94f, 0.94f, 1f));
-      }
-
-      loggedInUserTable.add(buildNameCell(nameLabel, user.getIcon())).padRight(20).padBottom(6f).left();
-
-      if (sessionAllowHeroSelection) {
-        boolean isOwnRow = user.getUserID().equals(menuState.getMyUserID());
-        boolean isBotRow = user.getUserID().startsWith("bot_");
-        if (isOwnRow) {
-          refreshHeroDropdown();
-          loggedInUserTable.add(heroSelectBox).padRight(20).padBottom(6f)
-              .width(heroSelectBox.getWidth()).height(heroSelectBox.getHeight());
-        } else if (isBotRow && isHost) {
-          final String botUserId = user.getUserID();
-          final String botCurrentHero = user.getSelectedHero();
+      if ("player".equals(slotType) && rowUser != null) {
+        // Human player row
+        Label nameLabel = new Label(rowUser.getName(), MyGdxGame.skin);
+        if (rowUser.getUserID().equals(menuState.getMyUserID())) nameLabel.setColor(Color.GOLD);
+        loggedInUserTable.add(buildNameCell(nameLabel, rowUser.getIcon())).padRight(20).padBottom(6f).left();
+        if (sessionAllowHeroSelection) {
+          boolean isOwnRow = rowUser.getUserID().equals(menuState.getMyUserID());
+          if (isOwnRow) {
+            refreshHeroDropdown();
+            loggedInUserTable.add(heroSelectBox).padRight(20).padBottom(6f)
+                .width(heroSelectBox.getWidth()).height(heroSelectBox.getHeight());
+          } else {
+            String heroName = rowUser.getSelectedHero();
+            Label heroLbl = new Label("None".equals(heroName) ? "-" : heroName, MyGdxGame.skin);
+            loggedInUserTable.add(heroLbl).padRight(20).padBottom(6f);
+          }
+        }
+        Table statusBadge = rowUser.isReady()
+            ? createStatusBadge("READY", new Color(0.14f, 0.56f, 0.24f, 1f), Color.WHITE)
+            : createStatusBadge("WAIT", new Color(0.64f, 0.14f, 0.14f, 1f), new Color(1f, 0.94f, 0.94f, 1f));
+        loggedInUserTable.add(statusBadge).left().padBottom(6f);
+      } else if ("bot".equals(slotType) && rowUser != null) {
+        // Bot row
+        Label nameLabel = new Label(rowUser.getName(), MyGdxGame.skin);
+        nameLabel.setColor(0.6f, 0.9f, 1f, 1f);
+        loggedInUserTable.add(buildNameCell(nameLabel, rowUser.getIcon())).padRight(20).padBottom(6f).left();
+        if (sessionAllowHeroSelection && isHost) {
+          final String botUserId = rowUser.getUserID();
+          final String botCurrentHero = rowUser.getSelectedHero();
           final SelectBox<String> botHeroBox = new SelectBox<String>(MyGdxGame.skin);
           botHeroBox.setItems(buildHeroDropdownItems(botCurrentHero));
           botHeroBox.setSelected(botCurrentHero);
@@ -1194,16 +1152,52 @@ public class MenuScreen extends AbstractScreen {
           });
           loggedInUserTable.add(botHeroBox).padRight(20).padBottom(6f)
               .width(heroSelectBox.getWidth()).height(heroSelectBox.getHeight());
-        } else {
-          String heroName = user.getSelectedHero();
+        } else if (sessionAllowHeroSelection) {
+          String heroName = rowUser.getSelectedHero();
           Label heroLbl = new Label("None".equals(heroName) ? "-" : heroName, MyGdxGame.skin);
           loggedInUserTable.add(heroLbl).padRight(20).padBottom(6f);
         }
+        loggedInUserTable.add(createStatusBadge("READY", new Color(0.14f, 0.56f, 0.24f, 1f), Color.WHITE)).left().padBottom(6f);
+      } else {
+        // Empty slot (open or closed) — host gets a config dropdown, others see a label
+        if (slotIdx == 0) {
+          Label placeholder = new Label("(waiting)", MyGdxGame.skin);
+          placeholder.setColor(1f, 1f, 1f, 0.4f);
+          loggedInUserTable.add(placeholder).colspan(tableColumns).left().padBottom(6f);
+        } else if (isHost) {
+          String currentDisplay = "closed".equals(slotType) ? "Closed" : "Open";
+          final SelectBox<String> slotBox = new SelectBox<String>(MyGdxGame.skin);
+          Array<String> slotOpts = new Array<String>();
+          for (String d : SLOT_DISPLAY) slotOpts.add(d);
+          slotBox.setItems(slotOpts);
+          slotBox.setSelected(currentDisplay);
+          slotBox.addListener(new ChangeListener() {
+            @Override
+            public void changed(ChangeEvent event, com.badlogic.gdx.scenes.scene2d.Actor actor) {
+              String sel = slotBox.getSelected();
+              for (int ki = 0; ki < SLOT_DISPLAY.length; ki++) {
+                if (SLOT_DISPLAY[ki].equals(sel)) {
+                  try {
+                    JSONObject slotData = new JSONObject();
+                    slotData.put("slotIndex", si);
+                    slotData.put("slotType", SLOT_TYPES[ki]);
+                    if (!SLOT_MODES[ki].isEmpty()) slotData.put("botMode", SLOT_MODES[ki]);
+                    socket.emit("setLobbySlot", slotData);
+                  } catch (JSONException e) { /* ignore */ }
+                  return;
+                }
+              }
+            }
+          });
+          loggedInUserTable.add(slotBox).colspan(tableColumns).fillX().padBottom(6f);
+        } else {
+          Label slotLabel = new Label("closed".equals(slotType) ? "[ Closed ]" : "[ Open ]", MyGdxGame.skin);
+          slotLabel.setColor(1f, 1f, 1f, 0.45f);
+          loggedInUserTable.add(slotLabel).colspan(tableColumns).left().padBottom(6f);
+        }
       }
-
-      loggedInUserTable.add(statusBadge).left().padBottom(6f);
       loggedInUserTable.row();
-      if (i < loggedInUsers.size() - 1) {
+      if (slotIdx < 3) {
         Image sep = new Image(MyGdxGame.skin.newDrawable("white", new Color(1f, 1f, 1f, 0.14f)));
         loggedInUserTable.add(sep).colspan(tableColumns).growX().height(1f).padTop(2f).padBottom(5f);
         loggedInUserTable.row();
@@ -1840,6 +1834,43 @@ public class MenuScreen extends AbstractScreen {
     });
 
     // Connect only after all listeners are registered so no events are missed
+    socket.on("lobbySlots", new SocketListener() {
+      @Override
+      public void call(Object... args) {
+        final JSONArray slots = (JSONArray) args[0];
+        Gdx.app.postRunnable(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              for (int i = 0; i < Math.min(4, slots.length()); i++) {
+                JSONObject s = slots.getJSONObject(i);
+                String type = s.optString("type", "open");
+                lobbySlotTypes[i]      = type;
+                lobbySlotUserIds[i]    = s.optString("userId", "");
+                lobbySlotBotUserIds[i] = s.optString("botUserId", "");
+                lobbySlotBotModes[i]   = s.optString("botMode", "");
+              }
+            } catch (JSONException e) {
+              Gdx.app.log("SocketIO", "Error parsing lobbySlots: " + e.getMessage());
+            }
+            updateScreen = true;
+          }
+        });
+      }
+    });
+
+    socket.on("sessionFull", new SocketListener() {
+      @Override
+      public void call(Object... args) {
+        Gdx.app.postRunnable(new Runnable() {
+          @Override
+          public void run() {
+            updateScreen = true;
+          }
+        });
+      }
+    });
+
     socket.connect();
   }
 

--- a/server/index.js
+++ b/server/index.js
@@ -81,6 +81,7 @@ function createSession(name, allowHeroSelection, startingCards, manualSetup, her
     winnerHandled: false,
     timeToStart: 0,
     timer: null,
+    creatorSocketId: null, // set when the creator joins; used for host auth checks
     // lobbySlots: 4 slot configs describing what each player slot should contain.
     // Slot 0 = host (always 'player'); slots 1-3 default to 'open'.
     // Each entry: {type: 'player'|'open'|'closed'|'bot', userId?, botMode?, botUserId?}
@@ -130,7 +131,15 @@ function getSessionList() {
   return Object.values(sessions)
     .filter(function(s) { return !s.isTutorial; })
     .map(function(s) {
-      return { id: s.id, name: s.name, playerCount: s.users.length, running: s.gameState !== null };
+      var humanCount = s.users.filter(function(u) { return u.id.indexOf('bot_') !== 0; }).length
+                     + s.spectators.length;
+      var closedCount = 0;
+      if (s.lobbySlots) {
+        for (var ci = 0; ci < s.lobbySlots.length; ci++) {
+          if (s.lobbySlots[ci] && s.lobbySlots[ci].type === 'closed') closedCount++;
+        }
+      }
+      return { id: s.id, name: s.name, playerCount: humanCount, maxSlots: 4 - closedCount, running: s.gameState !== null };
     });
 }
 
@@ -147,10 +156,15 @@ function getReadyUsers(sess) {
 }
 
 function canSessionStart(sess, requesterSocketId) {
-  if (!sess || sess.gameState !== null || !sess.users.length || sess.users[0].id !== requesterSocketId) {
-    return false;
+  if (!sess || sess.gameState !== null || !sess.users.length) return false;
+  // Only the creator can start the game
+  if (sess.creatorSocketId !== requesterSocketId) return false;
+  // If creator is spectating (slot 0 = bot), game can start when ≥ 2 players/bots are ready
+  var creatorIsSpectator = sess.spectators.indexOf(requesterSocketId) !== -1;
+  if (creatorIsSpectator) {
+    return getReadyUsers(sess).length >= 2;
   }
-
+  // Normal: creator must themselves be ready, and at least 2 total ready
   var requester = sess.users.find(function(u) { return u.id === requesterSocketId; });
   return !!requester && requester.isReady && getReadyUsers(sess).length >= 2;
 }
@@ -197,8 +211,8 @@ function startCountdownForSession(sess, requesterSocketId, seconds) {
 function startGameForSession(sess, requesterSocketId) {
   if (!sess || sess.gameState !== null) return false;
 
-  // Host is the first player in lobby order.
-  if (!sess.users.length || sess.users[0].id !== requesterSocketId) {
+  // Only the session creator can start the game.
+  if (!sess.users.length || sess.creatorSocketId !== requesterSocketId) {
     return false;
   }
 
@@ -270,6 +284,15 @@ function startGameForSession(sess, requesterSocketId) {
       tokenMap[u.token].sessionId = sess.id;
     }
   });
+  // Send spectator view to any spectators (e.g. creator who set slot 0 to bot)
+  sess.spectators.forEach(function(sid) {
+    io.to(sid).emit('gameState', {
+      playerIndex: -1,
+      gameState: sess.gameState.serialize(),
+      heroAssignMode: sess.heroAssignMode || 'value_mapping'
+    });
+    console.log('gameState emitted to spectator ' + sid);
+  });
   // Auto-submit manual setup for bots using the smart card-selection strategy
   if (sess.manualSetup && sess.gameState.setupPhase) {
     sess.users.forEach(function(u, idx) {
@@ -329,9 +352,9 @@ function leaveCurrentSession(socket) {
   delete sess.heroSelections[socket.id];
   var userIdx = sess.users.findIndex(function(u) { return u.id === socket.id; });
 
-  // If the creator (users[0]) leaves before the game has started, close the lobby
-  // for everyone — the remaining players cannot start without a host.
-  if (sess.gameState === null && userIdx === 0 && sess.users.length > 1) {
+  // If the creator leaves before the game has started, close the lobby for everyone.
+  var isCreator = sess.creatorSocketId === socket.id;
+  if (sess.gameState === null && isCreator && (sess.users.length > 1 || sess.spectators.length > 1)) {
     io.to(sess.id).emit('sessionClosed', { reason: 'host_left' });
     // Evict all remaining users from the socket room
     sess.users.forEach(function(u) {
@@ -1154,6 +1177,7 @@ io.on('connection', function(socket) {
       var hostUser = makeUser(socket.id, name, cToken, icon);
       sess.users.unshift(hostUser);
       sess.lobbySlots[0] = {type: 'player', userId: socket.id};
+      sess.creatorSocketId = socket.id;
       if (cToken) {
         if (!tokenMap[cToken]) tokenMap[cToken] = {};
         tokenMap[cToken].name = name;
@@ -1161,7 +1185,7 @@ io.on('connection', function(socket) {
         tokenMap[cToken].sessionId = sess.id;
       }
       console.log("Session created: " + sess.id + " '" + sess.name + "' by " + name + " (heroes: " + allowHeroSelection + ", startingCards: " + sess.startingCards + ", manualSetup: " + manualSetup + ")");
-      socket.emit('sessionJoined', { sessionId: sess.id, allowHeroSelection: sess.allowHeroSelection, startingCards: sess.startingCards, manualSetup: sess.manualSetup });
+      socket.emit('sessionJoined', { sessionId: sess.id, allowHeroSelection: sess.allowHeroSelection, startingCards: sess.startingCards, manualSetup: sess.manualSetup, isHost: true });
       broadcastLobbyState(sess);
       socket.emit('gameStatus', { running: false });
       broadcastSessionList();
@@ -1244,40 +1268,67 @@ io.on('connection', function(socket) {
         }
       }
     }
-    if (sess.timer && !canSessionStart(sess, sess.users[0] && sess.users[0].id)) {
+    if (sess.timer && !canSessionStart(sess, sess.creatorSocketId)) {
       cancelStartCountdown(sess, true);
     }
     broadcastLobbyState(sess);
   });
 
-  // Host configures a lobby slot (slots 1–3). Cannot change slot 0 (host) or occupied player slots.
-  // data = { slotIndex: 1|2|3, slotType: 'open'|'closed'|'bot', botMode: 'passive'|'balanced'|... }
+  // Host configures any lobby slot 0–3. Cannot change slots occupied by other human players.
+  // data = { slotIndex: 0|1|2|3, slotType: 'player'|'open'|'closed'|'bot', botMode: 'passive'|'balanced'|... }
+  // slotType 'player' is only meaningful for slot 0 (revert host back from spectator).
   socket.on('setLobbySlot', function(data) {
     var sess = getSession(socket.id);
     if (!sess || sess.gameState !== null) return;
-    // Only the host (users[0]) may configure slots
-    if (!sess.users.length || sess.users[0].id !== socket.id) return;
+    // Only the creator may configure slots
+    if (sess.creatorSocketId !== socket.id) return;
     var slotIndex = parseInt(data && data.slotIndex);
-    if (isNaN(slotIndex) || slotIndex < 1 || slotIndex > 3) return;
+    if (isNaN(slotIndex) || slotIndex < 0 || slotIndex > 3) return;
     var VALID_MODES = ['passive', 'balanced', 'aggressive', 'tactician', 'mcts'];
     var BOT_MODE_LABELS = { passive: 'Passive', balanced: 'Balanced', aggressive: 'Aggressive', tactician: 'Tactician', mcts: 'MCTS' };
     var newType = String(data.slotType || 'open');
     var newBotMode = String(data.botMode || 'balanced');
     var currentSlot = sess.lobbySlots[slotIndex];
-    // Cannot reconfigure a slot that has a real human player
-    if (currentSlot && currentSlot.type === 'player') return;
+    // Cannot reconfigure a slot occupied by a human who is not the creator
+    if (currentSlot && currentSlot.type === 'player' && currentSlot.userId !== socket.id) return;
     // Remove existing bot from this slot if any
     if (currentSlot && currentSlot.type === 'bot' && currentSlot.botUserId) {
       sess.users = sess.users.filter(function(u) { return u.id !== currentSlot.botUserId; });
       delete sess.heroSelections[currentSlot.botUserId];
     }
-    if (newType === 'bot' && VALID_MODES.indexOf(newBotMode) !== -1) {
+    if (slotIndex === 0 && (newType === 'open' || newType === 'closed')) {
+      // Slot 0 cannot be open or closed — revert to player
+      newType = 'player';
+    }
+    if (slotIndex === 0 && newType === 'player') {
+      // Revert slot 0 back to the creator being a real player
+      var specIdx0 = sess.spectators.indexOf(socket.id);
+      if (specIdx0 !== -1) sess.spectators.splice(specIdx0, 1);
+      var alreadyUser = sess.users.find(function(u) { return u.id === socket.id; });
+      if (!alreadyUser) {
+        var cp = connectedPlayers[socket.id];
+        var hostUser = makeUser(socket.id, cp ? cp.name : 'Host', null, cp ? cp.icon : '');
+        sess.users.unshift(hostUser);
+      }
+      sess.lobbySlots[0] = {type: 'player', userId: socket.id};
+      console.log("Slot 0 reverted to player (creator) in session " + sess.id);
+    } else if (newType === 'bot' && VALID_MODES.indexOf(newBotMode) !== -1) {
+      if (slotIndex === 0) {
+        // Move creator from users to spectators
+        var userIdx0 = sess.users.findIndex(function(u) { return u.id === socket.id; });
+        if (userIdx0 !== -1) sess.users.splice(userIdx0, 1);
+        if (sess.spectators.indexOf(socket.id) === -1) sess.spectators.push(socket.id);
+      }
       var botId = 'bot_' + sess.id + '_slot' + slotIndex;
       var botLabel = BOT_MODE_LABELS[newBotMode] || 'Bot';
       var botUser = makeUser(botId, 'Bot ' + slotIndex + ' (' + botLabel + ')');
       botUser.isReady = true;
       botUser.botMode = newBotMode;
-      sess.users.push(botUser);
+      if (slotIndex === 0) {
+        sess.users.unshift(botUser); // slot 0 bot is always users[0]
+      } else {
+        sess.users.push(botUser);
+      }
       sess.lobbySlots[slotIndex] = {type: 'bot', botMode: newBotMode, botUserId: botId};
       console.log("Slot " + slotIndex + " set to bot (" + newBotMode + ") in session " + sess.id);
     } else if (newType === 'closed') {

--- a/server/index.js
+++ b/server/index.js
@@ -80,9 +80,45 @@ function createSession(name, allowHeroSelection, startingCards, manualSetup, her
     heroSelections: {},
     winnerHandled: false,
     timeToStart: 0,
-    timer: null
+    timer: null,
+    // lobbySlots: 4 slot configs describing what each player slot should contain.
+    // Slot 0 = host (always 'player'); slots 1-3 default to 'open'.
+    // Each entry: {type: 'player'|'open'|'closed'|'bot', userId?, botMode?, botUserId?}
+    lobbySlots: [
+      {type: 'player'},
+      {type: 'open'},
+      {type: 'open'},
+      {type: 'open'}
+    ]
   };
   return sessions[id];
+}
+
+// Build the lobbySlots array for broadcasting to clients.
+function getLobbySlots(sess) {
+  if (!sess.lobbySlots) {
+    return [{type:'player'},{type:'open'},{type:'open'},{type:'open'}];
+  }
+  return sess.lobbySlots.map(function(slot) {
+    return {
+      type: slot.type,
+      botMode: slot.botMode || null,
+      userId: slot.userId || null,
+      botUserId: slot.botUserId || null
+    };
+  });
+}
+
+// Emit both getUsers and lobbySlots to the session room.
+function broadcastLobbyState(sess) {
+  io.to(sess.id).emit('getUsers', getUsersWithHeroes(sess));
+  io.to(sess.id).emit('lobbySlots', getLobbySlots(sess));
+}
+
+// Emit both getUsers and lobbySlots to a single socket (e.g. when a new player joins).
+function sendLobbyStateToSocket(sess, sock) {
+  sock.emit('getUsers', getUsersWithHeroes(sess));
+  sock.emit('lobbySlots', getLobbySlots(sess));
 }
 
 function getSession(socketId) {
@@ -321,10 +357,19 @@ function leaveCurrentSession(socket) {
   }
 
   if (userIdx !== -1) sess.users.splice(userIdx, 1);
+  // Reset the slot this player occupied back to 'open'
+  if (sess.lobbySlots) {
+    for (var lsi = 1; lsi <= 3; lsi++) {
+      if (sess.lobbySlots[lsi] && sess.lobbySlots[lsi].type === 'player' && sess.lobbySlots[lsi].userId === socket.id) {
+        sess.lobbySlots[lsi] = {type: 'open'};
+        break;
+      }
+    }
+  }
   var specIdx = sess.spectators.indexOf(socket.id);
   if (specIdx !== -1) sess.spectators.splice(specIdx, 1);
   socket.leave(sess.id);
-  io.to(sess.id).emit('getUsers', getUsersWithHeroes(sess));
+  broadcastLobbyState(sess);
   // Destroy tutorial sessions when the human leaves: only the bot would remain
   // and it would keep playing in a session no real user will ever rejoin.
   var humansLeft = sess.users.filter(function(u) { return u.id.indexOf('bot_') !== 0; }).length;
@@ -1058,20 +1103,16 @@ io.on('connection', function(socket) {
     var heroAssignMode = (data && VALID_HERO_MODES.indexOf(String(data.heroAssignMode)) !== -1)
       ? String(data.heroAssignMode) : 'value_mapping';
     var sess = createSession(sessionName, allowHeroSelection, startingCards, manualSetup, heroAssignMode);
-    // botModes: array of personality strings, e.g. ["aggressive","passive"].
-    // Falls back to legacy botCount (numeric) for backward compat.
-    // Spectator mode allows up to 4 bots; normal mode allows up to 3.
+    // botModes: legacy support — still accepted from old clients or spectator mode.
+    // In the new lobby flow, bots are configured after session creation via setLobbySlot.
     var VALID_MODES = ['passive', 'balanced', 'aggressive', 'tactician', 'mcts'];
+    var BOT_MODE_LABELS = { passive: 'Passive', balanced: 'Balanced', aggressive: 'Aggressive', tactician: 'Tactician', mcts: 'MCTS' };
     var maxBots = spectatorMode ? 4 : 3;
     var botModes = [];
-    if (data && Array.isArray(data.botModes)) {
+    if (spectatorMode && data && Array.isArray(data.botModes)) {
+      // Spectator mode: bots configured at creation time (no host player slot)
       botModes = data.botModes.filter(function(m) { return VALID_MODES.indexOf(String(m)) !== -1; }).slice(0, maxBots);
-    } else {
-      var legacyCount = Math.min(maxBots, Math.max(0, parseInt(data && data.botCount) || 0));
-      for (var li = 0; li < legacyCount; li++) botModes.push('balanced');
     }
-    var cToken = (data && data.token) ? String(data.token).slice(0, 64) : null;
-    var BOT_MODE_LABELS = { passive: 'Passive', balanced: 'Balanced', aggressive: 'Aggressive', tactician: 'Tactician', mcts: 'MCTS' };
     for (var bi = 0; bi < botModes.length; bi++) {
       var mode = botModes[bi];
       var label = BOT_MODE_LABELS[mode] || 'Bot';
@@ -1080,6 +1121,7 @@ io.on('connection', function(socket) {
       botUser.botMode = mode;
       sess.users.push(botUser);
     }
+    var cToken = (data && data.token) ? String(data.token).slice(0, 64) : null;
     socketToSession[socket.id] = sess.id;
     socket.join(sess.id);
 
@@ -1108,17 +1150,19 @@ io.on('connection', function(socket) {
       broadcastPlayerList();
       bot.playBotTurnIfNeeded(sess);
     } else {
-      // Normal mode: creator joins as player.
-      sess.users.unshift(makeUser(socket.id, name, cToken, icon));
+      // Normal mode: creator joins as player in slot 0.
+      var hostUser = makeUser(socket.id, name, cToken, icon);
+      sess.users.unshift(hostUser);
+      sess.lobbySlots[0] = {type: 'player', userId: socket.id};
       if (cToken) {
         if (!tokenMap[cToken]) tokenMap[cToken] = {};
         tokenMap[cToken].name = name;
         tokenMap[cToken].socketId = socket.id;
         tokenMap[cToken].sessionId = sess.id;
       }
-      console.log("Session created: " + sess.id + " '" + sess.name + "' by " + name + " (heroes: " + allowHeroSelection + ", startingCards: " + sess.startingCards + ", manualSetup: " + manualSetup + ", bots: [" + botModes.join(',') + "])");
+      console.log("Session created: " + sess.id + " '" + sess.name + "' by " + name + " (heroes: " + allowHeroSelection + ", startingCards: " + sess.startingCards + ", manualSetup: " + manualSetup + ")");
       socket.emit('sessionJoined', { sessionId: sess.id, allowHeroSelection: sess.allowHeroSelection, startingCards: sess.startingCards, manualSetup: sess.manualSetup });
-      io.to(sess.id).emit('getUsers', getUsersWithHeroes(sess));
+      broadcastLobbyState(sess);
       socket.emit('gameStatus', { running: false });
       broadcastSessionList();
       broadcastPlayerList();
@@ -1130,14 +1174,26 @@ io.on('connection', function(socket) {
     var sess = sessions[data.sessionId];
     if (!sess) { socket.emit('sessionNotFound'); return; }
     if (sess.gameState !== null) { socket.emit('gameStatus', { running: true }); return; }
+    // Reject if no open slots remain
+    var openSlotIdx = -1;
+    for (var si = 1; si <= 3; si++) {
+      if (sess.lobbySlots && sess.lobbySlots[si] && sess.lobbySlots[si].type === 'open') {
+        openSlotIdx = si;
+        break;
+      }
+    }
+    if (openSlotIdx === -1) { socket.emit('sessionFull'); return; }
     leaveCurrentSession(socket); // leave any previous session first
     sess = sessions[data.sessionId]; // re-fetch — leaveCurrentSession may have deleted a different session
+    if (!sess) { socket.emit('sessionNotFound'); return; }
     var name = (data.name) ? String(data.name).slice(0, 30) : 'Player';
     var jIcon = (data && data.icon) ? String(data.icon).slice(0, 50) : (connectedPlayers[socket.id] ? connectedPlayers[socket.id].icon || '' : '');
     var jToken = (data && data.token) ? String(data.token).slice(0, 64) : null;
     if (connectedPlayers[socket.id]) { connectedPlayers[socket.id].name = name; connectedPlayers[socket.id].icon = jIcon; }
     var existing = sess.users.find(function(u) { return u.id === socket.id; });
     if (!existing) sess.users.push(makeUser(socket.id, name, jToken, jIcon));
+    // Assign to the first open slot
+    sess.lobbySlots[openSlotIdx] = {type: 'player', userId: socket.id};
     if (jToken) {
       if (!tokenMap[jToken]) tokenMap[jToken] = {};
       tokenMap[jToken].name = name;
@@ -1146,7 +1202,7 @@ io.on('connection', function(socket) {
     }
     socketToSession[socket.id] = sess.id;
     socket.join(sess.id);
-    console.log("User " + name + " joined session " + sess.id);
+    console.log("User " + name + " joined session " + sess.id + " (slot " + openSlotIdx + ")");
     // Send existing hero reservations to the new joiner
     Object.keys(sess.heroSelections).forEach(function(sid) {
       var h = sess.heroSelections[sid];
@@ -1155,7 +1211,7 @@ io.on('connection', function(socket) {
       }
     });
     socket.emit('sessionJoined', { sessionId: sess.id, allowHeroSelection: sess.allowHeroSelection, startingCards: sess.startingCards, manualSetup: sess.manualSetup });
-    io.to(sess.id).emit('getUsers', getUsersWithHeroes(sess));
+    broadcastLobbyState(sess);
     socket.emit('gameStatus', { running: false });
     broadcastSessionList();
     broadcastPlayerList();
@@ -1191,8 +1247,50 @@ io.on('connection', function(socket) {
     if (sess.timer && !canSessionStart(sess, sess.users[0] && sess.users[0].id)) {
       cancelStartCountdown(sess, true);
     }
-    io.to(sess.id).emit('getUsers', getUsersWithHeroes(sess));
+    broadcastLobbyState(sess);
   });
+
+  // Host configures a lobby slot (slots 1–3). Cannot change slot 0 (host) or occupied player slots.
+  // data = { slotIndex: 1|2|3, slotType: 'open'|'closed'|'bot', botMode: 'passive'|'balanced'|... }
+  socket.on('setLobbySlot', function(data) {
+    var sess = getSession(socket.id);
+    if (!sess || sess.gameState !== null) return;
+    // Only the host (users[0]) may configure slots
+    if (!sess.users.length || sess.users[0].id !== socket.id) return;
+    var slotIndex = parseInt(data && data.slotIndex);
+    if (isNaN(slotIndex) || slotIndex < 1 || slotIndex > 3) return;
+    var VALID_MODES = ['passive', 'balanced', 'aggressive', 'tactician', 'mcts'];
+    var BOT_MODE_LABELS = { passive: 'Passive', balanced: 'Balanced', aggressive: 'Aggressive', tactician: 'Tactician', mcts: 'MCTS' };
+    var newType = String(data.slotType || 'open');
+    var newBotMode = String(data.botMode || 'balanced');
+    var currentSlot = sess.lobbySlots[slotIndex];
+    // Cannot reconfigure a slot that has a real human player
+    if (currentSlot && currentSlot.type === 'player') return;
+    // Remove existing bot from this slot if any
+    if (currentSlot && currentSlot.type === 'bot' && currentSlot.botUserId) {
+      sess.users = sess.users.filter(function(u) { return u.id !== currentSlot.botUserId; });
+      delete sess.heroSelections[currentSlot.botUserId];
+    }
+    if (newType === 'bot' && VALID_MODES.indexOf(newBotMode) !== -1) {
+      var botId = 'bot_' + sess.id + '_slot' + slotIndex;
+      var botLabel = BOT_MODE_LABELS[newBotMode] || 'Bot';
+      var botUser = makeUser(botId, 'Bot ' + slotIndex + ' (' + botLabel + ')');
+      botUser.isReady = true;
+      botUser.botMode = newBotMode;
+      sess.users.push(botUser);
+      sess.lobbySlots[slotIndex] = {type: 'bot', botMode: newBotMode, botUserId: botId};
+      console.log("Slot " + slotIndex + " set to bot (" + newBotMode + ") in session " + sess.id);
+    } else if (newType === 'closed') {
+      sess.lobbySlots[slotIndex] = {type: 'closed'};
+      console.log("Slot " + slotIndex + " closed in session " + sess.id);
+    } else {
+      sess.lobbySlots[slotIndex] = {type: 'open'};
+      console.log("Slot " + slotIndex + " opened in session " + sess.id);
+    }
+    broadcastLobbyState(sess);
+    broadcastSessionList();
+  });
+
   
   socket.on('startTimer', function(seconds) {
     var sess = getSession(socket.id);
@@ -1559,7 +1657,7 @@ io.on('connection', function(socket) {
     if (heroName !== 'None' && heroName !== 'Random') {
       socket.to(sess.id).emit('heroReserved', { heroName: heroName });
     }
-    io.to(sess.id).emit('getUsers', getUsersWithHeroes(sess));
+    broadcastLobbyState(sess);
   });
 
   socket.on('mercDefBoost', function(data) {

--- a/server/index.js
+++ b/server/index.js
@@ -131,8 +131,7 @@ function getSessionList() {
   return Object.values(sessions)
     .filter(function(s) { return !s.isTutorial; })
     .map(function(s) {
-      var humanCount = s.users.filter(function(u) { return u.id.indexOf('bot_') !== 0; }).length
-                     + s.spectators.length;
+      var humanCount = s.users.length + s.spectators.length;
       var closedCount = 0;
       if (s.lobbySlots) {
         for (var ci = 0; ci < s.lobbySlots.length; ci++) {


### PR DESCRIPTION
Closes #248

## Summary

Moves bot configuration out of the session-create screen and into the game lobby itself. The host can now configure each of the 3 non-host slots directly while waiting for players.

## Changes

### Server (`server/index.js`)
- Sessions now track 4 lobby slots: `[{type: 'player'|'open'|'closed'|'bot', userId?, botMode?, botUserId?}]`
- `joinSession`: assigns joining players to the first open slot; rejects with `sessionFull` if no open slot exists
- `leaveCurrentSession`: resets the player's slot back to `open` on leave
- New `setLobbySlot` event: host-only; configures slots 1–3 (open/closed/bot with mode)
- New `broadcastLobbyState()` helper: sends both `getUsers` and `lobbySlots` to all room members
- All lobby state changes now use `broadcastLobbyState` instead of ad-hoc `getUsers` emits

### Client (`core/src/com/mygdx/game/MenuScreen.java`)
- **Create screen**: removed bot selectors and spectator checkbox (now configured in the lobby)
- **Lobby screen**: redesigned to always show exactly 4 rows, one per slot:
  - Slot 0: always the host (real player row)
  - Slots 1–3: driven by `lobbySlots` events from server
    - `player`: shows name, hero, READY/WAIT badge
    - `bot`: shows bot name (blue), hero, READY badge
    - `open`/`closed`: host sees a dropdown (Open / Closed / Passive Bot / Balanced Bot / Aggressive Bot / Tactician Bot / MCTS Bot); guests see a dimmed label
- Added `lobbySlots` socket listener that parses slot state and triggers a screen redraw
- Added `sessionFull` socket listener