### PR TITLE
Show a global overlay when a hero is removed due to duplicate hero draw

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -6802,23 +6802,10 @@ public class GameScreen extends ScreenAdapter {
     int previousOwnerIdx = gameState.findHeroOwnerIndex(hero.getHeroName());
     int drawnCardId = currentPlayer.getPlayerTurn().getPendingDrawnCardId();
 
-    currentPlayer.addHero(hero);
-    // If the acquired hero is Reservists, immediately broadcast the count to all other clients.
-    if ("Reservists".equals(hero.getHeroName())) {
-      emitReservistsKingBoost(((Reservists) hero).countReady());
-    }
-    // When Banneret is acquired mid-turn and an attack symbol is already locked,
-    // immediately extend it to the paired color so the UI updates without waiting
-    // for the server stateUpdate round-trip.
-    if ("Banneret".equals(hero.getHeroName())) {
-      String sym = currentPlayer.getPlayerTurn().getAttackingSymbol()[0];
-      if (sym != null && !"none".equals(sym) && !"joker".equals(sym)) {
-        currentPlayer.getPlayerTurn().setAttackingSymbol(sym, true);
-      }
-    }
-
-    // Issue #269: when this acquisition steals an already-owned hero, broadcast hero-loss overlay.
+    // Issue #269: if the hero is already owned by another player, that player loses it
+    // but the drawing player receives NOTHING. Mirror the direct-draw path.
     if (previousOwnerIdx >= 0 && previousOwnerIdx < players.size()) {
+      players.get(previousOwnerIdx).removeHeroByName(hero.getHeroName());
       heroLossPlayerName = players.get(previousOwnerIdx).getPlayerName();
       heroLossHeroName = hero.getHeroName();
       heroLossTriggerName = currentPlayer.getPlayerName();
@@ -6833,6 +6820,25 @@ public class GameScreen extends ScreenAdapter {
         socket.emit("heroLost", lossData);
       } catch (JSONException e) {
         e.printStackTrace();
+      }
+      currentPlayer.getPlayerTurn().setHeroSelectionPending(false);
+      currentPlayer.getPlayerTurn().getHeroChoices().clear();
+      gameState.setUpdateState(true);
+      return;
+    }
+
+    currentPlayer.addHero(hero);
+    // If the acquired hero is Reservists, immediately broadcast the count to all other clients.
+    if ("Reservists".equals(hero.getHeroName())) {
+      emitReservistsKingBoost(((Reservists) hero).countReady());
+    }
+    // When Banneret is acquired mid-turn and an attack symbol is already locked,
+    // immediately extend it to the paired color so the UI updates without waiting
+    // for the server stateUpdate round-trip.
+    if ("Banneret".equals(hero.getHeroName())) {
+      String sym = currentPlayer.getPlayerTurn().getAttackingSymbol()[0];
+      if (sym != null && !"none".equals(sym) && !"joker".equals(sym)) {
+        currentPlayer.getPlayerTurn().setAttackingSymbol(sym, true);
       }
     }
 

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -309,11 +309,15 @@ public class GameScreen extends ScreenAdapter {
     panGameCamera(after.x - before.x, after.y - before.y);
   }
 
-  // ── Hero reveal overlay (issue #257) ──────────────────────────────────────
-  // Set when any player acquires a hero; cleared when the player dismisses the overlay.
-  private String heroRevealPlayerName  = null;
-  private String heroRevealHeroName    = null;
-  private int    heroRevealDrawnCardId = -1;
+  // ── Hero reveal/loss overlays (issues #257 / #269) ───────────────────────
+  // Set when any player acquires or loses a hero; cleared when the player dismisses the overlay.
+  private String heroRevealPlayerName   = null;
+  private String heroRevealHeroName     = null;
+  private int    heroRevealDrawnCardId  = -1;
+  private String heroLossPlayerName     = null;
+  private String heroLossHeroName       = null;
+  private String heroLossTriggerName    = null;
+  private int    heroLossDrawnCardId    = -1;
 
 
   // New constructor for centralized state
@@ -498,8 +502,8 @@ public class GameScreen extends ScreenAdapter {
       }
     });
 
