### PR TITLE
Improve login UX: explicit login button + avatar account menu in navigation

### DIFF
--- a/android/assets/data/i18n/menu.properties
+++ b/android/assets/data/i18n/menu.properties
@@ -24,6 +24,7 @@ menu.tutorial=Tutorial
 menu.newGame=New game
 menu.noPlayers=No players online
 menu.logOut=Log out
+menu.login=Log in
 menu.musicOn=Music ON
 menu.musicOff=Music OFF
 menu.lobbyTitle=Game lobby

--- a/android/assets/data/i18n/menu_de.properties
+++ b/android/assets/data/i18n/menu_de.properties
@@ -24,6 +24,7 @@ menu.tutorial=Tutorial
 menu.newGame=Neues Spiel
 menu.noPlayers=Keine Spieler online
 menu.logOut=Abmelden
+menu.login=Einloggen
 menu.musicOn=Musik AN
 menu.musicOff=Musik AUS
 menu.lobbyTitle=Spiel-Lobby

--- a/android/assets/data/i18n/menu_it.properties
+++ b/android/assets/data/i18n/menu_it.properties
@@ -24,6 +24,7 @@ menu.tutorial=Tutorial
 menu.newGame=Nuova partita
 menu.noPlayers=Nessun giocatore online
 menu.logOut=Esci
+menu.login=Accedi
 menu.musicOn=Musica ON
 menu.musicOff=Musica OFF
 menu.lobbyTitle=Lobby di gioco

--- a/android/assets/data/i18n/menu_no.properties
+++ b/android/assets/data/i18n/menu_no.properties
@@ -24,6 +24,7 @@ menu.tutorial=Tutorial
 menu.newGame=Nytt spill
 menu.noPlayers=Ingen spillere online
 menu.logOut=Logg ut
+menu.login=Logg inn
 menu.musicOn=Musikk PÅ
 menu.musicOff=Musikk AV
 menu.lobbyTitle=Spill-lobby

--- a/android/assets/data/i18n/menu_ru.properties
+++ b/android/assets/data/i18n/menu_ru.properties
@@ -24,6 +24,7 @@ menu.tutorial=Обучение
 menu.newGame=Новая игра
 menu.noPlayers=Нет игроков онлайн
 menu.logOut=Выйти
+menu.login=Войти
 menu.musicOn=Музыка ВКЛ
 menu.musicOff=Музыка ВЫКЛ
 menu.lobbyTitle=Лобби игры

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -645,7 +645,7 @@ public class MenuScreen extends AbstractScreen {
     // ── Login button (centered below avatar selector — positioned after it is built) ───
     final TextButton loginBtn = new TextButton(t("menu.login"), MyGdxGame.skin);
     loginBtn.pack();
-    loginBtn.setSize(loginBtn.getPrefWidth() + 16f, 50f);
+    loginBtn.setSize(loginBtn.getPrefWidth() + 40f, loginBtn.getPrefHeight() + 20f);
     final boolean initNameOk = !menuState.getMyName().isEmpty();
     final boolean initIconOk = !selectedIcon.isEmpty();
     loginBtn.setDisabled(!(initNameOk && initIconOk));
@@ -747,10 +747,10 @@ public class MenuScreen extends AbstractScreen {
         Math.round(0.3f * MyGdxGame.HEIGHT - avatarSelector.getHeight() - 10f));
     menuStage.addActor(avatarSelector);
 
-    // Login button: centered below avatar selector
+    // Login button: centered below avatar selector, clamped so it stays on screen
     loginBtn.setPosition(
         Math.round(cx - loginBtn.getWidth() / 2f),
-        Math.round(avatarSelector.getY() - loginBtn.getHeight() - 10f));
+        Math.max(6f, Math.round(avatarSelector.getY() - loginBtn.getHeight() - 10f)));
     menuStage.addActor(loginBtn);
 
     // Subtitle below logo — the DOM overlay (BAISCH + suits) occupies the upper half;

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -387,6 +387,7 @@ public class MenuScreen extends AbstractScreen {
     }
     if (MyGdxGame.nativeMusicButton) {
       if (MyGdxGame.onLanguageUiUpdate != null) MyGdxGame.onLanguageUiUpdate.run();
+      if (MyGdxGame.onAccountUiUpdate  != null) MyGdxGame.onAccountUiUpdate.run();
     } else {
       addLanguageButtons(menuStage);
     }
@@ -641,11 +642,10 @@ public class MenuScreen extends AbstractScreen {
       }
     });
 
