### PR TITLE
Persist in-game chat history across page refreshes

### DIFF
--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -866,6 +866,11 @@ public class GameScreen extends ScreenAdapter {
       }
     });
 
+    // Request chat history from the server now that the chatHistory listener is registered.
+    // (The server pushes chatHistory at reconnect time, but GameScreen may not exist yet
+    // when that push arrives — so we pull it explicitly here to guarantee delivery.)
+    socket.emit("requestChatHistory");
+
     socket.on("chatMessage", new SocketListener() {
       @Override
       public void call(Object... args) {

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -869,7 +869,7 @@ public class GameScreen extends ScreenAdapter {
     // Request chat history from the server now that the chatHistory listener is registered.
     // (The server pushes chatHistory at reconnect time, but GameScreen may not exist yet
     // when that push arrives — so we pull it explicitly here to guarantee delivery.)
-    socket.emit("requestChatHistory");
+    socket.emit("requestChatHistory", null);
 
     socket.on("chatMessage", new SocketListener() {
       @Override

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -841,6 +841,31 @@ public class GameScreen extends ScreenAdapter {
       }
     });
 
+    socket.on("chatHistory", new SocketListener() {
+      @Override
+      public void call(Object... args) {
+        if (args.length == 0) return;
+        try {
+          final org.json.JSONArray history = (org.json.JSONArray) args[0];
+          Gdx.app.postRunnable(new Runnable() {
+            @Override public void run() {
+              chatMessages.clear();
+              for (int hi = 0; hi < history.length(); hi++) {
+                try {
+                  org.json.JSONObject m = history.getJSONObject(hi);
+                  chatMessages.add(new String[]{ m.optString("name", "?"), m.optString("text", "") });
+                } catch (org.json.JSONException ignore) {}
+              }
+              // If the chat panel is currently open, rebuild it so history shows immediately.
+              if (chatOpen) {
+                showChatOverlay();
+              }
+            }
+          });
+        } catch (Exception e) { e.printStackTrace(); }
+      }
+    });
+
     socket.on("chatMessage", new SocketListener() {
       @Override
       public void call(Object... args) {

--- a/core/src/com/mygdx/game/GameScreen.java
+++ b/core/src/com/mygdx/game/GameScreen.java
@@ -846,15 +846,15 @@ public class GameScreen extends ScreenAdapter {
       public void call(Object... args) {
         if (args.length == 0) return;
         try {
-          final org.json.JSONArray history = (org.json.JSONArray) args[0];
+          final JSONArray history = (JSONArray) args[0];
           Gdx.app.postRunnable(new Runnable() {
             @Override public void run() {
               chatMessages.clear();
               for (int hi = 0; hi < history.length(); hi++) {
                 try {
-                  org.json.JSONObject m = history.getJSONObject(hi);
+                  JSONObject m = history.getJSONObject(hi);
                   chatMessages.add(new String[]{ m.optString("name", "?"), m.optString("text", "") });
-                } catch (org.json.JSONException ignore) {}
+                } catch (JSONException ignore) {}
               }
               // If the chat panel is currently open, rebuild it so history shows immediately.
               if (chatOpen) {

--- a/server/index.js
+++ b/server/index.js
@@ -90,7 +90,8 @@ function createSession(name, allowHeroSelection, startingCards, manualSetup, her
       {type: 'open'},
       {type: 'open'},
       {type: 'open'}
-    ]
+    ],
+    chatHistory: [] // persisted chat messages, capped at 200, replayed to reconnecting players
   };
   return sessions[id];
 }
@@ -1099,7 +1100,12 @@ io.on('connection', function(socket) {
     if (!sess) return;
     var sender = connectedPlayers[socket.id];
     var name = sender ? sender.name : 'Unknown';
-    io.to(sess.id).emit('chatMessage', { name: name, text: (data && data.text) ? String(data.text) : '' });
+    var text = (data && data.text) ? String(data.text) : '';
+    // Persist in session so reconnecting players receive the full history.
+    if (!sess.chatHistory) sess.chatHistory = [];
+    sess.chatHistory.push({ name: name, text: text });
+    if (sess.chatHistory.length > 200) sess.chatHistory.shift(); // cap at 200
+    io.to(sess.id).emit('chatMessage', { name: name, text: text });
   });
 
   socket.on('disconnect', function() {
@@ -1181,6 +1187,7 @@ io.on('connection', function(socket) {
             socketToSession[socket.id] = sessId;
             socket.join(sessId);
             socket.emit('gameState', { playerIndex: playerIdx, gameState: sess.gameState.serialize(false), heroAssignMode: sess.heroAssignMode || 'value_mapping' });
+            socket.emit('chatHistory', sess.chatHistory || []);
             broadcastPlayerList();
             console.log('Reconnected ' + name + ' (token ' + token.slice(0, 8) + '...) to session ' + sessId + ' as player ' + playerIdx);
             return;
@@ -1388,6 +1395,7 @@ io.on('connection', function(socket) {
     socket.join(sess.id);
     socket.emit('sessionJoined', { sessionId: sess.id });
     socket.emit('gameState', { playerIndex: -1, gameState: sess.gameState.serialize(), heroAssignMode: sess.heroAssignMode || 'value_mapping' });
+    socket.emit('chatHistory', sess.chatHistory || []);
   });
 
   // ── Lobby events ─────────────────────────────────────────────────────────

--- a/server/index.js
+++ b/server/index.js
@@ -1108,6 +1108,12 @@ io.on('connection', function(socket) {
     io.to(sess.id).emit('chatMessage', { name: name, text: text });
   });
 
+  socket.on('requestChatHistory', function() {
+    var sess = getSession(socket.id);
+    if (!sess) return;
+    socket.emit('chatHistory', sess.chatHistory || []);
+  });
+
   socket.on('disconnect', function() {
     console.log("User Disconnected: " + socket.id);
     // If the player was in a session (running game OR pre-game lobby) and has a


### PR DESCRIPTION
Closes #285

## What changed

**Server (`server/index.js`)**
- Each session now has a `chatHistory[]` array (capped at 200 messages).
- The `chatMessage` handler appends `{ name, text }` to the history before broadcasting.
- Reconnecting players (running game) receive a `chatHistory` event immediately after `gameState`.
- Spectators joining mid-game also receive `chatHistory`.

**Client (`core/src/com/mygdx/game/GameScreen.java`)**
- New `chatHistory` socket listener clears `chatMessages` and repopulates it from the server payload.
- If the chat overlay is currently open when history arrives, it is rebuilt immediately so history is visible without closing and reopening the panel.