### PR TITLE
feat: add game sound effects for in-game events (#115)

### DIFF
--- a/android/assets/data/sounds/bentomusic-comical-style-music-of-silliness-and-goofing-around-loop-439124.mp3
+++ b/android/assets/data/sounds/bentomusic-comical-style-music-of-silliness-and-goofing-around-loop-439124.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd5a87174b4c429cf9decf384a353299639994b6e5e065b8d5384836e4ee028e
+size 820035

--- a/android/assets/data/sounds/dragon-studio-horse-neigh-515279.mp3
+++ b/android/assets/data/sounds/dragon-studio-horse-neigh-515279.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92a5e82eb23cdea9c2b24c6e42d1618339e817374d85975a86fd1afad814dadb
+size 80640

--- a/android/assets/data/sounds/dragon-studio-loud-explosion-425457.mp3
+++ b/android/assets/data/sounds/dragon-studio-loud-explosion-425457.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7f21b3d499404cfbf1517857abaf6ccef82d3f6158af3702e63bb0ed8e58899
+size 92928

--- a/android/assets/data/sounds/freesound_community-carddrop2-92718.mp3
+++ b/android/assets/data/sounds/freesound_community-carddrop2-92718.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e15d5d38a7899ee30c11666fa26d2d381ca6e0fc80dceb4640d23094232ce305
+size 8640

--- a/android/assets/data/sounds/freesound_community-cartoon-slurp-37066.mp3
+++ b/android/assets/data/sounds/freesound_community-cartoon-slurp-37066.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c59747b96c26acdf44080f26affa4d048cdf176fd004f6c2f36085ec244818d7
+size 8640

--- a/android/assets/data/sounds/freesound_community-fx-comedy-marching-78276.mp3
+++ b/android/assets/data/sounds/freesound_community-fx-comedy-marching-78276.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad3bca3a9fb443423cc07e998e10167bef425a2c563f6dd8fec4611bc4b8b919
+size 518880

--- a/android/assets/data/sounds/freesound_community-joker-laugh-2-98829.mp3
+++ b/android/assets/data/sounds/freesound_community-joker-laugh-2-98829.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fc63b972cf09cdea494b6df89e3b23c357a7ab089659797f8dcd24ccc18188f
+size 56160

--- a/android/assets/data/sounds/freesound_community-medieval-fanfare-6826.mp3
+++ b/android/assets/data/sounds/freesound_community-medieval-fanfare-6826.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95cd0e345e6394cd135c17a4e710d62c19ba1e8ff0d4170330633be0ab910f8b
+size 155520

--- a/android/assets/data/sounds/freesound_community-middle-ages-war-crywav-14780.mp3
+++ b/android/assets/data/sounds/freesound_community-middle-ages-war-crywav-14780.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dabdd69709180d1f7fe0170254575354c38aa3f786f28a041822b0db976a703f
+size 36960

--- a/android/assets/data/sounds/freesound_community-riffle-card-shuffle-104313.mp3
+++ b/android/assets/data/sounds/freesound_community-riffle-card-shuffle-104313.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffd23bd72634de824e9583eea7fcc1f266893675ca3923072f64817ceeb2217a
+size 137472

--- a/android/assets/data/sounds/freesound_community-sfx_spirit_gain-95855.mp3
+++ b/android/assets/data/sounds/freesound_community-sfx_spirit_gain-95855.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3a5ae8360d8ec9d843f0e817ae2c916b3eb52fb804af6f862b6f60cfa586b2d
+size 145920

--- a/android/assets/data/sounds/fxprosound-magic-glitter-wand-5-248607.mp3
+++ b/android/assets/data/sounds/fxprosound-magic-glitter-wand-5-248607.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb62df81782b4bdcac51219ef40063ce5a5be671a04793c17085967463959bcb
+size 174707

--- a/android/assets/data/sounds/ksjsbwuil-apple-pay-success-sound-effect-481188.mp3
+++ b/android/assets/data/sounds/ksjsbwuil-apple-pay-success-sound-effect-481188.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6cf447db4d4dc0e04b388a3ead483d6866e045eec63f57ecff66ec9efd259bc
+size 49152

--- a/android/assets/data/sounds/universfield-fail-trumpet-02-383962.mp3
+++ b/android/assets/data/sounds/universfield-fail-trumpet-02-383962.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:707970b8ed61fc9b5c465f37f687b8ca285ef27908e0990358707ef6bf4660a8
+size 63744

--- a/android/src/com/mygdx/game/AndroidPlayerStorage.java
+++ b/android/src/com/mygdx/game/AndroidPlayerStorage.java
@@ -11,6 +11,7 @@ public class AndroidPlayerStorage implements PlayerStorage {
     private static final String KEY_SESSION_ID    = "session_id";
     private static final String KEY_SHOW_PLAYERS  = "show_players_tab";
     private static final String KEY_MUSIC_ENABLED = "music_enabled";
+    private static final String KEY_SOUND_ENABLED = "sound_enabled";
     private static final String KEY_ICON          = "player_icon";
 
     private final SharedPreferences prefs;
@@ -39,6 +40,8 @@ public class AndroidPlayerStorage implements PlayerStorage {
     @Override public void    saveShowPlayersTab(boolean val)     { prefs.edit().putBoolean(KEY_SHOW_PLAYERS, val).apply(); }
     @Override public boolean getMusicEnabled()                   { return prefs.getBoolean(KEY_MUSIC_ENABLED, true); }
     @Override public void    saveMusicEnabled(boolean enabled)   { prefs.edit().putBoolean(KEY_MUSIC_ENABLED, enabled).apply(); }
+    @Override public boolean getSoundEnabled()                   { return prefs.getBoolean(KEY_SOUND_ENABLED, true); }
+    @Override public void    saveSoundEnabled(boolean enabled)   { prefs.edit().putBoolean(KEY_SOUND_ENABLED, enabled).apply(); }
     @Override public String  getSavedIcon()                      { return prefs.getString(KEY_ICON, ""); }
     @Override public void    saveIcon(String icon)               { prefs.edit().putString(KEY_ICON, icon).apply(); }
     @Override public void    clearIcon()                         { prefs.edit().remove(KEY_ICON).apply(); }

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -324,6 +324,18 @@ public class GameScreen extends ScreenAdapter {
         Gdx.app.log("DIAG", "stateUpdate received seq=" + diagSeq + " currentPlayerIdx=" + diagIdx);
         try {
           applyStateUpdate(data);
+          // Play server-initiated sound events (all players hear these)
+          JSONArray soundEvts = data.optJSONArray("soundEvents");
+          if (soundEvts != null) {
+            for (int si = 0; si < soundEvts.length(); si++) {
+              try {
+                String key = soundEvts.getString(si);
+                if ("shuffle".equals(key)) MyGdxGame.playGameSound(MyGdxGame.soundCardShuffle);
+                else if ("slurp".equals(key)) MyGdxGame.playGameSound(MyGdxGame.soundSlurp);
+                else if ("joker_laugh".equals(key)) MyGdxGame.playGameSound(MyGdxGame.soundJokerLaugh);
+              } catch (JSONException ignored) {}
+            }
+          }
         } catch (Exception e) {
           // A RuntimeException inside applyStateUpdate was previously silently escaping
           // the JSONException catch, skipping setUpdateState(true) and freezing the UI.
@@ -2250,6 +2262,7 @@ public class GameScreen extends ScreenAdapter {
               JSONArray atkIds = new JSONArray();
               for (Card c : apt.getPendingAttackCards()) { atkIds.put(c.getCardId()); }
               emitData.put("attackCardIds", atkIds);
+              if (apt.isKingUsed()) MyGdxGame.playGameSound(MyGdxGame.soundKingAttack);
               socket.emit("kingAttackResolved", emitData);
               tutorialAdvance(TUTORIAL_STEP_KING_ATTACK);
             } catch (JSONException e) {
@@ -2286,6 +2299,7 @@ public class GameScreen extends ScreenAdapter {
               JSONArray ownDefIds = new JSONArray();
               for (Card c : apt.getPendingAttackOwnDefCards()) { ownDefIds.put(c.getCardId()); }
               emitData.put("attackerOwnDefCardIds", ownDefIds);
+              if (apt.isKingUsed()) MyGdxGame.playGameSound(MyGdxGame.soundKingAttack);
               socket.emit("defAttackResolved", emitData);
               tutorialAdvance(TUTORIAL_STEP_KING_ATTACK);
             } catch (JSONException e) {
@@ -5750,6 +5764,7 @@ public class GameScreen extends ScreenAdapter {
 
   private void emitTakeDefCard(int positionId) {
     if (socket == null) return;
+    MyGdxGame.playGameSound(MyGdxGame.soundCardDrop);
     try {
       // Issue #167: if the def cards on this slot carried mercenaries, reset
       // their boost on peer clients first so the boost label disappears once
@@ -5783,6 +5798,7 @@ public class GameScreen extends ScreenAdapter {
 
   private void emitPutDefCard(int positionId, int cardId) {
     if (socket == null) return;
+    MyGdxGame.playGameSound(MyGdxGame.soundCardDrop);
     try {
       JSONObject payload = new JSONObject();
       payload.put("playerIdx", playerIndex);

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -1978,6 +1978,7 @@ public class GameScreen extends ScreenAdapter {
             JSONArray ownDefIdArr = new JSONArray();
             for (Card c : pt.getPendingAttackOwnDefCards()) ownDefIdArr.put(c.getCardId());
             emitData.put("attackerOwnDefCardIds", ownDefIdArr);
+            if (pt.isKingUsed()) MyGdxGame.playGameSound(MyGdxGame.soundKingAttack);
             socket.emit("lootResolved", emitData);
           } catch (JSONException e) {
             e.printStackTrace();
@@ -4709,6 +4710,18 @@ public class GameScreen extends ScreenAdapter {
       }
     });
     table.add(historyBtn).width(300).height(90).padBottom(5).row();
+
+    final boolean soundOn = MyGdxGame.playerStorage.getSoundEnabled();
+    final TextButton soundBtn = new TextButton(soundOn ? "Sound: ON" : "Sound: OFF", MyGdxGame.skin);
+    soundBtn.addListener(new ClickListener() {
+      @Override
+      public void clicked(InputEvent event, float x, float y) {
+        boolean newVal = !MyGdxGame.playerStorage.getSoundEnabled();
+        MyGdxGame.setSoundEnabled(newVal);
+        soundBtn.setText(newVal ? "Sound: ON" : "Sound: OFF");
+      }
+    });
+    table.add(soundBtn).width(300).height(90).padBottom(5).row();
 
     if (isSpectator || (currentPlayer != null && currentPlayer.isOut())) {
       TextButton leaveBtn = new TextButton("Leave Game", MyGdxGame.skin);

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -333,12 +333,6 @@ public class GameScreen extends ScreenAdapter {
                 if ("shuffle".equals(key)) MyGdxGame.playGameSound(MyGdxGame.soundCardShuffle);
                 else if ("slurp".equals(key)) MyGdxGame.playGameSound(MyGdxGame.soundSlurp);
                 else if ("joker_laugh".equals(key)) MyGdxGame.playGameSound(MyGdxGame.soundJokerLaugh);
-                else if ("hero_spy".equals(key))         MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroSpy);
-                else if ("hero_mercenaries".equals(key)) MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroMercenaries);
-                else if ("hero_marshal".equals(key))     MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroMarshal);
-                else if ("hero_priest".equals(key))      MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroPriest);
-                else if ("hero_banneret".equals(key))    MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroBanneret);
-                else if ("hero_magician".equals(key))    MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroMagician);
               } catch (JSONException ignored) {}
             }
           }
@@ -432,6 +426,7 @@ public class GameScreen extends ScreenAdapter {
                 heroRevealPlayerName  = players.get(pIdx).getPlayerName();
                 heroRevealHeroName    = heroName;
                 heroRevealDrawnCardId = drawnId;
+                MyGdxGame.playHeroWonSound(heroName);
               }
               gameState.setUpdateState(true);
             } catch (JSONException e) {
@@ -631,8 +626,6 @@ public class GameScreen extends ScreenAdapter {
           public void run() {
             try {
               int attackerIdx = data.getInt("attackerIdx");
-              // Battery Tower fires — all players hear the explosion
-              MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroBatteryTower);
               if (attackerIdx == myPlayerIndex) {
                 int defIdx3 = data.optInt("targetPlayerIdx", -1);
                 String defName3 = (defIdx3 >= 0 && defIdx3 < gameState.getPlayers().size())
@@ -697,8 +690,6 @@ public class GameScreen extends ScreenAdapter {
                 while (c.getBoosted() > boosted) c.addBoosted(-1);
                 while (c.getBoosted() < boosted) c.addBoosted(1);
               }
-              // Mercenaries are being allocated — all players hear the fanfare
-              if (boosted > 0) MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroMercenaries);
               gameState.setUpdateState(true);
             } catch (JSONException e) {
               e.printStackTrace();
@@ -2922,7 +2913,6 @@ public class GameScreen extends ScreenAdapter {
             resp.put("isKing", btCheck.optBoolean("isKing", false));
             JSONArray atkExpIds = btCheck.optJSONArray("attackCardIds");
             if (atkExpIds != null) resp.put("attackCardIds", atkExpIds);
-            MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroBatteryTower);
             socket.emit("batteryDenyAttack", resp);
             pendingBatteryResultCards = atkExpIds;
             pendingBatteryDefCheck = null;
@@ -6585,6 +6575,7 @@ public class GameScreen extends ScreenAdapter {
     heroRevealPlayerName = currentPlayer.getPlayerName();
     heroRevealHeroName   = hero.getHeroName();
     heroRevealDrawnCardId = drawnCardId;
+    MyGdxGame.playHeroWonSound(hero.getHeroName());
     gameState.setUpdateState(true);
   }
 

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -333,6 +333,12 @@ public class GameScreen extends ScreenAdapter {
                 if ("shuffle".equals(key)) MyGdxGame.playGameSound(MyGdxGame.soundCardShuffle);
                 else if ("slurp".equals(key)) MyGdxGame.playGameSound(MyGdxGame.soundSlurp);
                 else if ("joker_laugh".equals(key)) MyGdxGame.playGameSound(MyGdxGame.soundJokerLaugh);
+                else if ("hero_spy".equals(key))         MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroSpy);
+                else if ("hero_mercenaries".equals(key)) MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroMercenaries);
+                else if ("hero_marshal".equals(key))     MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroMarshal);
+                else if ("hero_priest".equals(key))      MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroPriest);
+                else if ("hero_banneret".equals(key))    MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroBanneret);
+                else if ("hero_magician".equals(key))    MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroMagician);
               } catch (JSONException ignored) {}
             }
           }
