### PR TITLE
Dismiss mobile keyboard after sending a chat message

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -4876,7 +4876,7 @@ public class GameScreen extends ScreenAdapter {
         String text = inputField.getText().trim();
         if (text.isEmpty()) return;
         inputField.setText("");
-        MyGdxGame.keyboardHelper.showKeyboard(inputField, doSendRef[0]);
+        MyGdxGame.keyboardHelper.hideKeyboard();
         try {
           JSONObject msg = new JSONObject();
           String senderName = currentPlayer != null ? currentPlayer.getPlayerName() : "?";


### PR DESCRIPTION
Closes #262

## What changed

In `GameScreen.java`, the `doSend` runnable previously called `showKeyboard()` immediately after sending so the keyboard stayed open. This is unintuitive on mobile — the keyboard should dismiss after sending and only re-open when the user taps the text field again.

**One-line change:** replaced `MyGdxGame.keyboardHelper.showKeyboard(inputField, doSendRef[0])` with `MyGdxGame.keyboardHelper.hideKeyboard()` in the send action. The existing `touchDown` listener on `inputField` already handles re-showing the keyboard on tap.