-    // ── Login button (to the right of name field) ────────────────────────────
+    // ── Login button (centered below avatar selector — positioned after it is built) ───
     final TextButton loginBtn = new TextButton(t("menu.login"), MyGdxGame.skin);
     loginBtn.pack();
     loginBtn.setSize(loginBtn.getPrefWidth() + 16f, 50f);
-    loginBtn.setPosition(cx + 125f + 8f, 0.3f * MyGdxGame.HEIGHT);
     final boolean initNameOk = !menuState.getMyName().isEmpty();
     final boolean initIconOk = !selectedIcon.isEmpty();
     loginBtn.setDisabled(!(initNameOk && initIconOk));
@@ -657,7 +657,6 @@ public class MenuScreen extends AbstractScreen {
         doConfirm.run();
       }
     });
-    menuStage.addActor(loginBtn);
 
     // Update login button whenever the player types in the name field.
     nameField.setTextFieldListener(new com.badlogic.gdx.scenes.scene2d.ui.TextField.TextFieldListener() {
@@ -747,6 +746,12 @@ public class MenuScreen extends AbstractScreen {
         Math.round(cx - avatarSelector.getWidth() / 2f),
         Math.round(0.3f * MyGdxGame.HEIGHT - avatarSelector.getHeight() - 10f));
     menuStage.addActor(avatarSelector);
+
+    // Login button: centered below avatar selector
+    loginBtn.setPosition(
+        Math.round(cx - loginBtn.getWidth() / 2f),
+        Math.round(avatarSelector.getY() - loginBtn.getHeight() - 10f));
+    menuStage.addActor(loginBtn);
 
     // Subtitle below logo — the DOM overlay (BAISCH + suits) occupies the upper half;
     // position this label well above the Enter-your-name button (at 0.3f * HEIGHT)
@@ -1192,6 +1197,13 @@ public class MenuScreen extends AbstractScreen {
     show();
   }
 
+  /** Called from the DOM account-button dropdown on the web platform. */
+  public void triggerLogout() {
+    Gdx.app.postRunnable(new Runnable() {
+      @Override public void run() { logout(); }
+    });
+  }
+
   /** Adds a small "Log out" button to the bottom-right of the given stage. */
   private void addLogoutButton(final Stage stage) {
     TextButton logoutBtn = new TextButton(t("menu.logOut"), MyGdxGame.skin);
@@ -1214,6 +1226,8 @@ public class MenuScreen extends AbstractScreen {
    * addLogoutButton on screens where the user is logged in.
    */
   private void addTopRightButtons(final Stage stage) {
+    // On web the DOM overlay handles the account button; skip LibGDX drawing.
+    if (MyGdxGame.nativeMusicButton) return;
     accountBtnAdded = true;
     final float btnSize = ACCOUNT_BTN_SIZE;
     final float rMargin = 10f;

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -615,7 +615,7 @@ public class MenuScreen extends AbstractScreen {
     final Runnable doConfirm = new Runnable() {
       @Override public void run() {
         String name = nameField.getText().trim();
-        if (name.isEmpty()) return;
+        if (name.isEmpty() || selectedIcon.isEmpty()) return;
         MyGdxGame.keyboardHelper.hideKeyboard();
         menuState.setMyName(name);
         MyGdxGame.playerStorage.saveName(name);
@@ -642,14 +642,18 @@ public class MenuScreen extends AbstractScreen {
       }
     });
 
-    // ── Login button (centered below avatar selector — positioned after it is built) ───
-    final TextButton loginBtn = new TextButton(t("menu.login"), MyGdxGame.skin);
+    // ── Login button — enabled state driven by act() every frame so it reacts
+    // correctly regardless of whether text arrives via keyTyped or setText().
+    final TextButton loginBtn = new TextButton(t("menu.login"), MyGdxGame.skin) {
+      @Override public void act(float delta) {
+        super.act(delta);
+        boolean ok = !nameField.getText().trim().isEmpty() && !selectedIcon.isEmpty();
+        setDisabled(!ok);
+        getLabel().setColor(ok ? Color.WHITE : new Color(0.5f, 0.5f, 0.5f, 1f));
+      }
+    };
     loginBtn.pack();
     loginBtn.setSize(loginBtn.getPrefWidth() + 40f, loginBtn.getPrefHeight() + 20f);
-    final boolean initNameOk = !menuState.getMyName().isEmpty();
-    final boolean initIconOk = !selectedIcon.isEmpty();
-    loginBtn.setDisabled(!(initNameOk && initIconOk));
-    loginBtn.getLabel().setColor(initNameOk && initIconOk ? Color.WHITE : new Color(0.5f, 0.5f, 0.5f, 1f));
     loginBtn.addListener(new ClickListener() {
       @Override
       public void clicked(InputEvent event, float x, float y) {
@@ -658,21 +662,9 @@ public class MenuScreen extends AbstractScreen {
       }
     });
 
-    // Update login button whenever the player types in the name field.
-    nameField.setTextFieldListener(new com.badlogic.gdx.scenes.scene2d.ui.TextField.TextFieldListener() {
-      @Override
-      public void keyTyped(com.badlogic.gdx.scenes.scene2d.ui.TextField textField, char c) {
-        boolean nameOk = !textField.getText().trim().isEmpty();
-        boolean iconOk = !selectedIcon.isEmpty();
-        loginBtn.setDisabled(!(nameOk && iconOk));
-        loginBtn.getLabel().setColor(nameOk && iconOk ? Color.WHITE : new Color(0.5f, 0.5f, 0.5f, 1f));
-      }
-    });
-
     nameField.setWidth(250f);
     nameField.setHeight(50f);
-    nameField.setPosition(cx - 125f, 0.3f * MyGdxGame.HEIGHT);
-    menuStage.addActor(nameField);
+    // Position is set after avatarSelector is packed (bottom-up layout below).
 
     // Avatar selector — shown below the name field.
     // The icons row is placed inside a horizontal ScrollPane so it fits any screen width.
@@ -710,10 +702,7 @@ public class MenuScreen extends AbstractScreen {
             Color c = sel ? new Color(0.98f, 0.80f, 0.25f, 1f) : new Color(1f, 1f, 1f, 0.18f);
             avatarWrappers[j].setBackground(MyGdxGame.skin.newDrawable("white", c));
           }
-          // Enable login button if name is also set.
-          boolean nameOk = !nameField.getText().trim().isEmpty();
-          loginBtn.setDisabled(!nameOk);
-          loginBtn.getLabel().setColor(nameOk ? Color.WHITE : new Color(0.5f, 0.5f, 0.5f, 1f));
+          // loginBtn state is updated automatically via act() override.
         }
       });
       avatarRow.add(wrapper).padRight(avIdx < AVATAR_NAMES.length - 1 ? 6f : 0f);
@@ -742,26 +731,34 @@ public class MenuScreen extends AbstractScreen {
     avatarSelector.add(avatarLabel).padBottom(6f).row();
     avatarSelector.add(avatarScroll).width(selectorMaxW - 24f).height(120f);
     avatarSelector.pack();
-    avatarSelector.setPosition(
-        Math.round(cx - avatarSelector.getWidth() / 2f),
-        Math.round(0.3f * MyGdxGame.HEIGHT - avatarSelector.getHeight() - 10f));
-    menuStage.addActor(avatarSelector);
 
-    // Login button: centered below avatar selector, clamped so it stays on screen
+    // ── Bottom-up layout: loginBtn → avatarSelector → nameField ────────────
+    // Building upward from a fixed bottom margin guarantees no overlap.
+    final float bMargin = 16f;
+    final float elemGap = 10f;
+    float loginY   = bMargin;
+    float avatarY  = loginY  + loginBtn.getHeight()     + elemGap;
+    float nameY    = avatarY + avatarSelector.getHeight() + elemGap;
+
     loginBtn.setPosition(
-        Math.round(cx - loginBtn.getWidth() / 2f),
-        Math.max(6f, Math.round(avatarSelector.getY() - loginBtn.getHeight() - 10f)));
+        Math.round(cx - loginBtn.getWidth() / 2f), Math.round(loginY));
+    avatarSelector.setPosition(
+        Math.round(cx - avatarSelector.getWidth() / 2f), Math.round(avatarY));
+    nameField.setPosition(
+        Math.round(cx - nameField.getWidth() / 2f), Math.round(nameY));
+
+    menuStage.addActor(nameField);
+    menuStage.addActor(avatarSelector);
     menuStage.addActor(loginBtn);
 
-    // Subtitle below logo — the DOM overlay (BAISCH + suits) occupies the upper half;
-    // position this label well above the Enter-your-name button (at 0.3f * HEIGHT)
-    // so the two elements don't visually overlap.
+    // Subtitle — the DOM overlay (BAISCH + suits) occupies the upper half;
+    // position this label just above the name field.
     Label subtitle = new Label(t("menu.subtitle"), MyGdxGame.skin);
     subtitle.setColor(1f, 1f, 1f, 0.65f);
     subtitle.pack();
     subtitle.setPosition(
         Math.round(cx - subtitle.getWidth() / 2f),
-        Math.round(0.42f * MyGdxGame.HEIGHT));
+        Math.round(nameY + nameField.getHeight() + 12f));
     menuStage.addActor(subtitle);
 
 

--- a/core/src/com/mygdx/game/MenuScreen.java
+++ b/core/src/com/mygdx/game/MenuScreen.java
@@ -119,6 +119,11 @@ public class MenuScreen extends AbstractScreen {
   private final java.util.Map<String, Texture> avatarTextures = new java.util.HashMap<String, Texture>();
   // Known avatar names (file names without extension inside data/avatars/).
   private static final String[] AVATAR_NAMES = {"alien1","alien2","cat","dolphin","fishnugget","knight","lion","monkey","parrot","rat","rooster","stegosauros"};
+  // Size of the top-right account/avatar button (pixels in logical coords).
+  private static final float ACCOUNT_BTN_SIZE = 42f;
+  // True during show() calls where addTopRightButtons() has been called.
+  // Used by addLanguageButtons() to shift the language picker further left.
+  private boolean accountBtnAdded = false;
 
   private static class OnlinePlayerInfo {
     String id;
@@ -354,6 +359,7 @@ public class MenuScreen extends AbstractScreen {
     if (MyGdxGame.onMenuScreenActive != null) MyGdxGame.onMenuScreenActive.run();
     heroSelectBox.hideList();
     menuStage.clear();
+    accountBtnAdded = false;
     if (menuBgTexture == null) menuBgTexture = new Texture(Gdx.files.internal("data/graphics/bg_darkmoon.jpg"));
     Image menuBg = new Image(menuBgTexture);
     menuBg.setFillParent(true);
@@ -432,7 +438,10 @@ public class MenuScreen extends AbstractScreen {
     float gap = 6f;
     float rightMargin = 10f;
     float musicW = new TextButton(MyGdxGame.playerStorage.getMusicEnabled() ? t("menu.musicOn") : t("menu.musicOff"), MyGdxGame.skin).getPrefWidth() + 20f;
-    float musicX = MyGdxGame.WIDTH - musicW - rightMargin;
+    // When the account button is present (logged-in screens), the music button has been
+    // shifted left by (ACCOUNT_BTN_SIZE + gap). Match that offset here.
+    float accountOffset = accountBtnAdded ? (ACCOUNT_BTN_SIZE + gap) : 0f;
+    float musicX = MyGdxGame.WIDTH - musicW - rightMargin - accountOffset;
     float btnX   = musicX - iconW - gap;
     float btnY   = MyGdxGame.HEIGHT - iconH - 10f;
 
@@ -632,39 +641,83 @@ public class MenuScreen extends AbstractScreen {
       }
     });
 
+    // ── Login button (to the right of name field) ────────────────────────────
+    final TextButton loginBtn = new TextButton(t("menu.login"), MyGdxGame.skin);
+    loginBtn.pack();
+    loginBtn.setSize(loginBtn.getPrefWidth() + 16f, 50f);
+    loginBtn.setPosition(cx + 125f + 8f, 0.3f * MyGdxGame.HEIGHT);
+    final boolean initNameOk = !menuState.getMyName().isEmpty();
+    final boolean initIconOk = !selectedIcon.isEmpty();
+    loginBtn.setDisabled(!(initNameOk && initIconOk));
+    loginBtn.getLabel().setColor(initNameOk && initIconOk ? Color.WHITE : new Color(0.5f, 0.5f, 0.5f, 1f));
+    loginBtn.addListener(new ClickListener() {
+      @Override
+      public void clicked(InputEvent event, float x, float y) {
+        if (loginBtn.isDisabled()) return;
+        doConfirm.run();
+      }
+    });
+    menuStage.addActor(loginBtn);
+
+    // Update login button whenever the player types in the name field.
+    nameField.setTextFieldListener(new com.badlogic.gdx.scenes.scene2d.ui.TextField.TextFieldListener() {
+      @Override
+      public void keyTyped(com.badlogic.gdx.scenes.scene2d.ui.TextField textField, char c) {
+        boolean nameOk = !textField.getText().trim().isEmpty();
+        boolean iconOk = !selectedIcon.isEmpty();
+        loginBtn.setDisabled(!(nameOk && iconOk));
+        loginBtn.getLabel().setColor(nameOk && iconOk ? Color.WHITE : new Color(0.5f, 0.5f, 0.5f, 1f));
+      }
+    });
+
     nameField.setWidth(250f);
     nameField.setHeight(50f);
     nameField.setPosition(cx - 125f, 0.3f * MyGdxGame.HEIGHT);
     menuStage.addActor(nameField);
 
-    // Avatar selector — shown below the name button
+    // Avatar selector — shown below the name field.
     // The icons row is placed inside a horizontal ScrollPane so it fits any screen width.
+    // Clicking an avatar updates the selection in-place WITHOUT rebuilding the screen,
+    // so any text the player has typed into the name field is preserved.
     float selectorMaxW = MyGdxGame.WIDTH - 24f;
 
     Label avatarLabel = new Label(t("menu.avatarChoose"), MyGdxGame.skin);
     avatarLabel.setColor(1f, 1f, 1f, 0.70f);
 
+    final Table[] avatarWrappers = new Table[AVATAR_NAMES.length];
     Table avatarRow = new Table();
     avatarRow.pad(4f, 0f, 0f, 0f);
     for (int ai = 0; ai < AVATAR_NAMES.length; ai++) {
       final String avName = AVATAR_NAMES[ai];
+      final int avIdx = ai;
       Texture avTex = getAvatarTexture(avName);
       if (avTex == null) continue;
       Image avImg = new Image(avTex);
       boolean selected = avName.equals(selectedIcon);
       Color borderCol = selected ? new Color(0.98f, 0.80f, 0.25f, 1f) : new Color(1f, 1f, 1f, 0.18f);
-      Table wrapper = new Table();
+      final Table wrapper = new Table();
       wrapper.setBackground(MyGdxGame.skin.newDrawable("white", borderCol));
       wrapper.add(avImg).size(88f, 88f).pad(4f);
+      avatarWrappers[avIdx] = wrapper;
       wrapper.addListener(new ClickListener() {
         @Override
         public void clicked(InputEvent event, float x, float y) {
           selectedIcon = avName;
           MyGdxGame.playerStorage.saveIcon(avName);
-          show();
+          // Update avatar border highlights without rebuilding the whole screen.
+          for (int j = 0; j < AVATAR_NAMES.length; j++) {
+            if (avatarWrappers[j] == null) continue;
+            boolean sel = AVATAR_NAMES[j].equals(selectedIcon);
+            Color c = sel ? new Color(0.98f, 0.80f, 0.25f, 1f) : new Color(1f, 1f, 1f, 0.18f);
+            avatarWrappers[j].setBackground(MyGdxGame.skin.newDrawable("white", c));
+          }
+          // Enable login button if name is also set.
+          boolean nameOk = !nameField.getText().trim().isEmpty();
+          loginBtn.setDisabled(!nameOk);
+          loginBtn.getLabel().setColor(nameOk ? Color.WHITE : new Color(0.5f, 0.5f, 0.5f, 1f));
         }
       });
-      avatarRow.add(wrapper).padRight(ai < AVATAR_NAMES.length - 1 ? 6f : 0f);
+      avatarRow.add(wrapper).padRight(avIdx < AVATAR_NAMES.length - 1 ? 6f : 0f);
     }
 
     ScrollPane avatarScroll = new ScrollPane(avatarRow, MyGdxGame.skin);
@@ -945,8 +998,7 @@ public class MenuScreen extends AbstractScreen {
 
     }
 
-    addMusicToggleButton(menuStage);
-    addLogoutButton(menuStage);
+    addTopRightButtons(menuStage);
     Gdx.input.setInputProcessor(menuStage);
   }
 
@@ -1103,8 +1155,7 @@ public class MenuScreen extends AbstractScreen {
         Math.round(formY));
     menuStage.addActor(form);
 
-    addMusicToggleButton(menuStage);
-    addLogoutButton(menuStage);
+    addTopRightButtons(menuStage);
     Gdx.input.setInputProcessor(menuStage);
   }
 
@@ -1154,6 +1205,108 @@ public class MenuScreen extends AbstractScreen {
       }
     });
     stage.addActor(logoutBtn);
+  }
+
+  /**
+   * Adds the account/avatar button (top-right corner) plus the music toggle button
+   * (shifted left to make room). The account button opens a small dropdown that
+   * contains at least a Logout option. Call this instead of addMusicToggleButton +
+   * addLogoutButton on screens where the user is logged in.
+   */
+  private void addTopRightButtons(final Stage stage) {
+    accountBtnAdded = true;
+    final float btnSize = ACCOUNT_BTN_SIZE;
+    final float rMargin = 10f;
+    final float gap     = 6f;
+    final float topY    = MyGdxGame.HEIGHT - btnSize - 10f;
+
+    // ── Account / avatar button ──────────────────────────────────────────────
+    final Table accountBtn = new Table();
+    accountBtn.setBackground(MyGdxGame.skin.newDrawable("white", new Color(0.85f, 0.85f, 0.85f, 0.30f)));
+    accountBtn.pad(2f);
+    Texture avTex = (selectedIcon == null || selectedIcon.isEmpty()) ? null : getAvatarTexture(selectedIcon);
+    if (avTex != null) {
+      Image avImg = new Image(avTex);
+      accountBtn.add(avImg).size(btnSize - 4f, btnSize - 4f);
+    } else {
+      // Fallback: first letter of the player name
+      String initial = menuState.getMyName().isEmpty() ? "?" : String.valueOf(menuState.getMyName().charAt(0)).toUpperCase();
+      Label initLbl = new Label(initial, MyGdxGame.skin);
+      accountBtn.add(initLbl).size(btnSize - 4f, btnSize - 4f);
+    }
+    accountBtn.setSize(btnSize, btnSize);
+    accountBtn.setPosition(MyGdxGame.WIDTH - btnSize - rMargin, topY);
+
+    // ── Dropdown ─────────────────────────────────────────────────────────────
+    final Table dropdown = new Table(MyGdxGame.skin);
+    dropdown.setBackground(MyGdxGame.skin.newDrawable("white", new Color(0.12f, 0.12f, 0.12f, 0.96f)));
+    dropdown.pad(4f);
+    TextButton logoutItem = new TextButton(t("menu.logOut"), MyGdxGame.skin);
+    logoutItem.addListener(new ClickListener() {
+      @Override public void clicked(InputEvent event, float x, float y) {
+        dropdown.setVisible(false);
+        logout();
+      }
+    });
+    dropdown.add(logoutItem).fillX().pad(2f);
+    dropdown.pack();
+    dropdown.setPosition(MyGdxGame.WIDTH - dropdown.getWidth() - rMargin, topY - dropdown.getHeight() - 4f);
+    dropdown.setVisible(false);
+
+    accountBtn.addListener(new ClickListener() {
+      @Override public void clicked(InputEvent event, float x, float y) {
+        dropdown.setVisible(!dropdown.isVisible());
+      }
+    });
+
+    // Close dropdown when tapping outside it
+    stage.addListener(new InputListener() {
+      @Override
+      public boolean touchDown(InputEvent event, float x, float y, int pointer, int button) {
+        if (!dropdown.isVisible()) return false;
+        boolean inDrop = x >= dropdown.getX() && x <= dropdown.getX() + dropdown.getWidth()
+                      && y >= dropdown.getY() && y <= dropdown.getY() + dropdown.getHeight();
+        boolean inBtn  = x >= accountBtn.getX() && x <= accountBtn.getX() + accountBtn.getWidth()
+                      && y >= accountBtn.getY() && y <= accountBtn.getY() + accountBtn.getHeight();
+        if (!inDrop && !inBtn) dropdown.setVisible(false);
+        return false;
+      }
+    });
+
+    stage.addActor(accountBtn);
+    stage.addActor(dropdown);
+
+    // ── Music toggle (shifted left to make room for the account button) ───────
+    if (!MyGdxGame.nativeMusicButton) {
+      final boolean enabled = MyGdxGame.playerStorage.getMusicEnabled();
+      final TextButton musicBtn = new TextButton(enabled ? t("menu.musicOn") : t("menu.musicOff"), MyGdxGame.skin);
+      musicBtn.pack();
+      float musicW = musicBtn.getPrefWidth() + 20f;
+      float musicH = musicBtn.getPrefHeight() + 10f;
+      musicBtn.setSize(musicW, musicH);
+      musicBtn.setPosition(MyGdxGame.WIDTH - btnSize - rMargin - gap - musicW,
+                           MyGdxGame.HEIGHT - musicH - 10f);
+      musicBtn.addListener(new ClickListener() {
+        @Override public void clicked(InputEvent event, float x, float y) {
+          MyGdxGame.setMusicEnabled(!MyGdxGame.playerStorage.getMusicEnabled());
+          show();
+        }
+      });
+      stage.addActor(musicBtn);
+
+      if (!MyGdxGame.musicStarted) {
+        stage.addCaptureListener(new InputListener() {
+          @Override
+          public boolean touchDown(InputEvent event, float x, float y, int pointer, int button) {
+            if (!isChildOf(event.getTarget(), musicBtn)) {
+              MyGdxGame.ensureMusicStarted();
+            }
+            stage.removeCaptureListener(this);
+            return false;
+          }
+        });
+      }
+    }
   }
 
   /**
@@ -1681,8 +1834,7 @@ public class MenuScreen extends AbstractScreen {
     });
     menuStage.addActor(leaveBtn);
 
-    addMusicToggleButton(menuStage);
-    addLogoutButton(menuStage);
+    addTopRightButtons(menuStage);
     Gdx.input.setInputProcessor(menuStage);
   }
 

--- a/core/src/com/mygdx/game/MyGdxGame.java
+++ b/core/src/com/mygdx/game/MyGdxGame.java
@@ -95,6 +95,8 @@ public class MyGdxGame extends Game implements InputProcessor {
   public static Runnable onGameScreenActive = null;
   /** Called when a menu/stats screen becomes active; shows the native music button again. */
   public static Runnable onMenuScreenActive = null;
