### PR TITLE
GameScreen: Enable pinch and Ctrl+wheel zoom on board viewport only

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -802,6 +802,8 @@ public class GameScreen extends ScreenAdapter {
     inMulti.addProcessor(gameStage);
     inMulti.addProcessor(handStage);
     menuAndGameMulti = new InputMultiplexer();
+    // Gesture detector must be in the active multiplexer and should run before stages,
+    // otherwise stage listeners can consume touch events before pinch is detected.
     menuAndGameMulti.addProcessor(overlayStage);
     menuAndGameMulti.addProcessor(gameStage);
     menuAndGameMulti.addProcessor(handStage);
@@ -931,7 +933,7 @@ public class GameScreen extends ScreenAdapter {
                            com.badlogic.gdx.math.Vector2 pointer1, com.badlogic.gdx.math.Vector2 pointer2) { return false; }
       public void pinchStop() { }
     });
-    inMulti.addProcessor(gestureDetector);
+    menuAndGameMulti.addProcessor(0, gestureDetector);
 
     // Request authoritative state from server. This handles the case where the browser
     // tab was inactive during game initialization: requestAnimationFrame is paused for
@@ -971,6 +973,7 @@ public class GameScreen extends ScreenAdapter {
     }
 
     gameStage.addActor(gameBck);
+    gameStage.setScrollFocus(gameBck);
     handStage.addActor(handBck);
     handStage.addActor(handHighlight);
 

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -258,7 +258,10 @@ public class GameScreen extends ScreenAdapter {
   private int gamePanPointer = -1;
   private float gamePanLastX = 0f;
   private float gamePanLastY = 0f;
+  private float pinchCenterScreenX = MyGdxGame.WIDTH / 2f;
+  private float pinchCenterScreenY = MyGdxGame.WIDTH / 2f;
   private com.badlogic.gdx.input.GestureDetector gestureDetector = null;
+  private com.badlogic.gdx.InputAdapter zoomInputProcessor = null;
 
   private static float clampf(float v, float min, float max) {
     return Math.max(min, Math.min(max, v));
@@ -275,6 +278,34 @@ public class GameScreen extends ScreenAdapter {
     gameCameraCenterX -= deltaWorldX;
     gameCameraCenterY -= deltaWorldY;
     clampGameCameraCenter();
+  }
+
+  private void applyZoomAtScreenPoint(float screenX, float screenY, float newZoom) {
+    float clampedZoom = clampf(newZoom, MIN_ZOOM, MAX_ZOOM);
+    if (Math.abs(clampedZoom - gameScreenZoom) < 0.0001f) return;
+
+    com.badlogic.gdx.graphics.Camera gameCamera = gameStage.getViewport().getCamera();
+    if (!(gameCamera instanceof com.badlogic.gdx.graphics.OrthographicCamera)) {
+      gameScreenZoom = clampedZoom;
+      clampGameCameraCenter();
+      return;
+    }
+
+    com.badlogic.gdx.graphics.OrthographicCamera orthoCamera = (com.badlogic.gdx.graphics.OrthographicCamera) gameCamera;
+    orthoCamera.zoom = gameScreenZoom;
+    orthoCamera.position.set(gameCameraCenterX, gameCameraCenterY, 0f);
+    orthoCamera.update();
+
+    com.badlogic.gdx.math.Vector2 before = gameStage.screenToStageCoordinates(new com.badlogic.gdx.math.Vector2(screenX, screenY));
+    gameScreenZoom = clampedZoom;
+    clampGameCameraCenter();
+
+    orthoCamera.zoom = gameScreenZoom;
+    orthoCamera.position.set(gameCameraCenterX, gameCameraCenterY, 0f);
+    orthoCamera.update();
+
+    com.badlogic.gdx.math.Vector2 after = gameStage.screenToStageCoordinates(new com.badlogic.gdx.math.Vector2(screenX, screenY));
+    panGameCamera(after.x - before.x, after.y - before.y);
   }
 
   // ── Hero reveal overlay (issue #257) ──────────────────────────────────────
@@ -824,8 +855,20 @@ public class GameScreen extends ScreenAdapter {
     inMulti.addProcessor(gameStage);
     inMulti.addProcessor(handStage);
     menuAndGameMulti = new InputMultiplexer();
+    zoomInputProcessor = new com.badlogic.gdx.InputAdapter() {
+      public boolean scrolled(float amountX, float amountY) {
+        if (Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.CONTROL_LEFT)
+            || Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.CONTROL_RIGHT)) {
+          float newZoom = gameScreenZoom - (amountY * ZOOM_STEP);
+          applyZoomAtScreenPoint(Gdx.input.getX(), Gdx.input.getY(), newZoom);
+          return true;
+        }
+        return false;
+      }
+    };
     // Gesture detector must be in the active multiplexer and should run before stages,
     // otherwise stage listeners can consume touch events before pinch is detected.
+    menuAndGameMulti.addProcessor(zoomInputProcessor);
     menuAndGameMulti.addProcessor(overlayStage);
     menuAndGameMulti.addProcessor(gameStage);
     menuAndGameMulti.addProcessor(handStage);
@@ -881,19 +924,6 @@ public class GameScreen extends ScreenAdapter {
       }
       public void touchUp(InputEvent event, float x, float y, int pointer, int button) {
         if (pointer == gamePanPointer) gamePanPointer = -1;
-      }
-      public boolean scrolled(InputEvent event, float x, float y, float amountX, float amountY) {
-        // Issue #266: Handle Ctrl+scroll for desktop zoom
-        if (Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.CONTROL_LEFT) || 
-            Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.CONTROL_RIGHT)) {
-          // Scroll up (negative amountY) = zoom in, scroll down (positive amountY) = zoom out
-          float newZoom = gameScreenZoom - (amountY * ZOOM_STEP);
-          newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, newZoom));
-          gameScreenZoom = newZoom;
-          clampGameCameraCenter();
-          return true;
-        }
-        return false;
       }
     });
     gameStage.addActor(gameBck);
