### PR TITLE
fix: extend locked attack symbol to paired color when Banneret acquired mid-turn

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -6714,6 +6714,15 @@ public class GameScreen extends ScreenAdapter {
     if ("Reservists".equals(hero.getHeroName())) {
       emitReservistsKingBoost(((Reservists) hero).countReady());
     }
+    // When Banneret is acquired mid-turn and an attack symbol is already locked,
+    // immediately extend it to the paired color so the UI updates without waiting
+    // for the server stateUpdate round-trip.
+    if ("Banneret".equals(hero.getHeroName())) {
+      String sym = currentPlayer.getPlayerTurn().getAttackingSymbol()[0];
+      if (sym != null && !"none".equals(sym) && !"joker".equals(sym)) {
+        currentPlayer.getPlayerTurn().setAttackingSymbol(sym, true);
+      }
+    }
     currentPlayer.getPlayerTurn().setHeroSelectionPending(false);
     currentPlayer.getPlayerTurn().getHeroChoices().clear();
     int drawnCardId = currentPlayer.getPlayerTurn().getPendingDrawnCardId();

--- a/server/gameState.js
+++ b/server/gameState.js
@@ -960,6 +960,15 @@ class GameState {
     target.statHeroesReceived = (target.statHeroesReceived || 0) + 1;
     // Give an immediate charge when Battery Tower is acquired
     if (heroName === 'Battery Tower') target.batteryTowerCharges = 1;
+    // When Banneret is acquired mid-turn and an attack symbol is already locked,
+    // immediately extend it to the paired color (hearts<->diamonds, clubs<->spades).
+    if (heroName === 'Banneret' && target.attackingSymbol && target.attackingSymbol !== 'none') {
+      const sym = target.attackingSymbol;
+      if (sym === 'hearts') target.attackingSymbol2 = 'diamonds';
+      else if (sym === 'diamonds') target.attackingSymbol2 = 'hearts';
+      else if (sym === 'spades') target.attackingSymbol2 = 'clubs';
+      else if (sym === 'clubs') target.attackingSymbol2 = 'spades';
+    }
     this.pushLog(`${this.pname(playerIdx)} acquired hero: ${heroName}`, true, true);
   }
 


### PR DESCRIPTION
Closes #267