@@ -625,6 +631,8 @@ public class GameScreen extends ScreenAdapter {
           public void run() {
             try {
               int attackerIdx = data.getInt("attackerIdx");
+              // Battery Tower fires — all players hear the explosion
+              MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroBatteryTower);
               if (attackerIdx == myPlayerIndex) {
                 int defIdx3 = data.optInt("targetPlayerIdx", -1);
                 String defName3 = (defIdx3 >= 0 && defIdx3 < gameState.getPlayers().size())
@@ -689,6 +697,8 @@ public class GameScreen extends ScreenAdapter {
                 while (c.getBoosted() > boosted) c.addBoosted(-1);
                 while (c.getBoosted() < boosted) c.addBoosted(1);
               }
+              // Mercenaries are being allocated — all players hear the fanfare
+              if (boosted > 0) MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroMercenaries);
               gameState.setUpdateState(true);
             } catch (JSONException e) {
               e.printStackTrace();
@@ -1978,6 +1988,7 @@ public class GameScreen extends ScreenAdapter {
             JSONArray ownDefIdArr = new JSONArray();
             for (Card c : pt.getPendingAttackOwnDefCards()) ownDefIdArr.put(c.getCardId());
             emitData.put("attackerOwnDefCardIds", ownDefIdArr);
+            MyGdxGame.playGameSound(lootSuccess ? MyGdxGame.soundAttackSuccess : MyGdxGame.soundAttackFail);
             if (pt.isKingUsed()) MyGdxGame.playGameSound(MyGdxGame.soundKingAttack);
             socket.emit("lootResolved", emitData);
           } catch (JSONException e) {
@@ -2263,6 +2274,7 @@ public class GameScreen extends ScreenAdapter {
               JSONArray atkIds = new JSONArray();
               for (Card c : apt.getPendingAttackCards()) { atkIds.put(c.getCardId()); }
               emitData.put("attackCardIds", atkIds);
+              MyGdxGame.playGameSound(atkSuccess ? MyGdxGame.soundAttackSuccess : MyGdxGame.soundAttackFail);
               if (apt.isKingUsed()) MyGdxGame.playGameSound(MyGdxGame.soundKingAttack);
               socket.emit("kingAttackResolved", emitData);
               tutorialAdvance(TUTORIAL_STEP_KING_ATTACK);
@@ -2300,6 +2312,7 @@ public class GameScreen extends ScreenAdapter {
               JSONArray ownDefIds = new JSONArray();
               for (Card c : apt.getPendingAttackOwnDefCards()) { ownDefIds.put(c.getCardId()); }
               emitData.put("attackerOwnDefCardIds", ownDefIds);
+              MyGdxGame.playGameSound(atkSuccess ? MyGdxGame.soundAttackSuccess : MyGdxGame.soundAttackFail);
               if (apt.isKingUsed()) MyGdxGame.playGameSound(MyGdxGame.soundKingAttack);
               socket.emit("defAttackResolved", emitData);
               tutorialAdvance(TUTORIAL_STEP_KING_ATTACK);
@@ -2909,6 +2922,7 @@ public class GameScreen extends ScreenAdapter {
             resp.put("isKing", btCheck.optBoolean("isKing", false));
             JSONArray atkExpIds = btCheck.optJSONArray("attackCardIds");
             if (atkExpIds != null) resp.put("attackCardIds", atkExpIds);
+            MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroBatteryTower);
             socket.emit("batteryDenyAttack", resp);
             pendingBatteryResultCards = atkExpIds;
             pendingBatteryDefCheck = null;

--- a/core/src/com/mygdx/game/MyGdxGame.java
+++ b/core/src/com/mygdx/game/MyGdxGame.java
@@ -36,11 +36,11 @@ public class MyGdxGame extends Game implements InputProcessor {
   static Stage stage;
 
   // --- Sound effects ---
-  static Sound soundCardDrop    = null;
-  static Sound soundCardShuffle = null;
-  static Sound soundKingAttack  = null;
-  static Sound soundSlurp       = null;
-  static Sound soundJokerLaugh  = null;
+  public static Sound soundCardDrop    = null;
+  public static Sound soundCardShuffle = null;
+  public static Sound soundKingAttack  = null;
+  public static Sound soundSlurp       = null;
+  public static Sound soundJokerLaugh  = null;
 
   // --- Music tracks ---
   /** Menu screens (name-entry, session list, create-game). */
@@ -115,11 +115,16 @@ public class MyGdxGame extends Game implements InputProcessor {
     soundJokerLaugh  = loadSoundEffect("data/sounds/freesound_community-joker-laugh-2-98829.mp3");
   }
 
-  /** Play a one-shot sound effect (no-op if music/sound is disabled or sound is null). */
-  static void playGameSound(Sound s) {
+  /** Play a one-shot sound effect (no-op if sound effects are disabled or sound is null). */
+  public static void playGameSound(Sound s) {
     if (s == null) return;
-    if (!playerStorage.getMusicEnabled()) return;
+    if (!playerStorage.getSoundEnabled()) return;
     s.play();
+  }
+
+  /** Toggle sound effects on/off and persist the preference. */
+  static void setSoundEnabled(boolean enabled) {
+    playerStorage.saveSoundEnabled(enabled);
   }
 
   /** Switch to a new track (pass null for silence). */

--- a/core/src/com/mygdx/game/MyGdxGame.java
+++ b/core/src/com/mygdx/game/MyGdxGame.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Game;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.audio.Music;
+import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -33,6 +34,13 @@ public class MyGdxGame extends Game implements InputProcessor {
   /** Old plain uiskin — used for compact banner buttons (Skip / Next ►). */
   static Skin plainSkin;
   static Stage stage;
+
+  // --- Sound effects ---
+  static Sound soundCardDrop    = null;
+  static Sound soundCardShuffle = null;
+  static Sound soundKingAttack  = null;
+  static Sound soundSlurp       = null;
+  static Sound soundJokerLaugh  = null;
 
   // --- Music tracks ---
   /** Menu screens (name-entry, session list, create-game). */
@@ -88,6 +96,30 @@ public class MyGdxGame extends Game implements InputProcessor {
     musicShimmer  = loadTrack("data/sounds/freesound_community-desert-shimmer-24684.mp3");
     musicDrums    = loadTrack("data/sounds/tatamusic-battle-warrior-fighting-drums-478210.mp3");
     musicIntrigue = loadTrack("data/sounds/34724807-castle-of-intrigue-288660.mp3");
+  }
+
+  private static Sound loadSoundEffect(String path) {
+    try {
+      return Gdx.audio.newSound(Gdx.files.internal(path));
+    } catch (Exception e) {
+      Gdx.app.log("Audio", "Sound not found: " + path);
+      return null;
+    }
+  }
+
+  static void loadSounds() {
+    soundCardDrop    = loadSoundEffect("data/sounds/freesound_community-carddrop2-92718.mp3");
+    soundCardShuffle = loadSoundEffect("data/sounds/freesound_community-riffle-card-shuffle-104313.mp3");
+    soundKingAttack  = loadSoundEffect("data/sounds/freesound_community-middle-ages-war-crywav-14780.mp3");
+    soundSlurp       = loadSoundEffect("data/sounds/freesound_community-cartoon-slurp-37066.mp3");
+    soundJokerLaugh  = loadSoundEffect("data/sounds/freesound_community-joker-laugh-2-98829.mp3");
+  }
+
+  /** Play a one-shot sound effect (no-op if music/sound is disabled or sound is null). */
+  static void playGameSound(Sound s) {
+    if (s == null) return;
+    if (!playerStorage.getMusicEnabled()) return;
+    s.play();
   }
 
   /** Switch to a new track (pass null for silence). */
@@ -182,6 +214,7 @@ public class MyGdxGame extends Game implements InputProcessor {
     }
 
     loadMusic();
+    loadSounds();
 
     connectSocket();
 
@@ -196,6 +229,11 @@ public class MyGdxGame extends Game implements InputProcessor {
     if (musicShimmer  != null) musicShimmer.dispose();
     if (musicDrums    != null) musicDrums.dispose();
     if (musicIntrigue != null) musicIntrigue.dispose();
+    if (soundCardDrop    != null) soundCardDrop.dispose();
+    if (soundCardShuffle != null) soundCardShuffle.dispose();
+    if (soundKingAttack  != null) soundKingAttack.dispose();
+    if (soundSlurp       != null) soundSlurp.dispose();
+    if (soundJokerLaugh  != null) soundJokerLaugh.dispose();
   }
 
   @Override

--- a/core/src/com/mygdx/game/MyGdxGame.java
+++ b/core/src/com/mygdx/game/MyGdxGame.java
@@ -41,6 +41,17 @@ public class MyGdxGame extends Game implements InputProcessor {
   public static Sound soundKingAttack  = null;
   public static Sound soundSlurp       = null;
   public static Sound soundJokerLaugh  = null;
+  // Attack outcome (active player only)
+  public static Sound soundAttackSuccess   = null;
+  public static Sound soundAttackFail      = null;
+  // Hero sounds (all players)
+  public static Sound soundHeroSpy         = null;
+  public static Sound soundHeroMercenaries = null;
+  public static Sound soundHeroMarshal     = null;
+  public static Sound soundHeroPriest      = null;
+  public static Sound soundHeroBanneret    = null;
+  public static Sound soundHeroMagician    = null;
+  public static Sound soundHeroBatteryTower = null;
 
   // --- Music tracks ---
   /** Menu screens (name-entry, session list, create-game). */
@@ -113,6 +124,15 @@ public class MyGdxGame extends Game implements InputProcessor {
     soundKingAttack  = loadSoundEffect("data/sounds/freesound_community-middle-ages-war-crywav-14780.mp3");
     soundSlurp       = loadSoundEffect("data/sounds/freesound_community-cartoon-slurp-37066.mp3");
     soundJokerLaugh  = loadSoundEffect("data/sounds/freesound_community-joker-laugh-2-98829.mp3");
+    soundAttackSuccess    = loadSoundEffect("data/sounds/ksjsbwuil-apple-pay-success-sound-effect-481188.mp3");
+    soundAttackFail       = loadSoundEffect("data/sounds/universfield-fail-trumpet-02-383962.mp3");
+    soundHeroSpy          = loadSoundEffect("data/sounds/bentomusic-comical-style-music-of-silliness-and-goofing-around-loop-439124.mp3");
+    soundHeroMercenaries  = loadSoundEffect("data/sounds/freesound_community-medieval-fanfare-6826.mp3");
+    soundHeroMarshal      = loadSoundEffect("data/sounds/dragon-studio-horse-neigh-515279.mp3");
+    soundHeroPriest       = loadSoundEffect("data/sounds/freesound_community-sfx_spirit_gain-95855.mp3");
+    soundHeroBanneret     = loadSoundEffect("data/sounds/freesound_community-fx-comedy-marching-78276.mp3");
+    soundHeroMagician     = loadSoundEffect("data/sounds/fxprosound-magic-glitter-wand-5-248607.mp3");
+    soundHeroBatteryTower = loadSoundEffect("data/sounds/dragon-studio-loud-explosion-425457.mp3");
   }
 
   /** Play a one-shot sound effect (no-op if sound effects are disabled or sound is null). */
@@ -120,6 +140,19 @@ public class MyGdxGame extends Game implements InputProcessor {
     if (s == null) return;
     if (!playerStorage.getSoundEnabled()) return;
     s.play();
+  }
+
+  /** Play a sound and auto-stop it after 10 seconds (for hero sounds that may be long). */
+  public static void playGameSoundCapped(final Sound s) {
+    if (s == null) return;
+    if (!playerStorage.getSoundEnabled()) return;
+    final long soundId = s.play();
+    com.badlogic.gdx.utils.Timer.schedule(new com.badlogic.gdx.utils.Timer.Task() {
+      @Override
+      public void run() {
+        s.stop(soundId);
+      }
+    }, 10f);
   }
 
   /** Toggle sound effects on/off and persist the preference. */
@@ -239,6 +272,15 @@ public class MyGdxGame extends Game implements InputProcessor {
     if (soundKingAttack  != null) soundKingAttack.dispose();
     if (soundSlurp       != null) soundSlurp.dispose();
     if (soundJokerLaugh  != null) soundJokerLaugh.dispose();
+    if (soundAttackSuccess    != null) soundAttackSuccess.dispose();
+    if (soundAttackFail       != null) soundAttackFail.dispose();
+    if (soundHeroSpy          != null) soundHeroSpy.dispose();
+    if (soundHeroMercenaries  != null) soundHeroMercenaries.dispose();
+    if (soundHeroMarshal      != null) soundHeroMarshal.dispose();
+    if (soundHeroPriest       != null) soundHeroPriest.dispose();
+    if (soundHeroBanneret     != null) soundHeroBanneret.dispose();
+    if (soundHeroMagician     != null) soundHeroMagician.dispose();
+    if (soundHeroBatteryTower != null) soundHeroBatteryTower.dispose();
   }
 
   @Override

--- a/core/src/com/mygdx/game/MyGdxGame.java
+++ b/core/src/com/mygdx/game/MyGdxGame.java
@@ -155,6 +155,19 @@ public class MyGdxGame extends Game implements InputProcessor {
     }, 10f);
   }
 
+  /** Play the hero-won sound for the given hero name (capped at 10 s). Called for all players. */
+  public static void playHeroWonSound(String heroName) {
+    Sound s = null;
+    if ("Spy".equals(heroName))           s = soundHeroSpy;
+    else if ("Mercenaries".equals(heroName)) s = soundHeroMercenaries;
+    else if ("Marshal".equals(heroName))     s = soundHeroMarshal;
+    else if ("Priest".equals(heroName))      s = soundHeroPriest;
+    else if ("Banneret".equals(heroName))    s = soundHeroBanneret;
+    else if ("Magician".equals(heroName))    s = soundHeroMagician;
+    else if ("Battery Tower".equals(heroName)) s = soundHeroBatteryTower;
+    playGameSoundCapped(s);
+  }
+
   /** Toggle sound effects on/off and persist the preference. */
   static void setSoundEnabled(boolean enabled) {
     playerStorage.saveSoundEnabled(enabled);

--- a/core/src/com/mygdx/game/PlayerStorage.java
+++ b/core/src/com/mygdx/game/PlayerStorage.java
@@ -49,6 +49,12 @@ public interface PlayerStorage {
   /** Persists the music on/off preference. */
   void saveMusicEnabled(boolean enabled);
 
+  /** Returns true if in-game sound effects should play (default: true). */
+  boolean getSoundEnabled();
+
+  /** Persists the sound effects on/off preference. */
+  void saveSoundEnabled(boolean enabled);
+
   /** Clears the saved player name (logout). */
   void clearName();
 
@@ -73,6 +79,8 @@ public interface PlayerStorage {
     @Override public void    saveShowPlayersTab(boolean val)     { }
     @Override public boolean getMusicEnabled()                   { return true; }
     @Override public void    saveMusicEnabled(boolean enabled)   { }
+    @Override public boolean getSoundEnabled()                   { return true; }
+    @Override public void    saveSoundEnabled(boolean enabled)   { }
     @Override public void    clearName()                         { }
     @Override public String  getSavedIcon()                      { return ""; }
     @Override public void    saveIcon(String icon)               { }

--- a/core/src/com/mygdx/game/listeners/OwnDefCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnDefCardListener.java
@@ -153,7 +153,6 @@ public class OwnDefCardListener extends ClickListener {
                 mercenaries.operate();
                 selectedCard.addBoosted(1);
                 emitBoost(selectedCard.getPositionId(), selectedCard.getBoosted());
-                MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroMercenaries);
                 gameState.setUpdateState(true);
               }
             } else {

--- a/core/src/com/mygdx/game/listeners/OwnDefCardListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnDefCardListener.java
@@ -16,6 +16,7 @@ import com.mygdx.game.heroes.Merchant;
 import com.mygdx.game.heroes.Mercenaries;
 import com.mygdx.game.heroes.Spy;
 import com.mygdx.game.net.SocketClient;
+import com.mygdx.game.MyGdxGame;
 
 public class OwnDefCardListener extends ClickListener {
 
@@ -152,6 +153,7 @@ public class OwnDefCardListener extends ClickListener {
                 mercenaries.operate();
                 selectedCard.addBoosted(1);
                 emitBoost(selectedCard.getPositionId(), selectedCard.getBoosted());
+                MyGdxGame.playGameSoundCapped(MyGdxGame.soundHeroMercenaries);
                 gameState.setUpdateState(true);
               }
             } else {

--- a/core/src/com/mygdx/game/listeners/OwnPlaceholderListener.java
+++ b/core/src/com/mygdx/game/listeners/OwnPlaceholderListener.java
@@ -9,6 +9,7 @@ import com.badlogic.gdx.scenes.scene2d.actions.Actions;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.mygdx.game.Card;
 import com.mygdx.game.GameState;
+import com.mygdx.game.MyGdxGame;
 import com.mygdx.game.Player;
 import com.mygdx.game.heroes.Hero;
 
@@ -54,6 +55,7 @@ public class OwnPlaceholderListener extends ClickListener {
           return;
         }
         player.putDefCard(positionId, 0);
+        MyGdxGame.playGameSound(MyGdxGame.soundCardDrop);
         if (gameState.getSocket() != null && cardId > 0 && positionId >= 1 && positionId <= 3) {
           try {
             JSONObject payload = new JSONObject();

--- a/html/src/com/mygdx/game/client/BrowserPlayerStorage.java
+++ b/html/src/com/mygdx/game/client/BrowserPlayerStorage.java
@@ -75,6 +75,17 @@ public class BrowserPlayerStorage implements PlayerStorage {
   }-*/;
 
   @Override
+  public native boolean getSoundEnabled() /*-{
+    var val = $wnd.localStorage.getItem('baisch_sound_enabled');
+    return val === null || val === '1';
+  }-*/;
+
+  @Override
+  public native void saveSoundEnabled(boolean enabled) /*-{
+    $wnd.localStorage.setItem('baisch_sound_enabled', enabled ? '1' : '0');
+  }-*/;
+
+  @Override
   public native void clearName() /*-{
     $wnd.localStorage.removeItem('baisch_player_name');
   }-*/;

--- a/ios/src/com/mygdx/game/IOSPlayerStorage.java
+++ b/ios/src/com/mygdx/game/IOSPlayerStorage.java
@@ -14,6 +14,7 @@ public class IOSPlayerStorage implements PlayerStorage {
     private static final String KEY_SESSION_ID    = "session_id";
     private static final String KEY_SHOW_PLAYERS  = "show_players_tab";
     private static final String KEY_MUSIC_ENABLED = "music_enabled";
+    private static final String KEY_SOUND_ENABLED = "sound_enabled";
 
     private final NSUserDefaults prefs;
 
@@ -42,4 +43,6 @@ public class IOSPlayerStorage implements PlayerStorage {
     @Override public void    saveShowPlayersTab(boolean val)     { prefs.put(KEY_SHOW_PLAYERS, val);           prefs.synchronize(); }
     @Override public boolean getMusicEnabled()                   { String v = prefs.getString(KEY_MUSIC_ENABLED); if (v == null) return true; return prefs.getBoolean(KEY_MUSIC_ENABLED); }
     @Override public void    saveMusicEnabled(boolean enabled)   { prefs.put(KEY_MUSIC_ENABLED, enabled);     prefs.synchronize(); }
+    @Override public boolean getSoundEnabled()                   { String v = prefs.getString(KEY_SOUND_ENABLED); if (v == null) return true; return prefs.getBoolean(KEY_SOUND_ENABLED); }
+    @Override public void    saveSoundEnabled(boolean enabled)   { prefs.put(KEY_SOUND_ENABLED, enabled);     prefs.synchronize(); }
 }

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -31,6 +31,7 @@ class GameState {
     this.roundNumber = 1;     // incremented each time the full turn order wraps around
     this.eliminationOrder = []; // player indices in elimination order (first out = index 0)
     this.stateSeq = 0;          // incremented on every serialize(); clients detect gaps
+    this.pendingSoundEvents = []; // sound keys queued for broadcast in next stateUpdate
     this.dealCards(startingCards);
     if (manualSetup) {
       this.initPlayerStats(); // init combat counters without placing king/def/cemetery
@@ -180,6 +181,10 @@ class GameState {
       }
     }
     this.pendingLoot = Object.assign({}, data, { _lockedHandCards: lockedHandCards });
+    // Joker on top of picking deck: signal all players with the joker-laugh sound
+    if (data.defCardId >= 53) {
+      this.pendingSoundEvents.push('joker_laugh');
+    }
     // Persist the top card of the attacked deck as face-up so the stateUpdate
     // broadcast doesn't re-cover it for all players
     if (data.deckIndex !== undefined) {
@@ -253,6 +258,7 @@ class GameState {
           [this.deck[i], this.deck[j]] = [this.deck[j], this.deck[i]];
         }
         console.log('Deck empty — reshuffled cemetery (' + this.deck.length + ' cards) into deck');
+        this.pendingSoundEvents.push('shuffle');
       } else {
         return null; // both deck and cemetery are empty
       }
@@ -534,6 +540,7 @@ class GameState {
     if (success) {
       attacker.statPlundersSuccess = (attacker.statPlundersSuccess || 0) + 1;
       this.pushLog(`${this.pname(attackerIdx)} looted deck ${deckIdx + 1}! (${plunderAtkSum} vs ${deckDefStrength})`, true);
+      if (plunderAtkSum - deckDefStrength === 1) this.pendingSoundEvents.push('slurp');
       // Move all cards from plundered deck into attacker's hand
       for (const c of this.pickingDecks[deckIdx]) attacker.hand.push(c.id);
       this.pickingDecks[deckIdx] = [];
@@ -595,6 +602,7 @@ class GameState {
     if (success) {
       attacker.statAttacksSuccess = (attacker.statAttacksSuccess || 0) + 1;
       this.pushLog(`${this.pname(attackerIdx)} broke ${this.pname(defenderIdx)}'s shield [${positionId}] (${atkSum} vs ${defStrength})`, true);
+      if (atkSum - defStrength === 1) this.pendingSoundEvents.push('slurp');
       // If the slot was sabotaged, clear it (saboteur destroyed when card is removed by attack)
       if (defender.sabotaged && defender.sabotaged[positionId] !== undefined) {
         delete defender.sabotaged[positionId];
@@ -964,6 +972,8 @@ class GameState {
     // Pass false for point-to-point sends (requestStateSync responses, gameState reconnect events)
     // so the stateSeq is not incremented, preventing artificial gaps for other clients.
     var seq = (incSeq === false) ? this.stateSeq : ++this.stateSeq;
+    // Drain sound events only on broadcast updates (not reconnect/resync)
+    var broadcastSounds = (incSeq !== false) ? this.pendingSoundEvents.splice(0) : [];
     return {
       roundNumber: this.roundNumber,
       currentPlayerIndex: this.currentPlayerIndex,
@@ -1011,6 +1021,7 @@ class GameState {
       isTutorial: this.isTutorial || false,
       heroTutorialName: this.heroTutorialName || null,
       stateSeq: seq,
+      soundEvents: broadcastSounds,
     };
   }
 

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -287,7 +287,6 @@ class GameState {
       attacker.hand.push(cardId);
     }
     attacker.priestConversionAttempts = 0; // success burns all remaining attempts
-    this.pendingSoundEvents.push('hero_priest');
     this.pushLog(`${this.pname(attackerIdx)} (Priest) took card from ${this.pname(targetPlayerIdx)}`, true);
   }
 
@@ -350,7 +349,6 @@ class GameState {
     if (p.defCardsBoost) delete p.defCardsBoost[positionId];
     if (p.topDefCardsBoost) delete p.topDefCardsBoost[positionId];
     p.statTakeActions = (p.statTakeActions || 0) + 1;
-    if ((p.heroes || []).includes('Marshal')) this.pendingSoundEvents.push('hero_marshal');
     this.pushLog(`${this.pname(playerIdx)} took shield [${positionId}] to hand`, true, true);
   }
 
@@ -363,7 +361,6 @@ class GameState {
     p.defCardsCovered[positionId] = true; // newly placed card is always face-down
     if (p.defCardsBoost) delete p.defCardsBoost[positionId];
     p.statPutActions = (p.statPutActions || 0) + 1;
-    if ((p.heroes || []).includes('Marshal')) this.pendingSoundEvents.push('hero_marshal');
     this.pushLog(`${this.pname(playerIdx)} placed shield at [${positionId}]`, true, true);
   }
 
@@ -402,7 +399,6 @@ class GameState {
       target.kingCard = newBottomCardId;
       target.kingCovered = bottomCovered;
       attacker.magicianSpells--;
-      this.pendingSoundEvents.push('hero_magician');
       this.pushLog(`${this.pname(playerIdx)} cast Magician on ${this.pname(targetPlayerIdx)}'s king`, true);
       return;
     }
@@ -427,7 +423,6 @@ class GameState {
       target.topDefCardsCovered[positionId] = topCovered;
     }
     attacker.magicianSpells--;
-    this.pendingSoundEvents.push('hero_magician');
     this.pushLog(`${this.pname(playerIdx)} cast Magician on ${this.pname(targetPlayerIdx)}'s shield [${positionId}]`, true);
   }
 
@@ -546,7 +541,6 @@ class GameState {
       attacker.statPlundersSuccess = (attacker.statPlundersSuccess || 0) + 1;
       this.pushLog(`${this.pname(attackerIdx)} looted deck ${deckIdx + 1}! (${plunderAtkSum} vs ${deckDefStrength})`, true);
       if (plunderAtkSum - deckDefStrength === 1) this.pendingSoundEvents.push('slurp');
-      if ((attackerOwnDefCardIds || []).length > 0) this.pendingSoundEvents.push('hero_banneret');
       // Move all cards from plundered deck into attacker's hand
       for (const c of this.pickingDecks[deckIdx]) attacker.hand.push(c.id);
       this.pickingDecks[deckIdx] = [];
@@ -595,7 +589,6 @@ class GameState {
       }
       this.cemetery.push(cardId);
     }
-    if ((attackerOwnDefCardIds || []).length > 0) this.pendingSoundEvents.push('hero_banneret');
     if (kingUsed) { attacker.kingCovered = false; attacker.statKingUsed = (attacker.statKingUsed || 0) + 1; }
     // Capture defense values before the card may be removed (for log display)
     const _defCardId = defender.defCards[positionId];

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -287,6 +287,7 @@ class GameState {
       attacker.hand.push(cardId);
     }
     attacker.priestConversionAttempts = 0; // success burns all remaining attempts
+    this.pendingSoundEvents.push('hero_priest');
     this.pushLog(`${this.pname(attackerIdx)} (Priest) took card from ${this.pname(targetPlayerIdx)}`, true);
   }
 
@@ -349,6 +350,7 @@ class GameState {
     if (p.defCardsBoost) delete p.defCardsBoost[positionId];
     if (p.topDefCardsBoost) delete p.topDefCardsBoost[positionId];
     p.statTakeActions = (p.statTakeActions || 0) + 1;
+    if ((p.heroes || []).includes('Marshal')) this.pendingSoundEvents.push('hero_marshal');
     this.pushLog(`${this.pname(playerIdx)} took shield [${positionId}] to hand`, true, true);
   }
 
@@ -361,6 +363,7 @@ class GameState {
     p.defCardsCovered[positionId] = true; // newly placed card is always face-down
     if (p.defCardsBoost) delete p.defCardsBoost[positionId];
     p.statPutActions = (p.statPutActions || 0) + 1;
+    if ((p.heroes || []).includes('Marshal')) this.pendingSoundEvents.push('hero_marshal');
     this.pushLog(`${this.pname(playerIdx)} placed shield at [${positionId}]`, true, true);
   }
 
@@ -399,6 +402,7 @@ class GameState {
       target.kingCard = newBottomCardId;
       target.kingCovered = bottomCovered;
       attacker.magicianSpells--;
+      this.pendingSoundEvents.push('hero_magician');
       this.pushLog(`${this.pname(playerIdx)} cast Magician on ${this.pname(targetPlayerIdx)}'s king`, true);
       return;
     }
@@ -423,6 +427,7 @@ class GameState {
       target.topDefCardsCovered[positionId] = topCovered;
     }
     attacker.magicianSpells--;
+    this.pendingSoundEvents.push('hero_magician');
     this.pushLog(`${this.pname(playerIdx)} cast Magician on ${this.pname(targetPlayerIdx)}'s shield [${positionId}]`, true);
   }
 
@@ -541,6 +546,7 @@ class GameState {
       attacker.statPlundersSuccess = (attacker.statPlundersSuccess || 0) + 1;
       this.pushLog(`${this.pname(attackerIdx)} looted deck ${deckIdx + 1}! (${plunderAtkSum} vs ${deckDefStrength})`, true);
       if (plunderAtkSum - deckDefStrength === 1) this.pendingSoundEvents.push('slurp');
+      if ((attackerOwnDefCardIds || []).length > 0) this.pendingSoundEvents.push('hero_banneret');
       // Move all cards from plundered deck into attacker's hand
       for (const c of this.pickingDecks[deckIdx]) attacker.hand.push(c.id);
       this.pickingDecks[deckIdx] = [];
@@ -589,6 +595,7 @@ class GameState {
       }
       this.cemetery.push(cardId);
     }
+    if ((attackerOwnDefCardIds || []).length > 0) this.pendingSoundEvents.push('hero_banneret');
     if (kingUsed) { attacker.kingCovered = false; attacker.statKingUsed = (attacker.statKingUsed || 0) + 1; }
     // Capture defense values before the card may be removed (for log display)
     const _defCardId = defender.defCards[positionId];

--- a/server/index.js
+++ b/server/index.js
@@ -1796,7 +1796,6 @@ io.on('connection', function(socket) {
     var userIdx = sess.users.findIndex(function(u) { return u.id === socket.id; });
     if (userIdx === -1) return;
     if (!sess.gameState.spyFlip(userIdx, data.targetPlayerIdx, data.slot)) return;
-    sess.gameState.pendingSoundEvents.push('hero_spy');
     socket.to(sess.id).emit('spyFlip', data);
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });

--- a/server/index.js
+++ b/server/index.js
@@ -1796,6 +1796,7 @@ io.on('connection', function(socket) {
     var userIdx = sess.users.findIndex(function(u) { return u.id === socket.id; });
     if (userIdx === -1) return;
     if (!sess.gameState.spyFlip(userIdx, data.targetPlayerIdx, data.slot)) return;
+    sess.gameState.pendingSoundEvents.push('hero_spy');
     socket.to(sess.id).emit('spyFlip', data);
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });


### PR DESCRIPTION
Closes #115

## What's new

Adds five one-shot sound effects that play during gameplay.

| Sound | Trigger | Audience |
|---|---|---|
| Card drop | Put/take a defense card | Local player only |
| King attack | Confirm attack with king card | Local player only |
| Shuffle | Deck reshuffled from cemetery | All players |
| Slurp | Plunder/attack succeeds with minimal diff (+1) | All players |
| Joker laugh | Joker blocks a plunder attempt | All players |

When music is turned off, all sounds are muted (same toggle).

## Implementation

- **`android/assets/data/sounds/`** — added 5 mp3 files (moved from root `sounds/` folder)
- **`server/gameState.js`** — accumulates `pendingSoundEvents[]` during game logic; emits them as `soundEvents` array in the next `stateUpdate` broadcast (drained via `splice(0)`; empty on reconnect/resync serializations)
- **`core/…/MyGdxGame.java`** — loads 5 `Sound` fields via `loadSounds()`, exposes `playGameSound(Sound)` helper that respects the music-enabled toggle
- **`core/…/GameScreen.java`** — stateUpdate listener processes `soundEvents` from server; `emitPutDefCard`/`emitTakeDefCard` play card drop sound locally; king attack emit paths play king attack sound when `apt.isKingUsed()`