@@ -966,14 +996,16 @@ public class GameScreen extends ScreenAdapter {
           float scale = distance / initialDistance;
           // Zoom in when fingers move apart (scale > 1), zoom out when moving together (scale < 1)
           float newZoom = gameScreenZoom / scale;
-          newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, newZoom));
-          gameScreenZoom = newZoom;
-          clampGameCameraCenter();
+          applyZoomAtScreenPoint(pinchCenterScreenX, pinchCenterScreenY, newZoom);
         }
         return true;
       }
       public boolean pinch(com.badlogic.gdx.math.Vector2 initialPointer1, com.badlogic.gdx.math.Vector2 initialPointer2, 
-                           com.badlogic.gdx.math.Vector2 pointer1, com.badlogic.gdx.math.Vector2 pointer2) { return false; }
+                           com.badlogic.gdx.math.Vector2 pointer1, com.badlogic.gdx.math.Vector2 pointer2) {
+        pinchCenterScreenX = (pointer1.x + pointer2.x) / 2f;
+        pinchCenterScreenY = (pointer1.y + pointer2.y) / 2f;
+        return false;
+      }
       public void pinchStop() { }
     });
     menuAndGameMulti.addProcessor(0, gestureDetector);

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -864,7 +864,7 @@ public class GameScreen extends ScreenAdapter {
           if (currentPlayer.getKingCard() != null) currentPlayer.getKingCard().setSelected(false);
           gameState.setUpdateState(true);
         }