+  /** Called from MenuScreen.show() to refresh the DOM account/avatar button visibility. */
+  public static Runnable onAccountUiUpdate = null;
   /** Called when the name-entry screen is shown; reveals the DOM logo overlay. */
   public static Runnable onNameEntryScreenActive = null;
   /** Called when leaving the name-entry screen; hides the DOM logo overlay. */
@@ -254,6 +256,14 @@ public class MyGdxGame extends Game implements InputProcessor {
     if (INSTANCE != null) {
       com.badlogic.gdx.Screen scr = INSTANCE.getScreen();
       if (scr instanceof MenuScreen) ((MenuScreen) scr).show();
+    }
+  }
+
+  /** Called from the HTML account/avatar DOM button when the player taps "Log out". */
+  public static void handleLogoutButtonClick() {
+    if (INSTANCE != null) {
+      com.badlogic.gdx.Screen scr = INSTANCE.getScreen();
+      if (scr instanceof MenuScreen) ((MenuScreen) scr).triggerLogout();
     }
   }
 

--- a/html/src/com/mygdx/game/client/HtmlLauncher.java
+++ b/html/src/com/mygdx/game/client/HtmlLauncher.java
@@ -33,6 +33,7 @@ public class HtmlLauncher extends GwtApplication {
         // Inject the animated GIF music button into the DOM and wire up callbacks.
         installMusicButton(app);
         installLanguageButton(app);
+        installAccountButton(app);
         // Register the UI-update callback so setMusicEnabled() keeps the GIF in sync.
         MyGdxGame.onMusicUiUpdate = new Runnable() {
             @Override
@@ -46,11 +47,18 @@ public class HtmlLauncher extends GwtApplication {
                 refreshLanguageButton(Localization.getLanguage());
             }
         };
+        MyGdxGame.onAccountUiUpdate = new Runnable() {
+            @Override
+            public void run() {
+                refreshAccountButton();
+            }
+        };
         MyGdxGame.onGameScreenActive = new Runnable() {
             @Override
             public void run() {
                 setMusicButtonVisible(false);
                 setLanguageButtonVisible(false);
+                setAccountButtonVisible(false);
                 setViewportBackgroundMode(false);
             }
         };
@@ -155,7 +163,7 @@ public class HtmlLauncher extends GwtApplication {
         img.id  = 'baisch-music-img';
         img.src = '/music.gif';
         img.style.cssText =
-            'position:fixed;top:6px;right:6px;width:' + SIZE + ';height:' + SIZE + ';' +
+            'position:fixed;top:6px;right:66px;width:' + SIZE + ';height:' + SIZE + ';' +
             'cursor:pointer;z-index:9999;border-radius:50%;display:block;';
 
         $doc.body.appendChild(img);
@@ -210,7 +218,7 @@ public class HtmlLauncher extends GwtApplication {
         var holder = $doc.createElement('div');
         holder.id = 'baisch-lang-holder';
         holder.style.cssText =
-            'position:fixed;top:6px;right:66px;z-index:9999;display:block;';
+            'position:fixed;top:6px;right:126px;z-index:9999;display:block;';
 
         var btn = $doc.createElement('img');
         btn.id = 'baisch-lang-btn';
@@ -300,6 +308,94 @@ public class HtmlLauncher extends GwtApplication {
         holder.style.display = visible ? 'block' : 'none';
         var popup = $doc.getElementById('baisch-lang-popup');
         if (popup) popup.style.display = 'none';
+    }-*/;
+
+    /**
+     * Injects a fixed-position account/avatar button (top-right, same slot that the music
+     * button previously occupied). Tapping it opens a small dropdown with a Logout option.
+     * The button is shown/hidden by refreshAccountButton() which reads localStorage.
+     */
+    private static native void installAccountButton(MyGdxGame app) /*-{
+        var SIZE = '54px';
+        var btn = $doc.createElement('div');
+        btn.id  = 'baisch-account-btn';
+        btn.style.cssText =
+            'position:fixed;top:6px;right:6px;width:' + SIZE + ';height:' + SIZE + ';' +
+            'cursor:pointer;z-index:9999;border-radius:50%;display:none;' +
+            'background:rgba(80,80,80,0.5);overflow:hidden;box-sizing:border-box;';
+
+        var img = $doc.createElement('img');
+        img.id = 'baisch-account-img';
+        img.style.cssText = 'width:100%;height:100%;border-radius:50%;object-fit:cover;display:block;';
+        btn.appendChild(img);
+
+        var dropdown = $doc.createElement('div');
+        dropdown.id = 'baisch-account-dropdown';
+        dropdown.style.cssText =
+            'position:fixed;top:66px;right:6px;display:none;' +
+            'background:rgba(20,20,20,0.96);border:1px solid rgba(255,255,255,0.25);' +
+            'border-radius:4px;padding:4px;z-index:10000;min-width:110px;';
+
+        var logoutItem = $doc.createElement('div');
+        logoutItem.style.cssText =
+            'padding:8px 14px;color:white;cursor:pointer;white-space:nowrap;' +
+            'font-family:sans-serif;font-size:14px;border-radius:3px;';
+        logoutItem.textContent = 'Log out';
+        logoutItem.addEventListener('mouseover', function() {
+            logoutItem.style.background = 'rgba(255,255,255,0.12)';
+        });
+        logoutItem.addEventListener('mouseout', function() {
+            logoutItem.style.background = '';
+        });
+        logoutItem.addEventListener('click', function(ev) {
+            ev.stopPropagation();
+            dropdown.style.display = 'none';
+            @com.mygdx.game.MyGdxGame::handleLogoutButtonClick()();
+        });
+        dropdown.appendChild(logoutItem);
+
+        $doc.body.appendChild(btn);
+        $doc.body.appendChild(dropdown);
+
+        btn.addEventListener('click', function(ev) {
+            ev.stopPropagation();
+            dropdown.style.display =
+                (dropdown.style.display === 'none' || dropdown.style.display === '') ? 'block' : 'none';
+        });
+
+        $doc.addEventListener('click', function() {
+            dropdown.style.display = 'none';
+        }, true);
+
+        $wnd._baischRefreshAccountBtn = function() {
+            var icon = $wnd.localStorage.getItem('baisch_player_icon') || '';
+            var name = $wnd.localStorage.getItem('baisch_player_name') || '';
+            if (icon && name) {
+                btn.style.display = 'block';
+                img.src = '/assets/data/avatars/' + icon + '.png';
+            } else {
+                btn.style.display = 'none';
+                dropdown.style.display = 'none';
+            }
+        };
+    }-*/;
+
+    /** Refreshes the account button visibility and avatar image from localStorage. */
+    private static native void refreshAccountButton() /*-{
+        if ($wnd._baischRefreshAccountBtn) $wnd._baischRefreshAccountBtn();
+    }-*/;
+
+    /** Shows or hides the DOM account button (and always closes its dropdown). */
+    private static native void setAccountButtonVisible(boolean visible) /*-{
+        var btn      = $doc.getElementById('baisch-account-btn');
+        var dropdown = $doc.getElementById('baisch-account-dropdown');
+        if (dropdown) dropdown.style.display = 'none';
+        if (!btn) return;
+        if (visible) {
+            if ($wnd._baischRefreshAccountBtn) $wnd._baischRefreshAccountBtn();
+        } else {
+            btn.style.display = 'none';
+        }
     }-*/;
 
     /**


### PR DESCRIPTION
Closes #287

## Login screen
- Added a **Login** button to the right of the name text field
- Button is **disabled / greyed** until both a name is typed AND an avatar is selected
- Selecting an avatar now updates the border highlights **in-place** (no `show()` rebuild), so any text already typed into the name field is preserved
- A `TextFieldListener` on the name field keeps the button state in sync as the player types
- Either name or avatar can be set first — order no longer matters

## Navigation (session list, session create, lobby)
- New `addTopRightButtons()` method replaces `addMusicToggleButton + addLogoutButton` on all logged-in screens
- **Avatar/account button** (42 × 42, shows the player's current avatar) added to the top-right corner; the music toggle shifts left to make room
- Tapping the avatar button opens a small **dropdown** containing a **Logout** option
- The old standalone bottom-right logout button is removed
- Language picker position updated via `accountBtnAdded` flag so it stays correctly positioned alongside the shifted music button

## Localisation
- Added `menu.login` key in EN / DE / NO / IT / RU