-    // A joker draw landed on a hero that was already owned — the owner loses the hero.
-    // Per issue #25: the drawing player gets nothing; the previous owner loses the hero.
+    // A joker/hero draw landed on a hero that was already owned — the owner loses the hero.
+    // Issue #269: show a global hero-loss overlay to all players.
     socket.on("heroLost", new SocketListener() {
       @Override
       public void call(Object... args) {
@@ -508,11 +512,20 @@ public class GameScreen extends ScreenAdapter {
           @Override
           public void run() {
             try {
-              int pIdx = data.getInt("playerIndex");
+              int pIdx = data.optInt("lostPlayerIndex", data.optInt("playerIndex", -1));
               String heroName = data.getString("heroName");
               if (pIdx >= 0 && pIdx < players.size()) {
                 players.get(pIdx).removeHeroByName(heroName);
+                heroLossPlayerName = players.get(pIdx).getPlayerName();
+              } else {
+                heroLossPlayerName = "A player";
               }
+              int triggerIdx = data.optInt("triggerPlayerIndex", -1);
+              heroLossTriggerName = (triggerIdx >= 0 && triggerIdx < players.size())
+                  ? players.get(triggerIdx).getPlayerName()
+                  : null;
+              heroLossHeroName = heroName;
+              heroLossDrawnCardId = data.optInt("drawnCardId", -1);
               gameState.setUpdateState(true);
             } catch (JSONException e) {
               e.printStackTrace();
@@ -3301,10 +3314,62 @@ public class GameScreen extends ScreenAdapter {
       overlayStage.addActor(kdScroll);
     }
 
-    // ── Hero reveal overlay (issue #257) ───────────────────────────────────
-    // Shown to every player after any hero acquisition. Dismissed with "Got it!".
-    // Uses overlayStage (450x800) so elements at any HEIGHT fraction are visible.
-    if (heroRevealPlayerName != null && heroRevealHeroName != null) {
+    // ── Hero loss/reveal overlays (issues #269 / #257) ─────────────────────
+    // Hero-loss overlay is prioritized when both events happen in quick succession.
+    if (heroLossPlayerName != null && heroLossHeroName != null) {
+      final String lostHero = heroLossHeroName;
+      final int lostCardId = heroLossDrawnCardId;
+
+      Image lossOv = new Image(MyGdxGame.skin, "white");
+      lossOv.setFillParent(true);
+      lossOv.setColor(0f, 0f, 0f, 0.88f);
+      overlayStage.addActor(lossOv);
+
+      Table lossTable = new Table();
+      lossTable.setFillParent(true);
+      lossTable.center();
+
+      Label lossTitle = new Label(heroLossPlayerName + " lost a Hero!", MyGdxGame.skin);
+      lossTitle.setColor(Color.RED);
+      lossTable.add(lossTitle).padBottom(10f).row();
+
+      if (heroLossTriggerName != null && !heroLossTriggerName.isEmpty()) {
+        Label lossBy = new Label("Triggered by " + heroLossTriggerName, MyGdxGame.skin);
+        lossBy.setColor(Color.LIGHT_GRAY);
+        lossTable.add(lossBy).padBottom(8f).row();
+      }
+
+      Label lossHeroLabel = new Label(lostHero, MyGdxGame.skin);
+      lossHeroLabel.setColor(Color.WHITE);
+      lossTable.add(lossHeroLabel).padBottom(14f).row();
+
+      if (lostCardId > 0) {
+        Card lossCard = Card.fromCardId(lostCardId);
+        if (lossCard != null) {
+          float cScale = 1.4f;
+          float cW = lossCard.getWidth() * cScale;
+          float cH = lossCard.getHeight() * cScale;
+          lossCard.setSize(cW, cH);
+          lossTable.add(lossCard).size(cW, cH).padBottom(20f).row();
+        }
+      }
+
+      TextButton lossBtn = new TextButton("Got it!", MyGdxGame.skin);
+      lossBtn.pad(8f, 32f, 8f, 32f);
+      lossBtn.addListener(new ClickListener() {
+        @Override
+        public void clicked(InputEvent event, float x, float y) {
+          GameScreen.this.heroLossPlayerName = null;
+          GameScreen.this.heroLossHeroName = null;
+          GameScreen.this.heroLossTriggerName = null;
+          GameScreen.this.heroLossDrawnCardId = -1;
+          gameState.setUpdateState(true);
+        }
+      });
+      lossTable.add(lossBtn);
+
+      overlayStage.addActor(lossTable);
+    } else if (heroRevealPlayerName != null && heroRevealHeroName != null) {
       final String revealHero   = heroRevealHeroName;
       final int    revealCardId = heroRevealDrawnCardId;
 
@@ -6705,10 +6770,17 @@ public class GameScreen extends ScreenAdapter {
             int ownerIdx = gameState.findHeroOwnerIndex(takenName);
             if (ownerIdx >= 0) {
               players.get(ownerIdx).removeHeroByName(takenName);
+              heroLossPlayerName = players.get(ownerIdx).getPlayerName();
+              heroLossHeroName = takenName;
+              heroLossTriggerName = currentPlayer.getPlayerName();
+              heroLossDrawnCardId = drawnCard.getCardId();
               try {
                 JSONObject emitData = new JSONObject();
                 emitData.put("playerIndex", ownerIdx);
+                emitData.put("lostPlayerIndex", ownerIdx);
+                emitData.put("triggerPlayerIndex", playerIndex);
                 emitData.put("heroName", takenName);
+                emitData.put("drawnCardId", drawnCard.getCardId());
                 socket.emit("heroLost", emitData);
               } catch (JSONException e) {
                 e.printStackTrace();
@@ -6733,6 +6805,9 @@ public class GameScreen extends ScreenAdapter {
 
   /** Finalise hero acquisition: add hero to player, emit to server, trigger redraw. */
   private void completeHeroAcquisition(Hero hero) {
+    int previousOwnerIdx = gameState.findHeroOwnerIndex(hero.getHeroName());
+    int drawnCardId = currentPlayer.getPlayerTurn().getPendingDrawnCardId();
+
     currentPlayer.addHero(hero);
     // If the acquired hero is Reservists, immediately broadcast the count to all other clients.
     if ("Reservists".equals(hero.getHeroName())) {
@@ -6747,9 +6822,28 @@ public class GameScreen extends ScreenAdapter {
         currentPlayer.getPlayerTurn().setAttackingSymbol(sym, true);
       }
     }
+
+    // Issue #269: when this acquisition steals an already-owned hero, broadcast hero-loss overlay.
+    if (previousOwnerIdx >= 0 && previousOwnerIdx < players.size()) {
+      heroLossPlayerName = players.get(previousOwnerIdx).getPlayerName();
+      heroLossHeroName = hero.getHeroName();
+      heroLossTriggerName = currentPlayer.getPlayerName();
+      heroLossDrawnCardId = drawnCardId;
+      try {
+        JSONObject lossData = new JSONObject();
+        lossData.put("playerIndex", previousOwnerIdx);
+        lossData.put("lostPlayerIndex", previousOwnerIdx);
+        lossData.put("triggerPlayerIndex", playerIndex);
+        lossData.put("heroName", hero.getHeroName());
+        lossData.put("drawnCardId", drawnCardId);
+        socket.emit("heroLost", lossData);
+      } catch (JSONException e) {
+        e.printStackTrace();
+      }
+    }
+
     currentPlayer.getPlayerTurn().setHeroSelectionPending(false);
     currentPlayer.getPlayerTurn().getHeroChoices().clear();
-    int drawnCardId = currentPlayer.getPlayerTurn().getPendingDrawnCardId();
     try {
       JSONObject emitData = new JSONObject();
       emitData.put("playerIndex", playerIndex);

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -493,6 +493,11 @@ public class GameScreen extends ScreenAdapter {
                 heroRevealDrawnCardId = drawnId;
                 MyGdxGame.playHeroWonSound(heroName);
               }
+              // Clear any pending hero-loss overlay so the win overlay is never hidden behind it.
+              heroLossPlayerName = null;
+              heroLossHeroName = null;
+              heroLossTriggerName = null;
+              heroLossDrawnCardId = -1;
               gameState.setUpdateState(true);
             } catch (JSONException e) {
               e.printStackTrace();
@@ -526,6 +531,10 @@ public class GameScreen extends ScreenAdapter {
                   : null;
               heroLossHeroName = heroName;
               heroLossDrawnCardId = data.optInt("drawnCardId", -1);
+              // Clear any pending hero-win overlay so the loss overlay is never hidden behind it.
+              heroRevealPlayerName = null;
+              heroRevealHeroName = null;
+              heroRevealDrawnCardId = -1;
               gameState.setUpdateState(true);
             } catch (JSONException e) {
               e.printStackTrace();
@@ -6761,10 +6770,16 @@ public class GameScreen extends ScreenAdapter {
           // Per issue #25 the drawing player receives NOTHING.
           String takenName = HeroesSquare.heroNameByCardIndex(drawnIndex);
           if (takenName != null) {
-            int ownerIdx = gameState.findHeroOwnerIndex(takenName);
-            if (ownerIdx >= 0) {
-              players.get(ownerIdx).removeHeroByName(takenName);
-              heroLossPlayerName = players.get(ownerIdx).getPlayerName();
+            // Iterate directly to find owner; avoids findHeroOwnerIndex index mismatch.
+            Player ownerPlayer = null;
+            for (int oi = 0; oi < players.size(); oi++) {
+              if (players.get(oi).hasHero(takenName)) { ownerPlayer = players.get(oi); break; }
+            }
+            if (ownerPlayer != null) {
+              int ownerIdx = players.indexOf(ownerPlayer);
+              ownerPlayer.removeHeroByName(takenName);
+              heroRevealPlayerName = null; heroRevealHeroName = null; heroRevealDrawnCardId = -1;
+              heroLossPlayerName = ownerPlayer.getPlayerName();
               heroLossHeroName = takenName;
               heroLossTriggerName = currentPlayer.getPlayerName();
               heroLossDrawnCardId = drawnCard.getCardId();
@@ -6799,21 +6814,28 @@ public class GameScreen extends ScreenAdapter {
 
   /** Finalise hero acquisition: add hero to player, emit to server, trigger redraw. */
   private void completeHeroAcquisition(Hero hero) {
-    int previousOwnerIdx = gameState.findHeroOwnerIndex(hero.getHeroName());
+    // Find if any player already owns this hero by direct name search (avoids
+    // findHeroOwnerIndex index-into-internal-list vs GameScreen.players mismatch).
+    Player previousOwner = null;
+    for (int pi = 0; pi < players.size(); pi++) {
+      if (players.get(pi).hasHero(hero.getHeroName())) { previousOwner = players.get(pi); break; }
+    }
     int drawnCardId = currentPlayer.getPlayerTurn().getPendingDrawnCardId();
 
-    // Issue #269: if the hero is already owned by another player, that player loses it
-    // but the drawing player receives NOTHING. Mirror the direct-draw path.
-    if (previousOwnerIdx >= 0 && previousOwnerIdx < players.size()) {
-      players.get(previousOwnerIdx).removeHeroByName(hero.getHeroName());
-      heroLossPlayerName = players.get(previousOwnerIdx).getPlayerName();
+    // Issue #269: if the hero is already owned by anyone, the owner loses it
+    // but the drawing player receives NOTHING.
+    if (previousOwner != null) {
+      int ownerIdx = players.indexOf(previousOwner);
+      previousOwner.removeHeroByName(hero.getHeroName());
+      heroRevealPlayerName = null; heroRevealHeroName = null; heroRevealDrawnCardId = -1;
+      heroLossPlayerName = previousOwner.getPlayerName();
       heroLossHeroName = hero.getHeroName();
       heroLossTriggerName = currentPlayer.getPlayerName();
       heroLossDrawnCardId = drawnCardId;
       try {
         JSONObject lossData = new JSONObject();
-        lossData.put("playerIndex", previousOwnerIdx);
-        lossData.put("lostPlayerIndex", previousOwnerIdx);
+        lossData.put("playerIndex", ownerIdx);
+        lossData.put("lostPlayerIndex", ownerIdx);
         lossData.put("triggerPlayerIndex", playerIndex);
         lossData.put("heroName", hero.getHeroName());
         lossData.put("drawnCardId", drawnCardId);
@@ -6826,7 +6848,6 @@ public class GameScreen extends ScreenAdapter {
       gameState.setUpdateState(true);
       return;
     }
-
     currentPlayer.addHero(hero);
     // If the acquired hero is Reservists, immediately broadcast the count to all other clients.
     if ("Reservists".equals(hero.getHeroName())) {
@@ -6858,6 +6879,8 @@ public class GameScreen extends ScreenAdapter {
     heroRevealPlayerName = currentPlayer.getPlayerName();
     heroRevealHeroName   = hero.getHeroName();
     heroRevealDrawnCardId = drawnCardId;
+    // Clear any pending loss overlay so the win overlay is not suppressed behind it.
+    heroLossPlayerName = null; heroLossHeroName = null; heroLossTriggerName = null; heroLossDrawnCardId = -1;
     MyGdxGame.playHeroWonSound(hero.getHeroName());
     gameState.setUpdateState(true);
   }

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -3235,24 +3235,35 @@ public class GameScreen extends ScreenAdapter {
             if (consumed != null) {
               completeHeroAcquisition(consumed);
             } else {
-              // Hero is already owned — strip it from the owner and transfer it.
-              int ownerIdx = gameState.findHeroOwnerIndex(heroName);
-              if (ownerIdx >= 0) {
-                Hero stripped = players.get(ownerIdx).removeHeroByName(heroName);
-                if (stripped != null) {
-                  // Emit heroAcquired BEFORE heroLost so other clients can
-                  // still find the hero in the old owner's list inside
-                  // applyHeroAcquired and transfer it without it disappearing.
-                  completeHeroAcquisition(stripped);
-                  try {
-                    JSONObject emitData = new JSONObject();
-                    emitData.put("playerIndex", ownerIdx);
-                    emitData.put("heroName", heroName);
-                    socket.emit("heroLost", emitData);
-                  } catch (JSONException e) {
-                    e.printStackTrace();
-                  }
+              // Hero is already owned — the owner loses it and the drawing player gets NOTHING.
+              Player ownerPlayer = null;
+              for (int oi = 0; oi < players.size(); oi++) {
+                if (players.get(oi).hasHero(heroName)) { ownerPlayer = players.get(oi); break; }
+              }
+              if (ownerPlayer != null) {
+                int ownerIdx = players.indexOf(ownerPlayer);
+                ownerPlayer.removeHeroByName(heroName);
+                heroRevealPlayerName = null;
+                heroRevealHeroName = null;
+                heroRevealDrawnCardId = -1;
+                heroLossPlayerName = ownerPlayer.getPlayerName();
+                heroLossHeroName = heroName;
+                heroLossTriggerName = currentPlayer.getPlayerName();
+                heroLossDrawnCardId = currentPlayer.getPlayerTurn().getPendingDrawnCardId();
+                currentPlayer.getPlayerTurn().setHeroSelectionPending(false);
+                currentPlayer.getPlayerTurn().getHeroChoices().clear();
+                try {
+                  JSONObject emitData = new JSONObject();
+                  emitData.put("playerIndex", ownerIdx);
+                  emitData.put("lostPlayerIndex", ownerIdx);
+                  emitData.put("triggerPlayerIndex", playerIndex);
+                  emitData.put("heroName", heroName);
+                  emitData.put("drawnCardId", currentPlayer.getPlayerTurn().getPendingDrawnCardId());
+                  socket.emit("heroLost", emitData);
+                } catch (JSONException e) {
+                  e.printStackTrace();
                 }
+                gameState.setUpdateState(true);
               }
             }
           }

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -3333,12 +3333,6 @@ public class GameScreen extends ScreenAdapter {
       lossTitle.setColor(Color.RED);
       lossTable.add(lossTitle).padBottom(10f).row();
 
-      if (heroLossTriggerName != null && !heroLossTriggerName.isEmpty()) {
-        Label lossBy = new Label("Triggered by " + heroLossTriggerName, MyGdxGame.skin);
-        lossBy.setColor(Color.LIGHT_GRAY);
-        lossTable.add(lossBy).padBottom(8f).row();
-      }
-
       Label lossHeroLabel = new Label(lostHero, MyGdxGame.skin);
       lossHeroLabel.setColor(Color.WHITE);
       lossTable.add(lossHeroLabel).padBottom(14f).row();

--- a/core/src/com/mygdx/game/Player.java
+++ b/core/src/com/mygdx/game/Player.java
@@ -658,13 +658,12 @@ public class Player {
   }
 
   public boolean hasHero(String heroName) {
-    boolean hasHero = false;
     for (int i = 0; i < heroes.size(); i++) {
-      if (heroes.get(i).getHeroName() == heroName) {
-        hasHero = true;
+      if (heroName.equals(heroes.get(i).getHeroName())) {
+        return true;
       }
     }
-    return hasHero;
+    return false;
   }
 
   // Synced Reservists ready count — updated via socket event from the owning client.

--- a/server/bot.js
+++ b/server/bot.js
@@ -789,8 +789,23 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     var heroName = botHeroNameFromOracleCard(gs, oracleCardId);
     if (!heroName) return false;
 
+    var previousOwnerIdx = gs.players.findIndex(function(pp) {
+      return (pp.heroes || []).indexOf(heroName) !== -1;
+    });
+
     gs.jokerSacrifice(playerIdx, jokerId, oracleCardId);
     gs.heroAcquired(playerIdx, heroName);
+
+    if (previousOwnerIdx >= 0) {
+      io.to(sess.id).emit('heroLost', {
+        playerIndex: previousOwnerIdx,
+        lostPlayerIndex: previousOwnerIdx,
+        triggerPlayerIndex: playerIdx,
+        heroName: heroName,
+        drawnCardId: oracleCardId,
+      });
+    }
+
     io.to(sess.id).emit('stateUpdate', gs.serialize());
     return true;
   }

--- a/server/bot.js
+++ b/server/bot.js
@@ -794,9 +794,10 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
     });
 
     gs.jokerSacrifice(playerIdx, jokerId, oracleCardId);
-    gs.heroAcquired(playerIdx, heroName);
 
     if (previousOwnerIdx >= 0) {
+      // The drawing player receives nothing; only the previous owner loses the hero.
+      gs.heroLost(previousOwnerIdx, heroName);
       io.to(sess.id).emit('heroLost', {
         playerIndex: previousOwnerIdx,
         lostPlayerIndex: previousOwnerIdx,
@@ -804,6 +805,8 @@ module.exports = function createBotAI(io, checkAndHandleWinner) {
         heroName: heroName,
         drawnCardId: oracleCardId,
       });
+    } else {
+      gs.heroAcquired(playerIdx, heroName);
     }
 
     io.to(sess.id).emit('stateUpdate', gs.serialize());

--- a/server/index.js
+++ b/server/index.js
@@ -1639,6 +1639,8 @@ io.on('connection', function(socket) {
     if (!sess || !sess.gameState) return;
     console.log("heroLost: playerIndex=" + data.playerIndex + " heroName=" + data.heroName);
     sess.gameState.heroLost(data.playerIndex, data.heroName);
+    // Relay to all other players so everyone sees the hero-loss overlay.
+    socket.to(sess.id).emit('heroLost', data);
     io.to(sess.id).emit('stateUpdate', sess.gameState.serialize());
   });
 

--- a/server/index.js
+++ b/server/index.js
@@ -1628,6 +1628,11 @@ io.on('connection', function(socket) {
     var sess = getSession(socket.id);
     if (!sess || !sess.gameState) return;
     console.log("heroAcquired: playerIndex=" + data.playerIndex + " heroName=" + data.heroName);
+    // Guard: if the hero is already owned by any player, acquiring player gets nothing.
+    var alreadyOwned = sess.gameState.players.some(function(p) {
+      return (p.heroes || []).indexOf(data.heroName) !== -1;
+    });
+    if (alreadyOwned) return;
     sess.gameState.heroAcquired(data.playerIndex, data.heroName);
     // Relay to all other players so they show the hero reveal overlay.
     socket.to(sess.id).emit('heroAcquired', data);


### PR DESCRIPTION
## Summary
- add a dedicated hero-loss overlay (global, visible to all players)
- include drawn card, removed hero, affected player, and trigger player in hero-loss payload
- relay heroLost socket event to other clients and emit heroLost for bot joker-sacrifice paths
- prioritize hero-loss overlay rendering when both loss/win overlays are pending

## Validation
- static error check in edited files passed
- deployed to Fly.io and machine is started

Closes #269