-        return false;
+        return true;
       }
       public void touchDragged(InputEvent event, float x, float y, int pointer) {
         if (pointer != gamePanPointer) return;

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -245,8 +245,6 @@ public class GameScreen extends ScreenAdapter {
   private final HashSet<PickingDeck> deckZoomAttached = new HashSet<PickingDeck>();
   // Zoom-mode toggle (issue #246)
   private boolean zoomModeActive = false;
-  private Texture texZoomButton;
-  private Image zoomModeBtn;
 
   // Gesture-based zoom/pan for game screen (issue #266)
   private float gameScreenZoom = 1.0f; // 1.0f = full board (max zoomed out)
@@ -1000,7 +998,6 @@ public class GameScreen extends ScreenAdapter {
     texMenuButton = new Texture(Gdx.files.internal("data/graphics/options.png"));
     texChatIcon    = new Texture(Gdx.files.internal("data/graphics/chat.png"));
     texHistoryIcon = new Texture(Gdx.files.internal("data/graphics/history.png"));
-    texZoomButton  = new Texture(Gdx.files.internal("data/graphics/lens.png"));
 
     // Issue #266: Initialize gesture detector for pinch zoom on the game screen
     gestureDetector = new com.badlogic.gdx.input.GestureDetector(new com.badlogic.gdx.input.GestureDetector.GestureListener() {
@@ -5202,7 +5199,6 @@ public class GameScreen extends ScreenAdapter {
       setDeckScale(currentlyZoomedDeck, 1f);
       currentlyZoomedDeck = null;
     }
-    if (zoomModeBtn != null) zoomModeBtn.setColor(Color.WHITE);
   }
 
   private void attachZoomListener(final Card card) {
@@ -5301,27 +5297,9 @@ public class GameScreen extends ScreenAdapter {
     float btnSize = 44f;
     float gap = 4f;
 
-    // Zoom toggle button — to the left of the menu button
-    zoomModeBtn = new Image(texZoomButton);
-    zoomModeBtn.setSize(btnSize, btnSize);
-    zoomModeBtn.setPosition(MyGdxGame.WIDTH - 2 * btnSize - gap, MyGdxGame.HEIGHT - btnSize);
-    zoomModeBtn.setColor(zoomModeActive ? Color.YELLOW : Color.WHITE);
-    zoomModeBtn.addListener(new ClickListener() {
-      @Override
-      public void clicked(InputEvent event, float x, float y) {
-        if (zoomModeActive) {
-          deactivateZoomMode();
-        } else {
-          zoomModeActive = true;
-          if (zoomModeBtn != null) zoomModeBtn.setColor(Color.YELLOW);
-        }
-      }
-    });
-    overlayStage.addActor(zoomModeBtn);
-
     Image menuBtn = new Image(texMenuButton);
     menuBtn.setSize(btnSize, btnSize);
-    menuBtn.setPosition(MyGdxGame.WIDTH - btnSize, MyGdxGame.HEIGHT - btnSize);
+    menuBtn.setPosition(MyGdxGame.WIDTH - btnSize - gap, MyGdxGame.HEIGHT - btnSize);
     menuBtn.addListener(new ClickListener() {
       @Override
       public void clicked(InputEvent event, float x, float y) {
@@ -7070,7 +7048,6 @@ public class GameScreen extends ScreenAdapter {
     texSword.dispose();
     texSuits.dispose();
     texMenuButton.dispose();
-    texZoomButton.dispose();
   }
 
 }

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -253,6 +253,8 @@ public class GameScreen extends ScreenAdapter {
   private static final float MIN_ZOOM = 0.35f; // Most zoomed-in level
   private static final float MAX_ZOOM = 1.0f;  // Never allow further zoom-out than default view
   private static final float ZOOM_STEP = 0.1f; // Zoom increment per wheel event
+  private static final float PINCH_ZOOM_SENSITIVITY = 0.65f;
+  private static final float PAN_DAMPING = 0.85f;
   private float gameCameraCenterX = MyGdxGame.WIDTH / 2f;
   private float gameCameraCenterY = MyGdxGame.WIDTH / 2f;
   private int gamePanPointer = -1;
@@ -260,6 +262,7 @@ public class GameScreen extends ScreenAdapter {
   private float gamePanLastY = 0f;
   private float pinchCenterScreenX = MyGdxGame.WIDTH / 2f;
   private float pinchCenterScreenY = MyGdxGame.WIDTH / 2f;
+  private float pinchLastDistance = -1f;
   private com.badlogic.gdx.input.GestureDetector gestureDetector = null;
   private com.badlogic.gdx.InputAdapter zoomInputProcessor = null;
 
@@ -859,7 +862,7 @@ public class GameScreen extends ScreenAdapter {
       public boolean scrolled(int amount) {
         if (Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.CONTROL_LEFT)
             || Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.CONTROL_RIGHT)) {
-          float newZoom = gameScreenZoom - (amount * ZOOM_STEP);
+          float newZoom = gameScreenZoom + (amount * ZOOM_STEP);
           applyZoomAtScreenPoint(Gdx.input.getX(), Gdx.input.getY(), newZoom);
           return true;
         }
@@ -933,8 +936,8 @@ public class GameScreen extends ScreenAdapter {
           gamePanLastY = y;
           return;
         }
-        float dx = x - gamePanLastX;
-        float dy = y - gamePanLastY;
+        float dx = (x - gamePanLastX) * PAN_DAMPING;
+        float dy = (y - gamePanLastY) * PAN_DAMPING;
         panGameCamera(dx, dy);
         gamePanLastX = x;
         gamePanLastY = y;
@@ -1009,11 +1012,16 @@ public class GameScreen extends ScreenAdapter {
       public boolean panStop(float x, float y, int pointer, int button) { return false; }
       public boolean zoom(float initialDistance, float distance) {
         // Pinch gesture: zoom in/out based on distance change
-        if (initialDistance > 0) {
-          float scale = distance / initialDistance;
-          // Zoom in when fingers move apart (scale > 1), zoom out when moving together (scale < 1)
-          float newZoom = gameScreenZoom / scale;
+        if (distance > 0) {
+          if (pinchLastDistance <= 0f) {
+            pinchLastDistance = (initialDistance > 0f) ? initialDistance : distance;
+          }
+          float scale = distance / pinchLastDistance;
+          float adjustedScale = (float) Math.pow(scale, PINCH_ZOOM_SENSITIVITY);
+          // Incremental zoom yields much smoother, fine-grained pinch behavior.
+          float newZoom = gameScreenZoom / adjustedScale;
           applyZoomAtScreenPoint(pinchCenterScreenX, pinchCenterScreenY, newZoom);
+          pinchLastDistance = distance;
         }
         return true;
       }
@@ -1023,7 +1031,7 @@ public class GameScreen extends ScreenAdapter {
         pinchCenterScreenY = (pointer1.y + pointer2.y) / 2f;
         return false;
       }
-      public void pinchStop() { }
+      public void pinchStop() { pinchLastDistance = -1f; }
     });
     menuAndGameMulti.addProcessor(0, gestureDetector);
 

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -248,6 +248,13 @@ public class GameScreen extends ScreenAdapter {
   private Texture texZoomButton;
   private Image zoomModeBtn;
 
+  // Gesture-based zoom for game screen (issue #266)
+  private float gameScreenZoom = 1.0f; // Current zoom level (1.0 = fully zoomed out)
+  private static final float MIN_ZOOM = 0.8f; // Minimum zoom level
+  private static final float MAX_ZOOM = 3.0f; // Maximum zoom level
+  private static final float ZOOM_STEP = 0.1f; // Zoom increment per gesture event
+  private com.badlogic.gdx.input.GestureDetector gestureDetector = null;
+
   // ── Hero reveal overlay (issue #257) ──────────────────────────────────────
   // Set when any player acquires a hero; cleared when the player dismisses the overlay.
   private String heroRevealPlayerName  = null;
@@ -832,6 +839,18 @@ public class GameScreen extends ScreenAdapter {
         }
         return false;
       }
+      public boolean scrolled(InputEvent event, float x, float y, float amountX, float amountY) {
+        // Issue #266: Handle Ctrl+scroll for desktop zoom
+        if (Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.CONTROL_LEFT) || 
+            Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.CONTROL_RIGHT)) {
+          // Scroll up (negative amountY) = zoom in, scroll down (positive amountY) = zoom out
+          float newZoom = gameScreenZoom - (amountY * ZOOM_STEP);
+          newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, newZoom));
+          gameScreenZoom = newZoom;
+          return true;
+        }
+        return false;
+      }
     });
     gameStage.addActor(gameBck);
 
@@ -889,6 +908,31 @@ public class GameScreen extends ScreenAdapter {
     texHistoryIcon = new Texture(Gdx.files.internal("data/graphics/history.png"));
     texZoomButton  = new Texture(Gdx.files.internal("data/graphics/lens.png"));
 
+    // Issue #266: Initialize gesture detector for pinch zoom on the game screen
+    gestureDetector = new com.badlogic.gdx.input.GestureDetector(new com.badlogic.gdx.input.GestureDetector.GestureListener() {
+      public boolean touchDown(float x, float y, int pointer, int button) { return false; }
+      public boolean tap(float x, float y, int count, int button) { return false; }
+      public boolean longPress(float x, float y) { return false; }
+      public boolean fling(float velocityX, float velocityY, int button) { return false; }
+      public boolean pan(float x, float y, float deltaX, float deltaY) { return false; }
+      public boolean panStop(float x, float y, int pointer, int button) { return false; }
+      public boolean zoom(float initialDistance, float distance) {
+        // Pinch gesture: zoom in/out based on distance change
+        if (initialDistance > 0) {
+          float scale = distance / initialDistance;
+          // Zoom in when fingers move apart (scale > 1), zoom out when moving together (scale < 1)
+          float newZoom = gameScreenZoom / scale;
+          newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, newZoom));
+          gameScreenZoom = newZoom;
+        }
+        return true;
+      }
+      public boolean pinch(com.badlogic.gdx.math.Vector2 initialPointer1, com.badlogic.gdx.math.Vector2 initialPointer2, 
+                           com.badlogic.gdx.math.Vector2 pointer1, com.badlogic.gdx.math.Vector2 pointer2) { return false; }
+      public void pinchStop() { }
+    });
+    inMulti.addProcessor(gestureDetector);
+
     // Request authoritative state from server. This handles the case where the browser
     // tab was inactive during game initialization: requestAnimationFrame is paused for
     // inactive tabs, so postRunnable tasks (including this constructor) are deferred.
@@ -903,6 +947,9 @@ public class GameScreen extends ScreenAdapter {
     INSTANCE = this;
     MyGdxGame.setMusicTrack(null); // no music during the game
     if (MyGdxGame.onGameScreenActive != null) MyGdxGame.onGameScreenActive.run();
+
+    // Issue #266: Reset gesture zoom to default when screen is shown
+    gameScreenZoom = 1.0f;
 
     players = gameState.getPlayers();
     // Spectators always follow the player whose turn it currently is.
@@ -6439,6 +6486,15 @@ public class GameScreen extends ScreenAdapter {
     gameStage.getViewport().update(gamePixelW, upperH, true);
     gameStage.getViewport().setScreenBounds(offsetX, offsetY + lowerH, gamePixelW, upperH);
     gameStage.getViewport().apply();
+    
+    // Issue #266: Apply gesture zoom to the game board camera
+    com.badlogic.gdx.graphics.Camera gameCamera = gameStage.getViewport().getCamera();
+    if (gameCamera != null && gameCamera instanceof com.badlogic.gdx.graphics.OrthographicCamera) {
+      com.badlogic.gdx.graphics.OrthographicCamera orthoCamera = (com.badlogic.gdx.graphics.OrthographicCamera) gameCamera;
+      orthoCamera.zoom = gameScreenZoom;
+      orthoCamera.update();
+    }
+    
     gameStage.act(delta);
     gameStage.draw();
 

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -248,12 +248,34 @@ public class GameScreen extends ScreenAdapter {
   private Texture texZoomButton;
   private Image zoomModeBtn;
 
-  // Gesture-based zoom for game screen (issue #266)
-  private float gameScreenZoom = 1.0f; // Current zoom level (1.0 = fully zoomed out)
-  private static final float MIN_ZOOM = 0.8f; // Minimum zoom level
-  private static final float MAX_ZOOM = 3.0f; // Maximum zoom level
-  private static final float ZOOM_STEP = 0.1f; // Zoom increment per gesture event
+  // Gesture-based zoom/pan for game screen (issue #266)
+  private float gameScreenZoom = 1.0f; // 1.0f = full board (max zoomed out)
+  private static final float MIN_ZOOM = 0.35f; // Most zoomed-in level
+  private static final float MAX_ZOOM = 1.0f;  // Never allow further zoom-out than default view
+  private static final float ZOOM_STEP = 0.1f; // Zoom increment per wheel event
+  private float gameCameraCenterX = MyGdxGame.WIDTH / 2f;
+  private float gameCameraCenterY = MyGdxGame.WIDTH / 2f;
+  private int gamePanPointer = -1;
+  private float gamePanLastX = 0f;
+  private float gamePanLastY = 0f;
   private com.badlogic.gdx.input.GestureDetector gestureDetector = null;
+
+  private static float clampf(float v, float min, float max) {
+    return Math.max(min, Math.min(max, v));
+  }
+
+  private void clampGameCameraCenter() {
+    float halfView = (MyGdxGame.WIDTH * gameScreenZoom) / 2f;
+    gameCameraCenterX = clampf(gameCameraCenterX, halfView, MyGdxGame.WIDTH - halfView);
+    gameCameraCenterY = clampf(gameCameraCenterY, halfView, MyGdxGame.WIDTH - halfView);
+  }
+
+  private void panGameCamera(float deltaWorldX, float deltaWorldY) {
+    if (gameScreenZoom >= MAX_ZOOM) return;
+    gameCameraCenterX -= deltaWorldX;
+    gameCameraCenterY -= deltaWorldY;
+    clampGameCameraCenter();
+  }
 
   // ── Hero reveal overlay (issue #257) ──────────────────────────────────────
   // Set when any player acquires a hero; cleared when the player dismisses the overlay.
@@ -830,6 +852,9 @@ public class GameScreen extends ScreenAdapter {
     gameBck.addListener(new InputListener() {
       @Override
       public boolean touchDown(InputEvent event, float x, float y, int pointer, int button) {
+        gamePanPointer = pointer;
+        gamePanLastX = x;
+        gamePanLastY = y;
         if (currentlyZoomedCard != null) unzoomCard(currentlyZoomedCard);
         if (currentlyZoomedDeck != null) { setDeckScale(currentlyZoomedDeck, 1f); currentlyZoomedDeck = null; }
         // Deselect any selected defense or king card
@@ -841,6 +866,22 @@ public class GameScreen extends ScreenAdapter {
         }
         return false;
       }
+      public void touchDragged(InputEvent event, float x, float y, int pointer) {
+        if (pointer != gamePanPointer) return;
+        if (gameScreenZoom >= MAX_ZOOM) {
+          gamePanLastX = x;
+          gamePanLastY = y;
+          return;
+        }
+        float dx = x - gamePanLastX;
+        float dy = y - gamePanLastY;
+        panGameCamera(dx, dy);
+        gamePanLastX = x;
+        gamePanLastY = y;
+      }
+      public void touchUp(InputEvent event, float x, float y, int pointer, int button) {
+        if (pointer == gamePanPointer) gamePanPointer = -1;
+      }
       public boolean scrolled(InputEvent event, float x, float y, float amountX, float amountY) {
         // Issue #266: Handle Ctrl+scroll for desktop zoom
         if (Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.CONTROL_LEFT) || 
@@ -849,6 +890,7 @@ public class GameScreen extends ScreenAdapter {
           float newZoom = gameScreenZoom - (amountY * ZOOM_STEP);
           newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, newZoom));
           gameScreenZoom = newZoom;
+          clampGameCameraCenter();
           return true;
         }
         return false;
@@ -926,6 +968,7 @@ public class GameScreen extends ScreenAdapter {
           float newZoom = gameScreenZoom / scale;
           newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, newZoom));
           gameScreenZoom = newZoom;
+          clampGameCameraCenter();
         }
         return true;
       }
@@ -952,6 +995,9 @@ public class GameScreen extends ScreenAdapter {
 
     // Issue #266: Reset gesture zoom to default when screen is shown
     gameScreenZoom = 1.0f;
+    gameCameraCenterX = MyGdxGame.WIDTH / 2f;
+    gameCameraCenterY = MyGdxGame.WIDTH / 2f;
+    gamePanPointer = -1;
 
     players = gameState.getPlayers();
     // Spectators always follow the player whose turn it currently is.
@@ -6495,6 +6541,8 @@ public class GameScreen extends ScreenAdapter {
     if (gameCamera != null && gameCamera instanceof com.badlogic.gdx.graphics.OrthographicCamera) {
       com.badlogic.gdx.graphics.OrthographicCamera orthoCamera = (com.badlogic.gdx.graphics.OrthographicCamera) gameCamera;
       orthoCamera.zoom = gameScreenZoom;
+      clampGameCameraCenter();
+      orthoCamera.position.set(gameCameraCenterX, gameCameraCenterY, 0f);
       orthoCamera.update();
     }
     

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -856,10 +856,10 @@ public class GameScreen extends ScreenAdapter {
     inMulti.addProcessor(handStage);
     menuAndGameMulti = new InputMultiplexer();
     zoomInputProcessor = new com.badlogic.gdx.InputAdapter() {
-      public boolean scrolled(float amountX, float amountY) {
+      public boolean scrolled(int amount) {
         if (Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.CONTROL_LEFT)
             || Gdx.input.isKeyPressed(com.badlogic.gdx.Input.Keys.CONTROL_RIGHT)) {
-          float newZoom = gameScreenZoom - (amountY * ZOOM_STEP);
+          float newZoom = gameScreenZoom - (amount * ZOOM_STEP);
           applyZoomAtScreenPoint(Gdx.input.getX(), Gdx.input.getY(), newZoom);
           return true;
         }
@@ -898,14 +898,31 @@ public class GameScreen extends ScreenAdapter {
         gamePanPointer = pointer;
         gamePanLastX = x;
         gamePanLastY = y;
-        if (currentlyZoomedCard != null) unzoomCard(currentlyZoomedCard);
-        if (currentlyZoomedDeck != null) { setDeckScale(currentlyZoomedDeck, 1f); currentlyZoomedDeck = null; }
+        boolean changed = false;
+        if (currentlyZoomedCard != null) {
+          unzoomCard(currentlyZoomedCard);
+          changed = true;
+        }
+        if (currentlyZoomedDeck != null) {
+          setDeckScale(currentlyZoomedDeck, 1f);
+          currentlyZoomedDeck = null;
+          changed = true;
+        }
         // Deselect any selected defense or king card
         if (currentPlayer != null) {
-          for (Card c : currentPlayer.getDefCards().values()) c.setSelected(false);
-          for (Card c : currentPlayer.getTopDefCards().values()) c.setSelected(false);
-          if (currentPlayer.getKingCard() != null) currentPlayer.getKingCard().setSelected(false);
-          gameState.setUpdateState(true);
+          for (Card c : currentPlayer.getDefCards().values()) {
+            if (c.isSelected()) changed = true;
+            c.setSelected(false);
+          }
+          for (Card c : currentPlayer.getTopDefCards().values()) {
+            if (c.isSelected()) changed = true;
+            c.setSelected(false);
+          }
+          if (currentPlayer.getKingCard() != null) {
+            if (currentPlayer.getKingCard().isSelected()) changed = true;
+            currentPlayer.getKingCard().setSelected(false);
+          }
+          if (changed) gameState.setUpdateState(true);
         }
         return true;
       }

--- a/html/webapp/index.html
+++ b/html/webapp/index.html
@@ -203,8 +203,14 @@
                 evt.stopPropagation();
                 evt.target.style.cursor = '';
               }
-              document.getElementById('embed-html').addEventListener('mousedown', handleMouseDown, false);
-              document.getElementById('embed-html').addEventListener('mouseup', handleMouseUp, false);
+              var embedHtml = document.getElementById('embed-html');
+              embedHtml.addEventListener('mousedown', handleMouseDown, false);
+              embedHtml.addEventListener('mouseup', handleMouseUp, false);
+              embedHtml.addEventListener('wheel', function(evt) {
+                if (evt.ctrlKey) {
+                  evt.preventDefault();
+                }
+              }, { passive: false });
 
               // Remove the loading overlay once GWT creates the canvas,
               // but always show it for at least 1.4 s so the stagger animation plays.

--- a/html/webapp/mobile.html
+++ b/html/webapp/mobile.html
@@ -196,34 +196,17 @@
         e.preventDefault();
       }, { passive: false });
 
-      // GWT's canvas only listens to mouse events. Forward touch events as
-      // mouse events so the game is controllable on mobile.
-      function forwardTouchAsMouseEvents(canvas) {
-        function relay(mouseType, touch) {
-          canvas.dispatchEvent(new MouseEvent(mouseType, {
-            bubbles: true, cancelable: true, view: window,
-            clientX: touch.clientX, clientY: touch.clientY
-          }));
-        }
-        canvas.addEventListener('touchstart', function(e) {
-          e.preventDefault(); relay('mousedown', e.changedTouches[0]);
-        }, { passive: false });
-        canvas.addEventListener('touchmove', function(e) {
-          e.preventDefault(); relay('mousemove', e.changedTouches[0]);
-        }, { passive: false });
-        canvas.addEventListener('touchend', function(e) {
-          e.preventDefault(); relay('mouseup', e.changedTouches[0]);
-        }, { passive: false });
-      }
-
-      // Poll until GWT creates the canvas, then attach touch handlers.
+      // Poll until GWT creates the canvas, then disable browser gesture handling
+      // so LibGDX receives the real touch stream for drag and pinch.
       (function waitForCanvas() {
         var canvas = document.querySelector('#embed-html canvas');
         if (canvas) {
-          // Prevent the browser from handling touch gestures (scroll, zoom)
-          // on the canvas itself — the game handles all touch input.
           canvas.style.touchAction = 'none';
-          forwardTouchAsMouseEvents(canvas);
+          ['gesturestart', 'gesturechange', 'gestureend'].forEach(function(type) {
+            canvas.addEventListener(type, function(e) {
+              e.preventDefault();
+            }, { passive: false });
+          });
           return;
         }
         setTimeout(waitForCanvas, 200);


### PR DESCRIPTION
## Summary
Implements issue #266 by enabling zoom controls on the game board viewport in `GameScreen`.

- Pinch gesture support for touch devices
- `Ctrl` + mouse wheel support for desktop browsers
- Zoom clamped to `0.8f..3.0f`
- Default zoom reset to `1.0f` when entering `GameScreen`
- Zoom applied only to the board camera path (game viewport)

## Fix for non-working zoom
The prior implementation attached `gestureDetector` to `inMulti`, but runtime input in `render()` uses `menuAndGameMulti`. This PR wires the gesture detector to the active multiplexer and sets scroll focus to the board background so wheel events are routed correctly.

## Validation
- `./gradlew html:dist` compiles successfully
- Deployed to Fly.io app `baisch-game`

Closes #266